### PR TITLE
🛠️ Fix workspace deletion issue in local mode

### DIFF
--- a/PuppyFlow/app/api/workspace/[workspaceId]/route.ts
+++ b/PuppyFlow/app/api/workspace/[workspaceId]/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from 'next/server';
+import fs from 'fs';
+import path from 'path';
+import { promises as fsPromises } from 'fs';
+
+interface FileSystemError extends Error {
+    code?: string;
+    path?: string;
+}
+
+// 删除工作区
+export async function DELETE(
+    request: Request,
+    { params }: { params: { workspaceId: string } }
+) {
+    console.log('=== DELETE /api/workspace/[workspaceId] 开始处理请求 ===');
+    try {
+        const { workspaceId } = params;
+        console.log('要删除的工作区ID:', workspaceId);
+        
+        if (!workspaceId) {
+            console.error('缺少工作区ID');
+            return NextResponse.json({ 
+                success: false, 
+                error: 'Workspace ID is required' 
+            }, { status: 400 });
+        }
+
+        // 构建工作区目录路径
+        const workspaceDir = path.join(process.cwd(), 'workspace_data', workspaceId);
+        console.log('工作区目录路径:', workspaceDir);
+        
+        // 检查工作区目录是否存在
+        if (!fs.existsSync(workspaceDir)) {
+            console.log('工作区目录不存在，可能是未保存的workspace');
+            return NextResponse.json({ 
+                success: true, 
+                message: 'Workspace not found in file system (may be unsaved)' 
+            }, { status: 200 });
+        }
+
+        // 递归删除整个工作区目录
+        await fsPromises.rm(workspaceDir, { recursive: true, force: true });
+        console.log('工作区目录删除成功');
+        
+        console.log('=== DELETE /api/workspace/[workspaceId] 请求处理成功 ===');
+        return NextResponse.json({ 
+            success: true, 
+            message: 'Workspace deleted successfully' 
+        });
+    } catch (error) {
+        const fsError = error as FileSystemError;
+        console.error("=== DELETE /api/workspace/[workspaceId] 发生错误 ===");
+        console.error("错误类型:", fsError.constructor.name);
+        console.error("错误信息:", fsError.message);
+        console.error("错误堆栈:", fsError.stack);
+        if (fsError.code) {
+            console.error("错误代码:", fsError.code);
+        }
+        if (fsError.path) {
+            console.error("错误路径:", fsError.path);
+        }
+        return NextResponse.json({ 
+            success: false, 
+            error: `Failed to delete workspace: ${fsError.message}` 
+        }, { status: 500 });
+    }
+} 

--- a/PuppyFlow/app/components/hooks/useWorkspaceManagement.ts
+++ b/PuppyFlow/app/components/hooks/useWorkspaceManagement.ts
@@ -231,25 +231,11 @@ export const useWorkspaceManagement = () => {
     const createWorkspace = async (workspaceId: string, workspaceName: string, userId?: string): Promise<WorkspaceBasicInfo | undefined> => {
         try {
             if (isLocalDeployment) {
-                // 本地部署模式的创建逻辑
-                const response = await fetch('/api/workspace/create', {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                    },
-                    body: JSON.stringify({
-                        workspace_id: workspaceId,
-                        workspace_name: workspaceName
-                    })
-                });
-
-                if (response.ok) {
-                    const data = await response.json();
-                    return {
-                        workspace_id: data.workspace_id,
-                        workspace_name: data.workspace_name
-                    };
-                }
+                // 本地部署模式：直接返回workspace信息，目录会在保存时创建
+                return {
+                    workspace_id: workspaceId,
+                    workspace_name: workspaceName
+                };
             } else {
                 // 云端部署模式
                 let finalUserId = userId;


### PR DESCRIPTION
# Local Mode Workspace Deletion Feature Implementation Document

## Overview

This update implements the workspace deletion feature in local deployment mode, resolving the previous issue where only saved workspaces could be deleted.

## Problem Description

### Original Issues
- Delete button in local mode did not work properly.
- Only saved workspaces could be deleted.
- Deleting unsaved workspaces returned a 404 error.

### Root Causes
1. Missing DELETE API route for workspace deletion in local mode.
2. `createWorkspace` function called a non-existent `/api/workspace/create` route.
3. Deletion logic was too strict, returning 404 for non-existent directories.

## Changes Made

### 1. Added DELETE API Route

- File: `PuppyFlow/app/api/workspace/[workspaceId]/route.ts`
- Implemented DELETE method to remove specified workspace directory.
- Features:
  - Parameter validation for workspaceId.
  - Correct path construction.
  - Directory existence check.
  - Recursive deletion with `fsPromises.rm()`.
  - Comprehensive error handling and logging.
- API endpoint: `DELETE /api/workspace/{workspaceId}`
- Response format:
  - Success: `{ "success": true, "message": "Workspace deleted successfully" }`
  - Failure: `{ "success": false, "error": "error message" }`

### 2. Fixed Workspace Creation Logic

- File: `PuppyFlow/app/components/hooks/useWorkspaceManagement.ts`
- Modified `createWorkspace` to avoid calling non-existent API in local mode.
- Now directly returns workspace info; directory is created on save.

### 3. Optimized Deletion Logic

- File: `PuppyFlow/app/api/workspace/[workspaceId]/route.ts`
- Changed handling of non-existent directories to return success with a message instead of 404 error.

## Technical Details

- Workspace directories stored under `workspace_data/{workspaceId}`.
- Deletion flow:
  1. Receive DELETE request with workspaceId.
  2. Construct workspace directory path.
  3. Check existence.
  4. If exists, recursively delete directory.
  5. If not, return success indicating workspace may be unsaved.
  6. Return operation result.
- Error handling returns appropriate HTTP status codes and logs errors.

## Compatibility

- Fully compatible with existing deletion logic in `useWorkspaceManagement.ts`.
- Compatible with front-end delete button handling.
- API usage consistent with cloud mode.
- Supports both local (file system) and cloud deployment modes.

## Testing and Validation

- Tested deleting saved, unsaved, non-existent, and currently displayed workspaces.
- Expected results:
  - All deletions return success.
  - Saved workspace files are fully deleted.
  - Front-end state updates correctly.
  - Errors are properly handled.

## Impact

- Positive:
  - Workspace deletion works correctly in local mode.
  - Improved user experience consistency.
  - Fixed creation and deletion logic issues.
- No negative impact on cloud mode or existing save/load functionality.
- Maintains backward compatibility.

## Summary

This change delivers a minimal and clean implementation of workspace deletion in local mode, fixing user experience issues while maintaining code simplicity and maintainability.

