### PR TITLE
:rocket: Switch to Hypercorn for storage server deployment

### DIFF
--- a/PuppyStorage/Dockerfile
+++ b/PuppyStorage/Dockerfile
@@ -23,4 +23,4 @@ ENV PYTHONPATH="/app"
 EXPOSE 8002
 
 # Set the entry point to run the FastAPI server
-CMD ["python", "-m", "server.storage_server"]
+CMD ["hypercorn", "server.storage_server:app", "--bind", "0.0.0.0:8002"]


### PR DESCRIPTION
- Updated Dockerfile CMD to use Hypercorn for running the storage server
- Replaced Python module execution with Hypercorn ASGI server
- Configured server to bind to all network interfaces on port 8002