### PR TITLE
:recycle: Cleanup module path resolution and Dockerfile CMD

### DIFF
--- a/PuppyStorage/Dockerfile
+++ b/PuppyStorage/Dockerfile
@@ -28,4 +28,4 @@ COPY . .
 EXPOSE 8002
 
 # Use Hypercorn as the ASGI server
-CMD ["hypercorn", "./Server.StorageServer:app", "--bind", "0.0.0.0:8002"]
+CMD ["hypercorn", "./Server/StorageServer:app", "--bind", "0.0.0.0:8002"]

--- a/PuppyStorage/Server/routes/VectorRoutes.py
+++ b/PuppyStorage/Server/routes/VectorRoutes.py
@@ -3,8 +3,6 @@ import sys
 # 修改路径添加方式，确保能正确找到模块
 sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 
-print (sys.path)
-
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 


### PR DESCRIPTION
- Removed debug print statement in VectorRoutes.py
- Updated Dockerfile CMD to use correct relative path for StorageServer