### PR TITLE
Fix issue where selecting the same JSON file consecutively does not trigger upload

### DIFF
--- a/PuppyFlow/app/components/upbar/topRightToolBar/MoreOptionsButtonMenu.tsx
+++ b/PuppyFlow/app/components/upbar/topRightToolBar/MoreOptionsButtonMenu.tsx
@@ -163,7 +163,7 @@ function MoreOptionsButtonMenu({clearTopRightToolBarMenu}: MoreOptionsButtonMenu
   const handleFileContent = async (file: File) => {
     try {
       const text = await file.text(); // 使用更现代的 API 替代 FileReader
-       console.log(text, "text hello")
+      // console.log(text, "text hello")
       const jsonContent = JSON.parse(text);
       
       if (jsonContent.blocks && jsonContent.edges) {


### PR DESCRIPTION
Reset the file input value after each selection. This ensures that selecting the same file consecutively will correctly trigger the onChange event and allow the upload to proceed as expected.