### PR TITLE
feat(auth): enforce service-key on /api/auth/verify and avoid middlew…

### DIFF
--- a/PuppyFlow/lib/serverEnv.ts
+++ b/PuppyFlow/lib/serverEnv.ts
@@ -35,6 +35,9 @@ export const SERVER_ENV = {
   USER_SYSTEM_BACKEND: normalizeUrlBase(requireEnv('USER_SYSTEM_BACKEND')),
   // Optional service key for S2S auth; not all routes need it
   SERVICE_KEY: process.env.SERVICE_KEY || '',
+  // Allow bypassing service key for local/dev verification only
+  ALLOW_VERIFY_WITHOUT_SERVICE_KEY:
+    (process.env.ALLOW_VERIFY_WITHOUT_SERVICE_KEY || '').toLowerCase() === 'true',
 };
 
 

--- a/PuppyFlow/middleware.ts
+++ b/PuppyFlow/middleware.ts
@@ -35,6 +35,10 @@ function getCookieDomain(request: NextRequest): string | undefined {
 
 // 定义一个中间件函数，用于处理请求
 export async function middleware(request: NextRequest) {
+  // Bypass middleware for the internal verification endpoint to avoid recursion
+  if (request.nextUrl.pathname === '/api/auth/verify') {
+    return NextResponse.next();
+  }
   const userPageUrl = SYSTEM_URLS.USER_SYSTEM.FRONTEND;
   const token = request.cookies.get('access_token')?.value;
 
@@ -125,6 +129,7 @@ export async function middleware(request: NextRequest) {
         headers: {
           'Content-Type': 'application/json',
           Authorization: `Bearer ${authTokenFromUrl}`,
+          'X-Service-Key': process.env.SERVICE_KEY || '',
         },
       });
 
@@ -273,6 +278,7 @@ export async function middleware(request: NextRequest) {
         headers: {
           'Content-Type': 'application/json',
           Authorization: `Bearer ${token}`,
+          'X-Service-Key': process.env.SERVICE_KEY || '',
         },
       });
 
@@ -440,5 +446,5 @@ export async function middleware(request: NextRequest) {
 
 // 配置需要进行认证的路径
 export const config = {
-  matcher: ['/((?!_next/static|_next/image|favicon.ico).*)'],
+  matcher: ['/((?!_next/static|_next/image|favicon.ico|api/auth/verify).*)'],
 };


### PR DESCRIPTION
…are recursion

- Middleware bypasses /api/auth/verify and attaches X-Service-Key for S2S calls
- Verify route requires X-Service-Key (with dev bypass flag)
- Add ALLOW_VERIFY_WITHOUT_SERVICE_KEY env for local/dev fallback
- Matcher excludes /api/auth/verify from auth interception