### PR TITLE
:wrench: Fix Dockerfile and module path resolution

### DIFF
--- a/PuppyStorage/Dockerfile
+++ b/PuppyStorage/Dockerfile
@@ -28,4 +28,4 @@ COPY . .
 EXPOSE 8002
 
 # Use Hypercorn as the ASGI server
-CMD ["hypercorn", "Server.StorageServer:app", "--bind", "0.0.0.0:8002"]
+CMD ["hypercorn", "./Server.StorageServer:app", "--bind", "0.0.0.0:8002"]

--- a/PuppyStorage/Server/routes/VectorRoutes.py
+++ b/PuppyStorage/Server/routes/VectorRoutes.py
@@ -1,9 +1,7 @@
 import os
 import sys
 # 修改路径添加方式，确保能正确找到模块
-current_dir = os.path.dirname(os.path.abspath(__file__))
-project_root = os.path.dirname(os.path.dirname(current_dir))  # 指向 PuppyStorage 目录
-sys.path.append(project_root)
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse


### PR DESCRIPTION
- Updated Dockerfile CMD to use relative path for StorageServer
- Simplified module path resolution in VectorRoutes.py
- Streamlined sys.path appending method for more concise module importing