### PR TITLE
Fix/usage display

### DIFF
--- a/PuppyFlow/app/components/states/AppSettingsContext.tsx
+++ b/PuppyFlow/app/components/states/AppSettingsContext.tsx
@@ -322,10 +322,21 @@ export const AppSettingsProvider: React.FC<{ children: ReactNode }> = ({ childre
         throw new Error(`HTTP error! status: ${response.status}, error message: ${error_data.error}`);
       }
 
-      const subscriptionData: UserSubscriptionStatus = await response.json();
+      const subscriptionData: any = await response.json();
       console.log('用户订阅状态:', subscriptionData);
       
-      setUserSubscriptionStatus(subscriptionData);
+      // 字段名映射：将 API 返回的字段名转换为前端期望的字段名
+      setUserSubscriptionStatus({
+        is_premium: subscriptionData.is_premium ?? false,
+        subscription_plan: subscriptionData.plan ?? 'free',
+        subscription_status: subscriptionData.status ?? 'expired',
+        subscription_period_start: subscriptionData.period_start ?? '',
+        subscription_period_end: subscriptionData.period_end ?? '',
+        effective_end_date: subscriptionData.effective_end_date ?? '',
+        days_left: subscriptionData.days_left ?? 0,
+        expired_date: subscriptionData.expired_date ?? '',
+        polar_subscription_id: subscriptionData.polar_subscription_id,
+      });
     } catch (error) {
       console.error('Error fetching user subscription status:', error);
       

--- a/PuppyFlow/app/components/userDashBoard/Usage.tsx
+++ b/PuppyFlow/app/components/userDashBoard/Usage.tsx
@@ -47,7 +47,7 @@ const Usage: React.FC = () => {
               <span className={`text-[14px] font-medium ${
                 userSubscriptionStatus.is_premium ? 'text-[#16A34A]' : 'text-[#888888]'
               }`}>
-                {userSubscriptionStatus.subscription_plan?.toUpperCase() || 'UNKNOWN'}
+                {userSubscriptionStatus.subscription_plan?.toUpperCase() || 'FREE'}
               </span>
             </div>
             <div className="flex items-center justify-between">
@@ -55,7 +55,7 @@ const Usage: React.FC = () => {
               <span className={`text-[14px] font-medium capitalize ${
                 userSubscriptionStatus.subscription_status === 'active' ? 'text-[#16A34A]' : 'text-[#F59E0B]'
               }`}>
-                {userSubscriptionStatus.subscription_status}
+                {userSubscriptionStatus.subscription_status || 'expired'}
               </span>
             </div>
             {!isLocalDeployment && (


### PR DESCRIPTION
# Pull Request: Map API subscription fields to frontend expected fields

## Problem Analysis
The API returns subscription-related fields with different names than what the frontend expects:
- API uses `"plan"` instead of `subscription_plan`
- API uses `"status"` instead of `subscription_status`
- API uses `"period_start"` instead of `subscription_period_start`
- API uses `"period_end"` instead of `subscription_period_end`

This mismatch causes the frontend to fail displaying subscription status correctly.

## Solution
Add a field mapping in `AppSettingsContext.tsx` to convert API response fields to the frontend’s expected field names:

```typescript
const subscriptionData: any = await response.json();

setUserSubscriptionStatus({
  is_premium: subscriptionData.is_premium ?? false,
  subscription_plan: subscriptionData.plan ?? 'free',
  subscription_status: subscriptionData.status ?? 'expired',
  subscription_period_start: subscriptionData.period_start ?? '',
  subscription_period_end: subscriptionData.period_end ?? '',
  effective_end_date: subscriptionData.effective_end_date ?? '',
  days_left: subscriptionData.days_left ?? 0,
  expired_date: subscriptionData.expired_date ?? '',
  polar_subscription_id: subscriptionData.polar_subscription_id,
});
```

## Fix Details
1. Map API fields to frontend fields:
   - `plan` → `subscription_plan`
   - `status` → `subscription_status`
   - `period_start` → `subscription_period_start`
   - `period_end` → `subscription_period_end`
2. Use nullish coalescing (`??`) to provide default values if API fields are missing.
3. Use `any` type for `subscriptionData` to handle discrepancy between API response and TypeScript types.

## Result
After this fix, the `Usage` page on cloud deployment will correctly display user subscription information without errors.
<img width="2388" height="1614" alt="image" src="https://github.com/user-attachments/assets/40841bc8-8302-4c80-9b86-d83dab90c462" />
