### PR TITLE
Add .cursor directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ json_received.json
 
 # vs code
 .vscode/
+.cursor/
 
 # Local Storage
 **/local_storage/


### PR DESCRIPTION
Add `.cursor/` directory (generated by Cursor IDE) to `.gitignore` to avoid committing IDE-specific settings, similar to `.vscode/`.