### PR TITLE
Update EditText edge label to "edit name" for consistency with edge n…

### DIFF
--- a/PuppyFlow/app/components/workflow/edgesNode/edgeNodesNew/EditText.tsx
+++ b/PuppyFlow/app/components/workflow/edgesNode/edgeNodesNew/EditText.tsx
@@ -216,7 +216,7 @@ function EditText({ data, isConnectable, id }: ModifyConfigNodeProps) {
                                 </svg>
                             </div>
                             <div className='flex items-center justify-center text-[14px] font-[600] text-main-grey font-plus-jakarta-sans leading-normal'>
-                                Modify Text
+                                Edit Text
                             </div>
                         </div>
                         <div className='flex flex-row gap-[8px] items-center justify-center'>


### PR DESCRIPTION
This pull request updates the label text of the EditText Edge component:
Changed the label from "Modify Text" to "Edit Name".
The change aims to keep the label consistent with the original name of this Edge, improving semantic clarity and user experience.