### PR TITLE
🐛 Fix stuck bug after generating node

### DIFF
--- a/PuppyEngine/DataClass/schemas.py
+++ b/PuppyEngine/DataClass/schemas.py
@@ -13,9 +13,8 @@ Goals:
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional, Literal
-from pydantic import BaseModel, Field
-from pydantic import model_validator, field_validator
+from typing import Any, Dict, List, Optional, Literal, Union
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 
 ALLOWED_EDGE_TYPES = (
@@ -131,7 +130,7 @@ class SearchDataSourceItem(BaseModel):
         return v
 
 
-class SearchEdgeData(EdgeCommonData):
+class VectorSearchModel(BaseModel):
     search_type: Literal["vector"]
     query_id: Dict[str, Any]
     doc_ids: Optional[List[str]] = None
@@ -146,9 +145,31 @@ class SearchEdgeData(EdgeCommonData):
         if not isinstance(v, dict) or len(v) == 0:
             raise ValueError("query_id must be a non-empty mapping of block_id -> {}")
         if len(v.keys()) != 1:
-            # current parser expects single query_id
             raise ValueError("query_id must contain exactly one block_id")
         return v
+
+
+class KeywordSearchModel(VectorSearchModel):
+    search_type: Literal["keyword"]
+
+
+class QASearchModel(BaseModel):
+    search_type: Literal["qa"]
+    sub_search_type: str
+    query_id: Dict[str, Any]
+    extra_configs: Optional[Dict[str, Any]] = None
+
+
+class WebSearchModel(BaseModel):
+    search_type: Literal["web"]
+    sub_search_type: str
+    top_k: Optional[int] = Field(default=5, ge=1)
+    extra_configs: Optional[Dict[str, Any]] = None
+
+
+SearchEdgeData = Union[
+    VectorSearchModel, KeywordSearchModel, QASearchModel, WebSearchModel
+]
 
 
 class EdgeModel(BaseModel):
@@ -190,7 +211,17 @@ class EdgeModel(BaseModel):
         elif etype == "deep_research":
             DeepResearchEdgeData(**data)
         elif etype == "search":
-            SearchEdgeData(**data)
+            search_type = data.get("search_type")
+            if search_type == "vector":
+                VectorSearchModel(**data)
+            elif search_type == "keyword":
+                KeywordSearchModel(**data)
+            elif search_type == "qa":
+                QASearchModel(**data)
+            elif search_type == "web":
+                WebSearchModel(**data)
+            else:
+                raise ValueError(f"Unknown search_type: {search_type}")
 
         # write back potentially normalized data
         self.data = data

--- a/PuppyEngine/clients/storage_client.py
+++ b/PuppyEngine/clients/storage_client.py
@@ -230,6 +230,17 @@ class StorageClient:
                 else:
                     raise StorageException(f"Failed to update manifest: {response.text}")
 
+            # [FIX] Upload the physical _completed.marker file before updating the manifest
+            # This ensures the marker file actually exists when the manifest claims it does.
+            # Use a single space as content to avoid "No chunk data provided" error from storage server.
+            await self._upload_chunk(
+                block_id=block_id_from_key,
+                file_name="_completed.marker",
+                chunk_data=b" ",
+                version_id=version_id
+            )
+            log_info("Uploaded physical _completed.marker file.")
+
             # Mark as completed by adding a completion marker
             completion_chunk = {
                 "name": "_completed.marker",

--- a/PuppyFlow/app/components/workflow/blockNode/FileNode.tsx
+++ b/PuppyFlow/app/components/workflow/blockNode/FileNode.tsx
@@ -7,7 +7,13 @@ import {
   useReactFlow,
   NodeResizeControl,
 } from '@xyflow/react';
-import React, { useRef, useEffect, useState, useContext } from 'react';
+import React, {
+  useRef,
+  useEffect,
+  useState,
+  useCallback,
+  useMemo,
+} from 'react';
 import WhiteBallHandle from '../handles/WhiteBallHandle';
 import NodeToolBar from './nodeTopRightBar/NodeTopRightBar';
 import { useNodesPerFlowContext } from '../../states/NodesPerFlowContext';
@@ -29,854 +35,849 @@ export type FileNodeData = {
 
 type FileNodeProps = NodeProps<Node<FileNodeData>>;
 
-function FileNode({
-  data: {
-    content,
-    label,
-    isLoading,
-    isWaitingForFlow,
-    locked,
-    isInput,
-    isOutput,
-    editable,
-  },
-  type,
-  isConnectable,
-  id,
-}: FileNodeProps) {
-  const {
-    activatedNode,
-    isOnConnect,
-    isOnGeneratingNewNode,
-    setNodeUneditable,
-    editNodeLabel,
-    preventInactivateNode,
-    allowInactivateNodeWhenClickOutside,
-    activateNode,
-    inactivateNode,
-  } = useNodesPerFlowContext();
-  const { getNode, setNodes } = useReactFlow();
-  const [isTargetHandleTouched, setIsTargetHandleTouched] = useState(false);
-  const componentRef = useRef<HTMLDivElement | null>(null);
-  const contentRef = useRef<HTMLDivElement | null>(null);
-  const labelRef = useRef<HTMLInputElement | null>(null);
-  const labelContainerRef = useRef<HTMLDivElement | null>(null);
-  const [nodeLabel, setNodeLabel] = useState(label ?? id);
-  const [isLocalEdit, setIsLocalEdit] = useState(false);
-  const measureSpanRef = useRef<HTMLSpanElement | null>(null); // 用于测量 labelContainer 的宽度
-  const [borderColor, setBorderColor] = useState('border-main-deep-grey');
-  const [isHovered, setIsHovered] = useState(false);
-
-  // 从节点加载初始文件
-  const initialFiles = React.useMemo(() => {
-    const node = getNode(id);
-    return Array.isArray(node?.data?.content) ? node.data.content : [];
-  }, [id, getNode]);
-
-  // 文件变更时同步到节点
-  const handleFilesChange = React.useCallback(
-    (files: UploadedFile[]) => {
-      setNodes(nodes =>
-        nodes.map(node =>
-          node.id === id
-            ? { ...node, data: { ...node.data, content: files } }
-            : node
-        )
-      );
+// 优化点 1: 使用 React.memo 包裹组件，避免不必要的重渲染
+const FileNode = React.memo<FileNodeProps>(
+  ({
+    data: {
+      content,
+      label,
+      isLoading,
+      isWaitingForFlow,
+      locked,
+      isInput,
+      isOutput,
+      editable,
     },
-    [id, setNodes]
-  );
-
-  // 使用分离后的文件上传hook
-  const {
-    uploadedFiles,
-    isOnUploading,
-    inputRef,
-    handleInputChange,
-    handleFileDrop,
-    handleDelete,
-    resourceKey,
-    versionId,
-  } = useFileUpload({
-    nodeId: id,
-    initialFiles,
-    onFilesChange: handleFilesChange,
-  });
-
-  // 使用新的获取连接节点的工具函数
-  const { getSourceNodeIdWithLabel, getTargetNodeIdWithLabel } =
-    useGetSourceTarget();
-
-  // 获取连接的节点
-  const sourceNodes = getSourceNodeIdWithLabel(id);
-  const targetNodes = getTargetNodeIdWithLabel(id);
-
-  // 根据连接节点动态确定 isInput 和 isOutput
-  const dynamicIsInput = sourceNodes.length === 0 && targetNodes.length > 0;
-  const dynamicIsOutput = targetNodes.length === 0 && sourceNodes.length > 0;
-
-  // 使用已有属性或动态计算的值
-  const effectiveIsInput = isInput || dynamicIsInput;
-  const effectiveIsOutput = isOutput || dynamicIsOutput;
-
-  useEffect(() => {
-    if (isLoading) {
-      setBorderColor('border-[#FFA500]');
-    } else if (isWaitingForFlow) {
-      setBorderColor('border-[#39bc66]');
-    } else if (activatedNode?.id === id) {
-      setBorderColor('border-[#BF9A78]');
-    } else if (isHovered) {
-      setBorderColor('border-[#BF9A78]');
-    } else {
-      setBorderColor(
-        isOnConnect && isTargetHandleTouched
-          ? 'border-main-orange'
-          : 'border-main-deep-grey'
-      );
-    }
-  }, [
-    activatedNode,
-    isHovered,
-    isOnConnect,
-    isTargetHandleTouched,
-    locked,
-    effectiveIsInput,
-    effectiveIsOutput,
+    type,
+    isConnectable,
     id,
-    isLoading,
-    isWaitingForFlow,
-  ]);
+  }) => {
+    const {
+      activatedNode,
+      isOnConnect,
+      isOnGeneratingNewNode,
+      setNodeUneditable,
+      editNodeLabel,
+      preventInactivateNode,
+      allowInactivateNodeWhenClickOutside,
+      activateNode,
+      inactivateNode,
+    } = useNodesPerFlowContext();
 
-  // 管理labelContainer的宽度
-  useEffect(() => {
-    const onLabelContainerBlur = () => {
-      if (labelContainerRef.current) {
-        setNodeUneditable(id);
+    const { getNode, setNodes } = useReactFlow();
+
+    // 优化点 2: 将多个相关的 state 合并，减少 state 更新的复杂性
+    const [nodeState, setNodeState] = useState({
+      isTargetHandleTouched: false,
+      nodeLabel: label ?? id,
+      isLocalEdit: false,
+      isHovered: false,
+    });
+
+    // 使用 refs 来引用 DOM 元素，避免因引用变化导致重渲染
+    const componentRef = useRef<HTMLDivElement | null>(null);
+    const contentRef = useRef<HTMLDivElement | null>(null);
+    const labelRef = useRef<HTMLInputElement | null>(null);
+    const labelContainerRef = useRef<HTMLDivElement | null>(null);
+    const measureSpanRef = useRef<HTMLSpanElement | null>(null);
+
+    // 优化点 3: 使用 ref 标记初始渲染，用于延迟计算
+    const hasMountedRef = useRef(false);
+
+    // 从节点加载初始文件
+    const initialFiles = useMemo(() => {
+      const node = getNode(id);
+      return Array.isArray(node?.data?.content) ? node.data.content : [];
+    }, [id, getNode]);
+
+    // 优化点 6: 使用 useCallback 缓存文件变更处理函数
+    const handleFilesChange = useCallback(
+      (files: UploadedFile[]) => {
+        setNodes(nodes =>
+          nodes.map(node =>
+            node.id === id
+              ? { ...node, data: { ...node.data, content: files } }
+              : node
+          )
+        );
+      },
+      [id, setNodes]
+    );
+
+    // 使用分离后的文件上传hook
+    const {
+      uploadedFiles,
+      isOnUploading,
+      inputRef,
+      handleInputChange,
+      handleFileDrop,
+      handleDelete,
+      resourceKey,
+      versionId,
+    } = useFileUpload({
+      nodeId: id,
+      initialFiles,
+      onFilesChange: handleFilesChange,
+    });
+
+    // 使用新的获取连接节点的工具函数
+    const { getSourceNodeIdWithLabel, getTargetNodeIdWithLabel } =
+      useGetSourceTarget();
+
+    // 获取连接的节点
+    const sourceNodes = getSourceNodeIdWithLabel(id);
+    const targetNodes = getTargetNodeIdWithLabel(id);
+
+    // 根据连接节点动态确定 isInput 和 isOutput
+    const dynamicIsInput = sourceNodes.length === 0 && targetNodes.length > 0;
+    const dynamicIsOutput = targetNodes.length === 0 && sourceNodes.length > 0;
+
+    // 使用已有属性或动态计算的值
+    const effectiveIsInput = isInput || dynamicIsInput;
+    const effectiveIsOutput = isOutput || dynamicIsOutput;
+
+    // 优化点 4: 使用 useMemo 缓存边框颜色的计算逻辑
+    const borderColor = useMemo(() => {
+      if (isLoading) return 'border-[#FFA500]';
+      if (isWaitingForFlow) return 'border-[#39bc66]';
+      if (activatedNode?.id === id) return 'border-[#BF9A78]';
+      if (nodeState.isHovered) return 'border-[#BF9A78]';
+      return isOnConnect && nodeState.isTargetHandleTouched
+        ? 'border-main-orange'
+        : 'border-main-deep-grey';
+    }, [
+      isLoading,
+      isWaitingForFlow,
+      activatedNode?.id,
+      id,
+      nodeState.isHovered,
+      isOnConnect,
+      nodeState.isTargetHandleTouched,
+    ]);
+
+    // 优化点 4: 使用 useMemo 缓存整个容器的 className 字符串
+    const containerClassName = useMemo(
+      () =>
+        `flex flex-col w-full h-full border-[1.5px] border-solid border-[1.5px] min-w-[240px] min-h-[176px] p-[8px] rounded-[16px] flex justify-start ${borderColor} text-[#CDCDCD] bg-main-black-theme break-words font-plus-jakarta-sans text-base leading-5 font-[400] overflow-hidden file-block-node`,
+      [borderColor]
+    );
+
+    // 优化点 4 & 5: 使用 useMemo 缓存 Handle 的样式对象，避免内联样式导致重渲染
+    const handleStyle = useMemo(
+      () => ({
+        position: 'absolute' as const,
+        width: 'calc(100%)',
+        height: 'calc(100%)',
+        top: '0',
+        left: '0',
+        borderRadius: '0',
+        transform: 'translate(0px, 0px)',
+        background: 'transparent',
+        border: '3px solid transparent',
+        zIndex: !isOnConnect ? -1 : 1,
+      }),
+      [isOnConnect]
+    );
+
+    // 优化点 6: 使用 useCallback 缓存所有事件处理函数
+    const handleMouseEnter = useCallback(() => {
+      setNodeState(prev => ({ ...prev, isHovered: true }));
+      activateNode(id);
+    }, [activateNode, id]);
+
+    const handleMouseLeave = useCallback(() => {
+      setNodeState(prev => ({ ...prev, isHovered: false }));
+    }, []);
+
+    const handleTargetHandleMouseEnter = useCallback(() => {
+      setNodeState(prev => ({ ...prev, isTargetHandleTouched: true }));
+    }, []);
+
+    const handleTargetHandleMouseLeave = useCallback(() => {
+      setNodeState(prev => ({ ...prev, isTargetHandleTouched: false }));
+    }, []);
+
+    const onFocus = useCallback(() => {
+      preventInactivateNode();
+      const curRef = componentRef.current;
+      if (curRef && !curRef.classList.contains('nodrag')) {
+        curRef.classList.add('nodrag');
       }
-    };
+    }, [preventInactivateNode]);
 
-    if (labelContainerRef.current) {
-      document.addEventListener('click', (e: MouseEvent) => {
+    const onBlur = useCallback(() => {
+      allowInactivateNodeWhenClickOutside();
+      const curRef = componentRef.current;
+      if (curRef) {
+        curRef.classList.remove('nodrag');
+      }
+      if (nodeState.isLocalEdit) {
+        editNodeLabel(id, nodeState.nodeLabel);
+        setNodeState(prev => ({ ...prev, isLocalEdit: false }));
+      }
+    }, [
+      allowInactivateNodeWhenClickOutside,
+      editNodeLabel,
+      id,
+      nodeState.isLocalEdit,
+      nodeState.nodeLabel,
+    ]);
+
+    const handleLabelChange = useCallback(
+      (e: React.ChangeEvent<HTMLInputElement>) => {
+        setNodeState(prev => ({
+          ...prev,
+          isLocalEdit: true,
+          nodeLabel: e.target.value,
+        }));
+      },
+      []
+    );
+
+    const calculateMaxLabelContainerWidth = useCallback(() => {
+      if (contentRef.current) {
+        return `${contentRef.current.clientWidth - 48}px`;
+      }
+      return '100%';
+    }, []);
+
+    // 优化点 6: 缓存 renderTagLogo 函数
+    const renderTagLogo = useCallback(
+      () => (
+        <svg
+          width='24'
+          height='24'
+          viewBox='0 0 24 24'
+          fill='none'
+          xmlns='http://www.w3.org/2000/svg'
+          className='group'
+        >
+          <path
+            d='M4 6H10L12 8H20V18H4V6Z'
+            className='fill-transparent stroke-[#9E7E5F] group-active:stroke-[#BF9A78]'
+            strokeWidth='1.5'
+          />
+          <path
+            d='M8 13.5H16'
+            className='stroke-[#9E7E5F] group-active:stroke-[#BF9A78]'
+            strokeWidth='1.5'
+            strokeLinecap='round'
+          />
+        </svg>
+      ),
+      []
+    );
+
+    // 优化点 6: 缓存文件点击处理函数
+    const handleFileClick = useCallback(
+      (file: UploadedFile, e: React.MouseEvent) => {
+        e.stopPropagation();
+        if (file.download_url) {
+          window.open(file.download_url, '_blank');
+        }
+      },
+      []
+    );
+
+    const handleFileDelete = useCallback(
+      (file: UploadedFile, index: number, e: React.MouseEvent) => {
+        e.stopPropagation();
+        handleDelete(file, index);
+      },
+      [handleDelete]
+    );
+
+    const handleUploadAreaClick = useCallback(
+      (e: React.MouseEvent) => {
+        if (e.currentTarget === e.target) {
+          inputRef.current?.click();
+        }
+      },
+      [inputRef]
+    );
+
+    const handleEmptyAreaClick = useCallback(() => {
+      inputRef.current?.click();
+    }, [inputRef]);
+
+    // 管理labelContainer的宽度
+    useEffect(() => {
+      const handleClickOutside = (e: MouseEvent) => {
         if (
           !labelContainerRef.current?.contains(e.target as HTMLElement) &&
           !(e.target as HTMLElement).classList.contains('renameButton')
         ) {
-          onLabelContainerBlur();
+          setNodeUneditable(id);
         }
-      });
-    }
+      };
 
-    return () => {
-      if (labelContainerRef.current) {
-        document.removeEventListener('click', (e: MouseEvent) => {
-          if (!labelContainerRef.current?.contains(e.target as HTMLElement)) {
-            onLabelContainerBlur();
-          }
-        });
+      document.addEventListener('click', handleClickOutside);
+      return () => {
+        document.removeEventListener('click', handleClickOutside);
+      };
+    }, [id, setNodeUneditable]);
+
+    // 自动聚焦，同时需要让cursor focus 到input 的最后一位
+    useEffect(() => {
+      if (editable && labelRef.current) {
+        labelRef.current?.focus();
+        const length = labelRef.current.value.length;
+        labelRef.current.setSelectionRange(length, length);
       }
-    };
-  }, []);
+    }, [editable, id]);
 
-  // 自动聚焦，同时需要让cursor focus 到input 的最后一位
-  useEffect(() => {
-    if (editable && labelRef.current) {
-      labelRef.current?.focus();
-      const length = labelRef.current.value.length;
-      labelRef.current.setSelectionRange(length, length);
-    }
-  }, [editable, id]);
-
-  // 当生成 resourceKey 时，将 external 指针写入节点数据，便于后端识别
-  useEffect(() => {
-    if (resourceKey) {
-      setNodes(nodes =>
-        nodes.map(node =>
-          node.id === id
-            ? {
-                ...node,
-                data: {
-                  ...node.data,
-                  storage_class: 'external',
-                  external_metadata: {
-                    resource_key: resourceKey,
-                    content_type: 'files',
-                    version_id: versionId,
+    // 当生成 resourceKey 时，将 external 指针写入节点数据，便于后端识别
+    useEffect(() => {
+      if (resourceKey) {
+        setNodes(nodes =>
+          nodes.map(node =>
+            node.id === id
+              ? {
+                  ...node,
+                  data: {
+                    ...node.data,
+                    storage_class: 'external',
+                    external_metadata: {
+                      resource_key: resourceKey,
+                      content_type: 'files',
+                      version_id: versionId,
+                    },
                   },
-                },
-              }
-            : node
-        )
-      );
-    }
-  }, [resourceKey, versionId, id, setNodes]);
-
-  // 管理 label onchange， 注意：若是当前的workflow中已经存在同样的id，那么不回重新对于这个node进行initialized，那么此时label就是改变了也不会rendering 最新的值，所以我们必须要通过这个useEffect来确保label的值是最新的，同时需要update measureSpanRef 中需要被测量的内容
-  useEffect(() => {
-    const currentLabel = getNode(id)?.data?.label as string | undefined;
-    if (
-      currentLabel !== undefined &&
-      currentLabel !== nodeLabel &&
-      !isLocalEdit
-    ) {
-      setNodeLabel(currentLabel);
-      if (measureSpanRef.current) {
-        measureSpanRef.current.textContent = currentLabel;
+                }
+              : node
+          )
+        );
       }
-    }
-  }, [label, id, isLocalEdit, getNode]);
+    }, [resourceKey, versionId, id, setNodes]);
 
-  const onFocus = () => {
-    preventInactivateNode();
-    const curRef = componentRef.current;
-    if (curRef && !curRef.classList.contains('nodrag')) {
-      curRef.classList.add('nodrag');
-    }
-  };
+    // 管理 label onchange
+    useEffect(() => {
+      const currentLabel = getNode(id)?.data?.label as string | undefined;
+      if (
+        currentLabel !== undefined &&
+        currentLabel !== nodeState.nodeLabel &&
+        !nodeState.isLocalEdit
+      ) {
+        setNodeState(prev => ({ ...prev, nodeLabel: currentLabel }));
+        if (measureSpanRef.current) {
+          measureSpanRef.current.textContent = currentLabel;
+        }
+      }
+    }, [label, id, nodeState.isLocalEdit, nodeState.nodeLabel, getNode]);
 
-  const onBlur = () => {
-    allowInactivateNodeWhenClickOutside();
-    const curRef = componentRef.current;
-    if (curRef) {
-      curRef.classList.remove('nodrag');
-    }
-    if (isLocalEdit) {
-      editNodeLabel(id, nodeLabel);
-      setIsLocalEdit(false);
-    }
-  };
-
-  // for rendering diffent logo of upper right tag
-  const renderTagLogo = () => {
     return (
-      <svg
-        width='24'
-        height='24'
-        viewBox='0 0 24 24'
-        fill='none'
-        xmlns='http://www.w3.org/2000/svg'
-        className='group'
-      >
-        <path
-          d='M4 6H10L12 8H20V18H4V6Z'
-          className='fill-transparent stroke-[#9E7E5F] group-active:stroke-[#BF9A78]'
-          strokeWidth='1.5'
-        />
-        <path
-          d='M8 13.5H16'
-          className='stroke-[#9E7E5F] group-active:stroke-[#BF9A78]'
-          strokeWidth='1.5'
-          strokeLinecap='round'
-        />
-      </svg>
-    );
-  };
-
-  // 计算 labelContainer 的 最大宽度，最大宽度是由外部的container 的宽度决定的，同时需要减去 32px, 因为右边有一个menuIcon, 需要 - 他的宽度和右边的padding
-  const calculateMaxLabelContainerWidth = () => {
-    if (contentRef.current) {
-      return `${contentRef.current.clientWidth - 48}px`;
-    }
-    return '100%';
-  };
-
-  return (
-    <div
-      ref={componentRef}
-      className={`relative w-full h-full min-w-[240px] min-h-[176px] ${isOnGeneratingNewNode ? 'cursor-crosshair' : 'cursor-default'}`}
-      onMouseEnter={() => {
-        setIsHovered(true);
-        activateNode(id);
-      }}
-      onMouseLeave={() => {
-        setIsHovered(false);
-      }}
-    >
-      <div className='absolute -top-[28px] h-[24px] left-0 z-10 flex gap-1.5'>
-        {effectiveIsInput && (
-          <div className='px-2 py-0.5 rounded-[8px] flex items-center gap-1 text-[10px] font-bold bg-[#84EB89] text-black'>
-            <svg
-              width='16'
-              height='16'
-              viewBox='0 0 26 26'
-              fill='none'
-              xmlns='http://www.w3.org/2000/svg'
-            >
-              <rect
-                x='16'
-                y='7'
-                width='3'
-                height='12'
-                rx='1'
-                fill='currentColor'
-              />
-              <path
-                d='M5 13H14'
-                stroke='currentColor'
-                strokeWidth='2.5'
-                strokeLinecap='round'
-              />
-              <path
-                d='M10 9L14 13L10 17'
-                stroke='currentColor'
-                strokeWidth='2.5'
-                strokeLinecap='round'
-                strokeLinejoin='round'
-              />
-            </svg>
-            <span>INPUT</span>
-          </div>
-        )}
-
-        {effectiveIsOutput && (
-          <div className='px-2 py-0.5 rounded-[8px] flex items-center gap-1 text-[10px] font-bold bg-[#FF9267] text-black'>
-            <svg
-              width='16'
-              height='16'
-              viewBox='0 0 26 26'
-              fill='none'
-              xmlns='http://www.w3.org/2000/svg'
-            >
-              <rect
-                x='7'
-                y='7'
-                width='3'
-                height='12'
-                rx='1'
-                fill='currentColor'
-              />
-              <path
-                d='M12 13H21'
-                stroke='currentColor'
-                strokeWidth='2.5'
-                strokeLinecap='round'
-              />
-              <path
-                d='M17 9L21 13L17 17'
-                stroke='currentColor'
-                strokeWidth='2.5'
-                strokeLinecap='round'
-                strokeLinejoin='round'
-              />
-            </svg>
-            <span>OUTPUT</span>
-          </div>
-        )}
-
-        {locked && (
-          <div className='px-2 py-0.5 rounded-[8px] flex items-center gap-1 text-[10px] font-bold bg-[#3EDBC9] text-black'>
-            <svg
-              width='16'
-              height='16'
-              viewBox='0 0 16 16'
-              fill='none'
-              xmlns='http://www.w3.org/2000/svg'
-            >
-              <path
-                d='M5 7V5C5 3.34315 6.34315 2 8 2C9.65685 2 11 3.34315 11 5V7'
-                stroke='currentColor'
-                strokeWidth='1.5'
-                strokeLinecap='round'
-              />
-              <rect
-                x='4'
-                y='7'
-                width='8'
-                height='6'
-                rx='1'
-                fill='currentColor'
-              />
-            </svg>
-            <span>LOCKED</span>
-          </div>
-        )}
-      </div>
-
       <div
-        id={id}
-        ref={contentRef}
-        className={`flex flex-col w-full h-full border-[1.5px] border-solid border-[1.5px] min-w-[240px] min-h-[176px] p-[8px] rounded-[16px] flex justify-start ${borderColor} text-[#CDCDCD] bg-main-black-theme break-words font-plus-jakarta-sans text-base leading-5 font-[400] overflow-hidden file-block-node`}
+        ref={componentRef}
+        className={`relative w-full h-full min-w-[240px] min-h-[176px] ${
+          isOnGeneratingNewNode ? 'cursor-crosshair' : 'cursor-default'
+        }`}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
       >
-        {/* the top bar of a block */}
-        <div
-          ref={labelContainerRef}
-          className={`h-[24px] w-full max-w-full rounded-[4px] flex items-center justify-between mb-2`}
-        >
-          {/* top-left wrapper */}
-          <div
-            className='flex items-center gap-[8px] hover:cursor-grab active:cursor-grabbing group'
-            style={{
-              maxWidth: calculateMaxLabelContainerWidth(),
-            }}
-          >
-            <div className='min-w-[20px] min-h-[24px] flex items-center justify-center group-hover:text-[#CDCDCD] group-active:text-[#BF9A78]'>
-              {renderTagLogo()}
+        <div className='absolute -top-[28px] h-[24px] left-0 z-10 flex gap-1.5'>
+          {effectiveIsInput && (
+            <div className='px-2 py-0.5 rounded-[8px] flex items-center gap-1 text-[10px] font-bold bg-[#84EB89] text-black'>
+              <svg
+                width='16'
+                height='16'
+                viewBox='0 0 26 26'
+                fill='none'
+                xmlns='http://www.w3.org/2000/svg'
+              >
+                <rect
+                  x='16'
+                  y='7'
+                  width='3'
+                  height='12'
+                  rx='1'
+                  fill='currentColor'
+                />
+                <path
+                  d='M5 13H14'
+                  stroke='currentColor'
+                  strokeWidth='2.5'
+                  strokeLinecap='round'
+                />
+                <path
+                  d='M10 9L14 13L10 17'
+                  stroke='currentColor'
+                  strokeWidth='2.5'
+                  strokeLinecap='round'
+                  strokeLinejoin='round'
+                />
+              </svg>
+              <span>INPUT</span>
             </div>
+          )}
 
-            {/* measure label width span */}
-            <span
-              ref={measureSpanRef}
+          {effectiveIsOutput && (
+            <div className='px-2 py-0.5 rounded-[8px] flex items-center gap-1 text-[10px] font-bold bg-[#FF9267] text-black'>
+              <svg
+                width='16'
+                height='16'
+                viewBox='0 0 26 26'
+                fill='none'
+                xmlns='http://www.w3.org/2000/svg'
+              >
+                <rect
+                  x='7'
+                  y='7'
+                  width='3'
+                  height='12'
+                  rx='1'
+                  fill='currentColor'
+                />
+                <path
+                  d='M12 13H21'
+                  stroke='currentColor'
+                  strokeWidth='2.5'
+                  strokeLinecap='round'
+                />
+                <path
+                  d='M17 9L21 13L17 17'
+                  stroke='currentColor'
+                  strokeWidth='2.5'
+                  strokeLinecap='round'
+                  strokeLinejoin='round'
+                />
+              </svg>
+              <span>OUTPUT</span>
+            </div>
+          )}
+
+          {locked && (
+            <div className='px-2 py-0.5 rounded-[8px] flex items-center gap-1 text-[10px] font-bold bg-[#3EDBC9] text-black'>
+              <svg
+                width='16'
+                height='16'
+                viewBox='0 0 16 16'
+                fill='none'
+                xmlns='http://www.w3.org/2000/svg'
+              >
+                <path
+                  d='M5 7V5C5 3.34315 6.34315 2 8 2C9.65685 2 11 3.34315 11 5V7'
+                  stroke='currentColor'
+                  strokeWidth='1.5'
+                  strokeLinecap='round'
+                />
+                <rect
+                  x='4'
+                  y='7'
+                  width='8'
+                  height='6'
+                  rx='1'
+                  fill='currentColor'
+                />
+              </svg>
+              <span>LOCKED</span>
+            </div>
+          )}
+        </div>
+
+        <div id={id} ref={contentRef} className={containerClassName}>
+          {/* the top bar of a block */}
+          <div
+            ref={labelContainerRef}
+            className={`h-[24px] w-full max-w-full rounded-[4px] flex items-center justify-between mb-2`}
+          >
+            {/* top-left wrapper */}
+            <div
+              className='flex items-center gap-[8px] hover:cursor-grab active:cursor-grabbing group'
               style={{
-                visibility: 'hidden',
-                position: 'absolute',
-                whiteSpace: 'pre',
-                fontSize: '12px',
-                lineHeight: '18px',
-                fontWeight: '700',
-                fontFamily: 'Plus Jakarta Sans',
+                maxWidth: calculateMaxLabelContainerWidth(),
               }}
             >
-              {nodeLabel}
-            </span>
+              <div className='min-w-[20px] min-h-[24px] flex items-center justify-center group-hover:text-[#CDCDCD] group-active:text-[#BF9A78]'>
+                {renderTagLogo()}
+              </div>
 
-            {editable ? (
-              <input
-                ref={labelRef}
-                autoFocus={editable}
-                className={`
+              {/* measure label width span */}
+              <span
+                ref={measureSpanRef}
+                style={{
+                  visibility: 'hidden',
+                  position: 'absolute',
+                  whiteSpace: 'pre',
+                  fontSize: '12px',
+                  lineHeight: '18px',
+                  fontWeight: '700',
+                  fontFamily: 'Plus Jakarta Sans',
+                }}
+              >
+                {nodeState.nodeLabel}
+              </span>
+
+              {editable ? (
+                <input
+                  ref={labelRef}
+                  autoFocus={editable}
+                  className={`
                   flex items-center justify-start 
                   font-[600] text-[12px] leading-[18px] 
                   font-plus-jakarta-sans bg-transparent h-[18px] 
                   focus:outline-none truncate w-full text-[#6D7177] group-hover:text-[#CDCDCD] group-active:text-[#BF9A78]
                 `}
-                value={nodeLabel}
-                readOnly={!editable}
-                onChange={e => {
-                  setIsLocalEdit(true);
-                  setNodeLabel(e.target.value);
-                }}
-                onMouseDownCapture={onFocus}
-                onBlur={onBlur}
-              />
-            ) : (
-              <span
-                className={`
+                  value={nodeState.nodeLabel}
+                  readOnly={!editable}
+                  onChange={handleLabelChange}
+                  onMouseDownCapture={onFocus}
+                  onBlur={onBlur}
+                />
+              ) : (
+                <span
+                  className={`
                   flex items-center justify-start 
                   font-[600] text-[12px] leading-[18px] 
                   font-plus-jakarta-sans truncate w-fit text-[#6D7177] group-hover:text-[#CDCDCD] group-active:text-[#BF9A78]
                 `}
-              >
-                {nodeLabel}
-              </span>
-            )}
+                >
+                  {nodeState.nodeLabel}
+                </span>
+              )}
+            </div>
+
+            {/* top-right toolbar */}
+            <div className='min-w-[24px] min-h-[24px] flex items-center justify-center'>
+              <NodeToolBar Parentnodeid={id} ParentNodetype={type} />
+            </div>
           </div>
 
-          {/* top-right toolbar */}
-          <div className='min-w-[24px] min-h-[24px] flex items-center justify-center'>
-            <NodeToolBar Parentnodeid={id} ParentNodetype={type} />
-          </div>
-        </div>
-
-        <div
-          className='flex flex-col w-full h-full rounded-[8px]               
+          <div
+            className='flex flex-col w-full h-full rounded-[8px]               
         border-dashed border-[1px] border-gray-500
         hover:border-[#9E7E5F] active:border-[#9E7E5F]'
-        >
-          {/* 文件上传UI组件 */}
-          <div
-            className={`cursor-pointer h-full w-full px-[8px] py-[8px] mx-auto rounded-[8px] hover:bg-gray-800/40
-             transition-all duration-200`}
-            onDragOver={e => {
-              e.preventDefault();
-              e.stopPropagation();
-              e.currentTarget.classList.add(
-                'bg-gray-800/20',
-                'border-blue-400'
-              );
-            }}
-            onDragLeave={e => {
-              e.preventDefault();
-              e.stopPropagation();
-              e.currentTarget.classList.remove(
-                'bg-gray-800/42',
-                'border-blue-400'
-              );
-            }}
-            onDrop={handleFileDrop}
           >
-            {/* Loading overlay */}
-            {isOnUploading && (
-              <div className='absolute inset-0 bg-gray-900/80 backdrop-blur-[2px] rounded-[8px] flex flex-col items-center justify-center z-10'>
-                <div className='relative flex items-center justify-center'>
-                  {/* 背景圆环 */}
-                  <svg
-                    className='w-12 h-12 text-gray-700/50'
-                    viewBox='0 0 44 44'
-                  >
-                    <circle
-                      cx='22'
-                      cy='22'
-                      r='20'
+            {/* 文件上传UI组件 */}
+            <div
+              className={`cursor-pointer h-full w-full px-[8px] py-[8px] mx-auto rounded-[8px] hover:bg-gray-800/40
+             transition-all duration-200`}
+              onDragOver={e => {
+                e.preventDefault();
+                e.stopPropagation();
+                e.currentTarget.classList.add(
+                  'bg-gray-800/20',
+                  'border-blue-400'
+                );
+              }}
+              onDragLeave={e => {
+                e.preventDefault();
+                e.stopPropagation();
+                e.currentTarget.classList.remove(
+                  'bg-gray-800/42',
+                  'border-blue-400'
+                );
+              }}
+              onDrop={handleFileDrop}
+            >
+              {/* Loading overlay */}
+              {isOnUploading && (
+                <div className='absolute inset-0 bg-gray-900/80 backdrop-blur-[2px] rounded-[8px] flex flex-col items-center justify-center z-10'>
+                  <div className='relative flex items-center justify-center'>
+                    {/* 背景圆环 */}
+                    <svg
+                      className='w-12 h-12 text-gray-700/50'
+                      viewBox='0 0 44 44'
+                    >
+                      <circle
+                        cx='22'
+                        cy='22'
+                        r='20'
+                        fill='none'
+                        stroke='currentColor'
+                        strokeWidth='2'
+                      />
+                    </svg>
+
+                    {/* 动态进度圆环 */}
+                    <svg
+                      className='absolute w-12 h-12 animate-[spin_2s_linear_infinite] text-[#9E7E5F]'
+                      viewBox='0 0 44 44'
+                    >
+                      <circle
+                        cx='22'
+                        cy='22'
+                        r='20'
+                        fill='none'
+                        stroke='currentColor'
+                        strokeWidth='2'
+                        strokeLinecap='round'
+                        strokeDasharray='16 84'
+                      />
+                    </svg>
+
+                    {/* 中心上传图标 */}
+                    <svg
+                      className='absolute w-5 h-5 text-[#9E7E5F]'
+                      viewBox='0 0 24 24'
                       fill='none'
                       stroke='currentColor'
-                      strokeWidth='2'
-                    />
-                  </svg>
+                    >
+                      <path
+                        strokeLinecap='round'
+                        strokeLinejoin='round'
+                        strokeWidth={1.5}
+                        d='M7 10l5-5 5 5M12 5v10'
+                      />
+                    </svg>
+                  </div>
+                  <div className='mt-4 flex flex-col items-center'>
+                    <p className='text-[#9E7E5F] font-medium text-[13px]'>
+                      Uploading
+                    </p>
+                    <p className='text-gray-500 text-[11px] mt-1'>
+                      Please wait...
+                    </p>
+                  </div>
+                </div>
+              )}
 
-                  {/* 动态进度圆环 */}
+              {uploadedFiles.length === 0 ? (
+                <div
+                  className='text-center py-[8px] flex flex-col items-center justify-center h-full w-full cursor-pointer'
+                  onClick={handleEmptyAreaClick}
+                >
+                  {/* Upload Icon */}
                   <svg
-                    className='absolute w-12 h-12 animate-[spin_2s_linear_infinite] text-[#9E7E5F]'
-                    viewBox='0 0 44 44'
-                  >
-                    <circle
-                      cx='22'
-                      cy='22'
-                      r='20'
-                      fill='none'
-                      stroke='currentColor'
-                      strokeWidth='2'
-                      strokeLinecap='round'
-                      strokeDasharray='16 84'
-                    />
-                  </svg>
-
-                  {/* 中心上传图标 */}
-                  <svg
-                    className='absolute w-5 h-5 text-[#9E7E5F]'
+                    xmlns='http://www.w3.org/2000/svg'
+                    className='h-8 w-8 mx-auto text-gray-400 group-hover:text-[#9E7E5F] transition-colors duration-300 mb-3'
                     viewBox='0 0 24 24'
                     fill='none'
                     stroke='currentColor'
                   >
+                    {/* 文件轮廓 - 更锋利的角度 */}
                     <path
-                      strokeLinecap='round'
-                      strokeLinejoin='round'
-                      strokeWidth={1.5}
-                      d='M7 10l5-5 5 5M12 5v10'
+                      strokeLinecap='square'
+                      strokeLinejoin='miter'
+                      strokeWidth={1.2}
+                      d='M8 3h6l4 4v12a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1z'
+                    />
+                    {/* 文件折角 - 更锋利的转角 */}
+                    <path
+                      strokeLinecap='butt'
+                      strokeLinejoin='miter'
+                      strokeWidth={1.2}
+                      d='M14 3v4h4'
+                    />
+                    {/* 上传箭头 - 更细的线条 */}
+                    <path
+                      strokeLinecap='square'
+                      strokeLinejoin='miter'
+                      strokeWidth={1.2}
+                      d='M12 15V10m0 0l-2.5 2.5M12 10l2.5 2.5'
                     />
                   </svg>
-                </div>
-                <div className='mt-4 flex flex-col items-center'>
-                  <p className='text-[#9E7E5F] font-medium text-[13px]'>
-                    Uploading
-                  </p>
-                  <p className='text-gray-500 text-[11px] mt-1'>
-                    Please wait...
-                  </p>
-                </div>
-              </div>
-            )}
 
-            {uploadedFiles.length === 0 ? (
-              <div
-                className='text-center py-[8px] flex flex-col items-center justify-center h-full w-full cursor-pointer'
-                onClick={() => inputRef.current?.click()}
-              >
-                {/* Upload Icon */}
-                <svg
-                  xmlns='http://www.w3.org/2000/svg'
-                  className='h-8 w-8 mx-auto text-gray-400 group-hover:text-[#9E7E5F] transition-colors duration-300 mb-3'
-                  viewBox='0 0 24 24'
-                  fill='none'
-                  stroke='currentColor'
+                  <p className='text-[12px] text-gray-500'>
+                    Drag and drop files here, or
+                  </p>
+                  <p className='text-[12px] text-gray-500'>Click to upload</p>
+                </div>
+              ) : (
+                <div
+                  className='flex flex-col w-full gap-[8px] h-full'
+                  onClick={handleUploadAreaClick}
                 >
-                  {/* 文件轮廓 - 更锋利的角度 */}
-                  <path
-                    strokeLinecap='square'
-                    strokeLinejoin='miter'
-                    strokeWidth={1.2}
-                    d='M8 3h6l4 4v12a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1z'
-                  />
-                  {/* 文件折角 - 更锋利的转角 */}
-                  <path
-                    strokeLinecap='butt'
-                    strokeLinejoin='miter'
-                    strokeWidth={1.2}
-                    d='M14 3v4h4'
-                  />
-                  {/* 上传箭头 - 更细的线条 */}
-                  <path
-                    strokeLinecap='square'
-                    strokeLinejoin='miter'
-                    strokeWidth={1.2}
-                    d='M12 15V10m0 0l-2.5 2.5M12 10l2.5 2.5'
-                  />
-                </svg>
-
-                <p className='text-[12px] text-gray-500'>
-                  Drag and drop files here, or
-                </p>
-                <p className='text-[12px] text-gray-500'>Click to upload</p>
-              </div>
-            ) : (
-              <div
-                className='flex flex-col w-full gap-[8px] h-full'
-                onClick={e => {
-                  // 确保只有点击空白区域时触发
-                  if (e.currentTarget === e.target) {
-                    inputRef.current?.click();
-                  }
-                }}
-              >
-                {uploadedFiles.map((file: UploadedFile, index: number) => (
-                  <div
-                    key={index}
-                    className='bg-[#3C3B37] min-h-[32px] hover:bg-[#5A574F] text-[#CDCDCD] text-[14px] font-regular rounded-md pl-[12px] flex justify-between items-center'
-                  >
+                  {uploadedFiles.map((file: UploadedFile, index: number) => (
                     <div
-                      className='flex-1 py-2 cursor-pointer flex items-center'
-                      onClick={e => {
-                        e.stopPropagation(); // 防止触发父元素的点击事件
-                        // 检查download_url是否存在
-                        if (file.download_url) {
-                          // 在新窗口中打开下载链接
-                          window.open(file.download_url, '_blank');
-                        }
-                      }}
+                      key={index}
+                      className='bg-[#3C3B37] min-h-[32px] hover:bg-[#5A574F] text-[#CDCDCD] text-[14px] font-regular rounded-md pl-[12px] flex justify-between items-center'
                     >
-                      {/* 添加文件图标 */}
-                      <svg
-                        className='w-4 h-4 mr-2 text-gray-400 flex-shrink-0'
-                        viewBox='0 0 24 24'
-                        fill='none'
-                        stroke='currentColor'
+                      <div
+                        className='flex-1 py-2 cursor-pointer flex items-center'
+                        onClick={e => handleFileClick(file, e)}
                       >
-                        <path
-                          strokeLinecap='round'
-                          strokeLinejoin='round'
-                          strokeWidth={1.5}
-                          d='M8 3h6l4 4v12a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1z'
-                        />
-                        <path
-                          strokeLinecap='round'
-                          strokeLinejoin='round'
-                          strokeWidth={1.5}
-                          d='M14 3v4h4'
-                        />
-                      </svg>
+                        {/* 添加文件图标 */}
+                        <svg
+                          className='w-4 h-4 mr-2 text-gray-400 flex-shrink-0'
+                          viewBox='0 0 24 24'
+                          fill='none'
+                          stroke='currentColor'
+                        >
+                          <path
+                            strokeLinecap='round'
+                            strokeLinejoin='round'
+                            strokeWidth={1.5}
+                            d='M8 3h6l4 4v12a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1z'
+                          />
+                          <path
+                            strokeLinecap='round'
+                            strokeLinejoin='round'
+                            strokeWidth={1.5}
+                            d='M14 3v4h4'
+                          />
+                        </svg>
 
-                      {/* 文件名 */}
-                      <span className='truncate overflow-hidden text-ellipsis'>
-                        {file.fileName?.replace(/^file_/, '') ||
-                          file.task_id + '.' + file.fileType ||
-                          'Unnamed file'}
-                      </span>
+                        {/* 文件名 */}
+                        <span className='truncate overflow-hidden text-ellipsis'>
+                          {file.fileName?.replace(/^file_/, '') ||
+                            file.task_id + '.' + file.fileType ||
+                            'Unnamed file'}
+                        </span>
+                      </div>
+
+                      {/* 删除按钮 */}
+                      <button
+                        onClick={e => handleFileDelete(file, index, e)}
+                        className='text-gray-400 hover:text-red-400 w-[32px] h-[32px] flex items-center justify-center flex-shrink-0'
+                      >
+                        <svg
+                          width='14'
+                          height='14'
+                          viewBox='0 0 24 24'
+                          fill='none'
+                          stroke='currentColor'
+                        >
+                          <path
+                            d='M18 6L6 18M6 6l12 12'
+                            strokeWidth='2'
+                            strokeLinecap='round'
+                          />
+                        </svg>
+                      </button>
                     </div>
+                  ))}
+                </div>
+              )}
+            </div>
 
-                    {/* 删除按钮 */}
-                    <button
-                      onClick={e => {
-                        e.stopPropagation(); // 防止触发文件的点击事件
-                        handleDelete(file, index);
-                      }}
-                      className='text-gray-400 hover:text-red-400 w-[32px] h-[32px] flex items-center justify-center flex-shrink-0'
-                    >
-                      <svg
-                        width='14'
-                        height='14'
-                        viewBox='0 0 24 24'
-                        fill='none'
-                        stroke='currentColor'
-                      >
-                        <path
-                          d='M18 6L6 18M6 6l12 12'
-                          strokeWidth='2'
-                          strokeLinecap='round'
-                        />
-                      </svg>
-                    </button>
-                  </div>
-                ))}
-              </div>
+            {/* 添加隐藏的文件输入框 */}
+            {ReactDOM.createPortal(
+              <input
+                type='file'
+                ref={inputRef}
+                onChange={handleInputChange}
+                onClick={e => e.stopPropagation()}
+                accept='.json, .pdf, .txt, .docx, .csv, .xlsx, .markdown, .md, .mdx'
+                multiple
+                className='opacity-0 absolute top-0 left-0 w-full h-full cursor-pointer'
+                style={{
+                  position: 'fixed',
+                  top: '-100%',
+                  left: '-100%',
+                  zIndex: 9999,
+                }}
+              />,
+              document.body
             )}
           </div>
 
-          {/* 添加隐藏的文件输入框 */}
-          {ReactDOM.createPortal(
-            <input
-              type='file'
-              ref={inputRef}
-              onChange={handleInputChange}
-              onClick={e => e.stopPropagation()}
-              accept='.json, .pdf, .txt, .docx, .csv, .xlsx, .markdown, .md, .mdx'
-              multiple
-              className='opacity-0 absolute top-0 left-0 w-full h-full cursor-pointer'
-              style={{
-                position: 'fixed',
-                top: '-100%',
-                left: '-100%',
-                zIndex: 9999,
-              }}
-            />,
-            document.body
-          )}
-        </div>
-
-        <NodeResizeControl
-          minWidth={240}
-          minHeight={176}
-          style={{
-            position: 'absolute',
-            right: '0px',
-            bottom: '0px',
-            cursor: 'se-resize',
-            background: 'transparent',
-            border: 'none',
-            display: isLoading ? 'none' : 'flex',
-          }}
-        >
-          <div
+          <NodeResizeControl
+            minWidth={240}
+            minHeight={176}
             style={{
               position: 'absolute',
-              visibility: `${activatedNode?.id === id ? 'visible' : 'hidden'}`,
-              right: '8px',
-              bottom: '8px',
-              display: 'flex',
-              justifyContent: 'center',
-              alignItems: 'center',
-              backgroundColor: 'transparent',
-              zIndex: '200000',
-              width: '26px',
-              height: '26px',
+              right: '0px',
+              bottom: '0px',
+              cursor: 'se-resize',
+              background: 'transparent',
+              border: 'none',
+              display: isLoading ? 'none' : 'flex',
             }}
           >
-            <svg
-              width='26'
-              height='26'
-              viewBox='0 0 26 26'
-              fill='none'
-              xmlns='http://www.w3.org/2000/svg'
-              className='group active:group-[]:fill-[#BF9A78]'
+            <div
+              style={{
+                position: 'absolute',
+                visibility: `${
+                  activatedNode?.id === id ? 'visible' : 'hidden'
+                }`,
+                right: '8px',
+                bottom: '8px',
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+                backgroundColor: 'transparent',
+                zIndex: '200000',
+                width: '26px',
+                height: '26px',
+              }}
             >
-              <path
-                d='M10 5.99998H12V7.99998H10V5.99998Z'
-                className='fill-[#9E7E5F] group-hover:fill-[#CDCDCD] group-active:fill-[#BF9A78]'
-              />
-              <path
-                d='M10 2H12V4H10V2Z'
-                className='fill-[#9E7E5F] group-hover:fill-[#CDCDCD] group-active:fill-[#BF9A78]'
-              />
-              <path
-                d='M6 5.99998H8V7.99998H6V5.99998Z'
-                className='fill-[#9E7E5F] group-hover:fill-[#CDCDCD] group-active:fill-[#BF9A78]'
-              />
-              <path
-                d='M6 10H8V12H6V10Z'
-                className='fill-[#9E7E5F] group-hover:fill-[#CDCDCD] group-active:fill-[#BF9A78]'
-              />
-              <path
-                d='M2 10H4V12H2V10Z'
-                className='fill-[#9E7E5F] group-hover:fill-[#CDCDCD] group-active:fill-[#BF9A78]'
-              />
-              <path
-                d='M10 10H12V12H10V10Z'
-                className='fill-[#9E7E5F] group-hover:fill-[#CDCDCD] group-active:fill-[#BF9A78]'
-              />
-            </svg>
-          </div>
-        </NodeResizeControl>
+              <svg
+                width='26'
+                height='26'
+                viewBox='0 0 26 26'
+                fill='none'
+                xmlns='http://www.w3.org/2000/svg'
+                className='group active:group-[]:fill-[#BF9A78]'
+              >
+                <path
+                  d='M10 5.99998H12V7.99998H10V5.99998Z'
+                  className='fill-[#9E7E5F] group-hover:fill-[#CDCDCD] group-active:fill-[#BF9A78]'
+                />
+                <path
+                  d='M10 2H12V4H10V2Z'
+                  className='fill-[#9E7E5F] group-hover:fill-[#CDCDCD] group-active:fill-[#BF9A78]'
+                />
+                <path
+                  d='M6 5.99998H8V7.99998H6V5.99998Z'
+                  className='fill-[#9E7E5F] group-hover:fill-[#CDCDCD] group-active:fill-[#BF9A78]'
+                />
+                <path
+                  d='M6 10H8V12H6V10Z'
+                  className='fill-[#9E7E5F] group-hover:fill-[#CDCDCD] group-active:fill-[#BF9A78]'
+                />
+                <path
+                  d='M2 10H4V12H2V10Z'
+                  className='fill-[#9E7E5F] group-hover:fill-[#CDCDCD] group-active:fill-[#BF9A78]'
+                />
+                <path
+                  d='M10 10H12V12H10V10Z'
+                  className='fill-[#9E7E5F] group-hover:fill-[#CDCDCD] group-active:fill-[#BF9A78]'
+                />
+              </svg>
+            </div>
+          </NodeResizeControl>
 
-        {/* Handle components for ReactFlow */}
-        <WhiteBallHandle
-          id={`${id}-a`}
-          type='source'
-          sourceNodeId={id}
-          isConnectable={isConnectable}
-          position={Position.Top}
-        />
-        <WhiteBallHandle
-          id={`${id}-b`}
-          type='source'
-          sourceNodeId={id}
-          isConnectable={isConnectable}
-          position={Position.Right}
-        />
-        <WhiteBallHandle
-          id={`${id}-c`}
-          type='source'
-          sourceNodeId={id}
-          isConnectable={isConnectable}
-          position={Position.Bottom}
-        />
-        <WhiteBallHandle
-          id={`${id}-d`}
-          type='source'
-          sourceNodeId={id}
-          isConnectable={isConnectable}
-          position={Position.Left}
-        />
-        <Handle
-          id={`${id}-a`}
-          type='target'
-          position={Position.Top}
-          style={{
-            position: 'absolute',
-            width: 'calc(100%)',
-            height: 'calc(100%)',
-            top: '0',
-            left: '0',
-            borderRadius: '0',
-            transform: 'translate(0px, 0px)',
-            background: 'transparent',
-            border: '3px solid transparent',
-            zIndex: !isOnConnect ? '-1' : '1',
-          }}
-          isConnectable={isConnectable}
-          onMouseEnter={() => setIsTargetHandleTouched(true)}
-          onMouseLeave={() => setIsTargetHandleTouched(false)}
-        />
-        <Handle
-          id={`${id}-b`}
-          type='target'
-          position={Position.Right}
-          style={{
-            position: 'absolute',
-            width: 'calc(100%)',
-            height: 'calc(100%)',
-            top: '0',
-            left: '0',
-            borderRadius: '0',
-            transform: 'translate(0px, 0px)',
-            background: 'transparent',
-            border: '3px solid transparent',
-            zIndex: !isOnConnect ? '-1' : '1',
-          }}
-          isConnectable={isConnectable}
-          onMouseEnter={() => setIsTargetHandleTouched(true)}
-          onMouseLeave={() => setIsTargetHandleTouched(false)}
-        />
-        <Handle
-          id={`${id}-c`}
-          type='target'
-          position={Position.Bottom}
-          style={{
-            position: 'absolute',
-            width: 'calc(100%)',
-            height: 'calc(100%)',
-            top: '0',
-            left: '0',
-            borderRadius: '0',
-            transform: 'translate(0px, 0px)',
-            background: 'transparent',
-            border: '3px solid transparent',
-            zIndex: !isOnConnect ? '-1' : '1',
-          }}
-          isConnectable={isConnectable}
-          onMouseEnter={() => setIsTargetHandleTouched(true)}
-          onMouseLeave={() => setIsTargetHandleTouched(false)}
-        />
-        <Handle
-          id={`${id}-d`}
-          type='target'
-          position={Position.Left}
-          style={{
-            position: 'absolute',
-            width: 'calc(100%)',
-            height: 'calc(100%)',
-            top: '0',
-            left: '0',
-            borderRadius: '0',
-            transform: 'translate(0px, 0px)',
-            background: 'transparent',
-            border: '3px solid transparent',
-            zIndex: !isOnConnect ? '-1' : '1',
-          }}
-          isConnectable={isConnectable}
-          onMouseEnter={() => setIsTargetHandleTouched(true)}
-          onMouseLeave={() => setIsTargetHandleTouched(false)}
-        />
+          {/* Handle components for ReactFlow */}
+          <WhiteBallHandle
+            id={`${id}-a`}
+            type='source'
+            sourceNodeId={id}
+            isConnectable={isConnectable}
+            position={Position.Top}
+          />
+          <WhiteBallHandle
+            id={`${id}-b`}
+            type='source'
+            sourceNodeId={id}
+            isConnectable={isConnectable}
+            position={Position.Right}
+          />
+          <WhiteBallHandle
+            id={`${id}-c`}
+            type='source'
+            sourceNodeId={id}
+            isConnectable={isConnectable}
+            position={Position.Bottom}
+          />
+          <WhiteBallHandle
+            id={`${id}-d`}
+            type='source'
+            sourceNodeId={id}
+            isConnectable={isConnectable}
+            position={Position.Left}
+          />
+
+          {/* Target Handles */}
+          {[Position.Top, Position.Right, Position.Bottom, Position.Left].map(
+            (pos, index) => (
+              <Handle
+                key={pos}
+                id={`${id}-${String.fromCharCode(97 + index)}`}
+                type='target'
+                position={pos}
+                style={handleStyle}
+                isConnectable={isConnectable}
+                onMouseEnter={handleTargetHandleMouseEnter}
+                onMouseLeave={handleTargetHandleMouseLeave}
+              />
+            )
+          )}
+        </div>
       </div>
-    </div>
-  );
-}
+    );
+  }
+);
+
+FileNode.displayName = 'FileNode';
 
 export default FileNode;

--- a/PuppyFlow/app/components/workflow/blockNode/JsonNodeNew.tsx
+++ b/PuppyFlow/app/components/workflow/blockNode/JsonNodeNew.tsx
@@ -11,20 +11,16 @@ import React, {
   useRef,
   useEffect,
   useState,
-  ReactElement,
-  Fragment,
   useCallback,
+  useMemo,
 } from 'react';
-// import { nodeState, useNodeContext } from '../../states/NodeContext'
 import { useNodesPerFlowContext } from '../../states/NodesPerFlowContext';
 import WhiteBallHandle from '../handles/WhiteBallHandle';
-// 更新导入 - 使用新的 TreeJSONForm
 import TreeJSONForm from '../../tableComponent/TreeJSONForm';
 import SkeletonLoadingIcon from '../../loadingIcon/SkeletonLoadingIcon';
 import useGetSourceTarget from '../../hooks/useGetSourceTarget';
 import { useWorkspaceManagement } from '../../hooks/useWorkspaceManagement';
 import { useWorkspaces } from '../../states/UserWorkspacesContext';
-// 导入新组件
 import TreePathEditor, { PathNode } from '../components/TreePathEditor';
 import RichJSONForm from '../../tableComponent/RichJSONFormTableStyle/RichJSONForm';
 import JSONForm from '../../tableComponent/JSONForm';
@@ -40,7 +36,6 @@ type methodNames = 'cosine';
 type modelNames = 'text-embedding-ada-002';
 type vdb_typeNames = 'pgvector';
 
-// 添加这个类型定义
 type VectorIndexingStatus =
   | 'notStarted'
   | 'processing'
@@ -48,9 +43,8 @@ type VectorIndexingStatus =
   | 'error'
   | 'deleting';
 
-// 定义基本的 IndexingItem 类型
 export interface BaseIndexingItem {
-  type: string; // 用于区分不同类型的索引项
+  type: string;
 }
 
 interface PathSegment {
@@ -59,13 +53,12 @@ interface PathSegment {
   value: string;
 }
 
-// Vector 类型的索引项
 export interface VectorIndexingItem extends BaseIndexingItem {
   type: 'vector';
   status: VectorIndexingStatus;
   key_path: PathSegment[];
   value_path: PathSegment[];
-  chunks: any[]; // 修改为任意类型的列表
+  chunks: any[];
   index_name: string;
   collection_configs: {
     set_name: string;
@@ -76,472 +69,281 @@ export interface VectorIndexingItem extends BaseIndexingItem {
   };
 }
 
-// 可以添加其他类型的索引项
 export interface OtherIndexingItem extends BaseIndexingItem {
   type: 'other';
-  // 其他特定属性
 }
 
-// 联合类型，包含所有可能的索引项类型
 export type IndexingItem = VectorIndexingItem | OtherIndexingItem;
 
 export type JsonNodeData = {
   content: string;
   label: string;
   isLoading: boolean;
-  isWaitingForFlow: boolean; // 添加这个字段
+  isWaitingForFlow: boolean;
   locked: boolean;
   isInput: boolean;
   isOutput: boolean;
   editable: boolean;
   looped: boolean;
   indexingList: IndexingItem[];
-
-  // embedding configurations
   model?: modelNames | undefined;
   method?: methodNames | undefined;
   vdb_type?: vdb_typeNames | undefined;
-  index_name?: string | undefined; // 用于存储embedding 的index_name
+  index_name?: string | undefined;
 };
 
 type JsonBlockNodeProps = NodeProps<Node<JsonNodeData>>;
 
-// 注意：PathNode 类型已经在 TreePathEditor 组件中导出，这里不需要重复定义
-
-function JsonBlockNode({
-  isConnectable,
-  id,
-  type,
-  data: {
-    content,
-    label,
-    isLoading,
-    isWaitingForFlow,
-    locked,
-    isInput,
-    isOutput,
-    editable,
-    index_name,
-    indexingList = [],
-  },
-}: JsonBlockNodeProps) {
-  const { fetchUserId } = useWorkspaceManagement();
-  const { userId } = useWorkspaces();
-
-  type ExtendedNode = Node<JsonNodeData> & { looped?: boolean };
-  // selectHandle = 1: TOP, 2: RIGHT, 3: BOTTOM, 4: LEFT.
-  // Initialization: 0
-  // const [selectedHandle, setSelectedHandle] = useState<Position | null>(null)
-  const {
-    activatedNode,
-    isOnConnect,
-    isOnGeneratingNewNode,
-    setNodeUneditable,
-    editNodeLabel,
-    preventInactivateNode,
-    allowInactivateNodeWhenClickOutside,
-    clearAll,
-    manageNodeasInput,
-    manageNodeasOutput,
-    activateNode, // 添加 activateNode 方法
-    inactivateNode, // 添加 inactivateNode 方法
-  } = useNodesPerFlowContext();
-  const { setNodes, setEdges, getEdges, getNode } = useReactFlow();
-  // for linking to handle bar, it will be highlighed.
-  const [isTargetHandleTouched, setIsTargetHandleTouched] = useState(false);
-  const componentRef = useRef<HTMLDivElement | null>(null);
-  const contentRef = useRef<HTMLDivElement | null>(null);
-  const labelContainerRef = useRef<HTMLDivElement | null>(null);
-  const labelRef = useRef<HTMLInputElement | null>(null);
-  const [nodeLabel, setNodeLabel] = useState(label ?? id);
-  const [isLocalEdit, setIsLocalEdit] = useState(false); //使用 isLocalEdit 标志来区分本地编辑和外部更新。只有内部编辑：才能触发 更新 data.label, 只有外部更新才能触发 更新 nodeLabel
-  const [isEditing, setIsEditing] = useState(false);
-  const [vectorIndexingStatus, setVectorIndexingStatus] =
-    useState<VectorIndexingStatus>('notStarted');
-  const [isHovered, setIsHovered] = useState(false); // 添加 hover 状态
-
-  // Get connected nodes
-  const { getSourceNodeIdWithLabel, getTargetNodeIdWithLabel } =
-    useGetSourceTarget();
-  const sourceNodes = getSourceNodeIdWithLabel(id);
-  const targetNodes = getTargetNodeIdWithLabel(id);
-
-  // 添加自动检测和同步状态的 useEffect
-  useEffect(() => {
-    const isAutoDetectInput =
-      sourceNodes.length === 0 && targetNodes.length > 0;
-    const isAutoDetectOutput =
-      targetNodes.length === 0 && sourceNodes.length > 0;
-
-    // 仅当当前状态与自动检测不一致时更新状态
-    if (isAutoDetectInput && !isInput) {
-      manageNodeasInput(id);
-    } else if (isAutoDetectOutput && !isOutput) {
-      manageNodeasOutput(id);
-    } else if (
-      !isAutoDetectInput &&
-      !isAutoDetectOutput &&
-      (isInput || isOutput)
-    ) {
-      // 如果既不是输入也不是输出，但当前有一个标记，则移除标记
-      if (isInput) manageNodeasInput(id);
-      if (isOutput) manageNodeasOutput(id);
-    }
-  }, [sourceNodes.length, targetNodes.length, isInput, isOutput, id]);
-
-  // Validation function to check if any node has an empty value
-  const hasEmptyValues = (nodes: PathNode[]): boolean => {
-    for (const node of nodes) {
-      if (node.value.trim() === '') {
-        return true;
-      }
-      if (node.children.length > 0 && hasEmptyValues(node.children)) {
-        return true;
-      }
-    }
-    return false;
-  };
-
-  // 添加纯函数来计算边框颜色
-  const getBorderColor = () => {
-    if (isLoading) return 'border-[#FFA500]';
-    if (isWaitingForFlow) return 'border-[#39bc66]';
-    if (activatedNode?.id === id) return 'border-[#9B7EDB]';
-    if (isHovered) return 'border-[#9B7EDB]';
-    return isOnConnect && isTargetHandleTouched
-      ? 'border-main-orange'
-      : 'border-main-deep-grey';
-  };
-
-  // 管理labelContainer的宽度
-  useEffect(() => {
-    const handleClickOutside = (e: MouseEvent) => {
-      if (
-        !labelContainerRef.current?.contains(e.target as HTMLElement) &&
-        !(e.target as HTMLElement).classList.contains('renameButton')
-      ) {
-        setNodeUneditable(id);
-      }
-    };
-
-    document.addEventListener('click', handleClickOutside);
-
-    return () => {
-      document.removeEventListener('click', handleClickOutside);
-    };
-  }, [id]); // 添加 id 作为依赖
-
-  // 自动聚焦，同时需要让cursor focus 到input 的最后一位
-  useEffect(() => {
-    if (editable && labelRef.current) {
-      labelRef.current?.focus();
-      const length = labelRef.current.value.length;
-      labelRef.current.setSelectionRange(length, length);
-    }
-  }, [editable, id]);
-
-  // 管理 label onchange， 注意：若是当前的workflow中已经存在同样的id，那么不回重新对于这个node进行initialized，那么此时label就是改变了也不会rendering 最新的值，所以我们必须要通过这个useEffect来确保label的值是最新的，同时需要update measureSpanRef 中需要被测量的内容
-  useEffect(() => {
-    const currentLabel = getNode(id)?.data?.label as string | undefined;
-    if (
-      currentLabel !== undefined &&
-      currentLabel !== nodeLabel &&
-      !isLocalEdit
-    ) {
-      setNodeLabel(currentLabel);
-    }
-  }, [label, id, isLocalEdit]);
-
-  const onFocus: () => void = () => {
-    preventInactivateNode();
-    const curRef = componentRef.current;
-    if (curRef && !curRef.classList.contains('nodrag')) {
-      curRef.classList.add('nodrag');
-    }
-  };
-
-  const onBlur: () => void = () => {
-    allowInactivateNodeWhenClickOutside();
-    const curRef = componentRef.current;
-    if (curRef) {
-      curRef.classList.remove('nodrag');
-    }
-    if (isLocalEdit) {
-      //  管理 node label onchange，只有 onBlur 的时候，才会更新 label
-      // setNodes(nodes => nodes.map(node => node.id === id ? { ...node, data: { ...node.data, label: nodeLabel } } : node))
-      editNodeLabel(id, nodeLabel);
-      setIsLocalEdit(false);
-    }
-  };
-
-  // 添加 JSON 内容同步函数
-  const updateNodeContent = useCallback(
-    (newValue: string) => {
-      setNodes(prevNodes =>
-        prevNodes.map(node =>
-          node.id === id
-            ? {
-                ...node,
-                data: { ...node.data, content: newValue },
-              }
-            : node
-        )
-      );
+// 优化点 1: 使用 React.memo 包裹组件，避免不必要的重渲染
+const JsonBlockNode = React.memo<JsonBlockNodeProps>(
+  ({
+    isConnectable,
+    id,
+    type,
+    data: {
+      content,
+      label,
+      isLoading,
+      isWaitingForFlow,
+      locked,
+      isInput,
+      isOutput,
+      editable,
+      index_name,
+      indexingList = [],
     },
-    [id, setNodes]
-  );
+  }) => {
+    const { fetchUserId } = useWorkspaceManagement();
+    const { userId } = useWorkspaces();
 
-  // for rendering diffent logo of upper right tag
-  const renderTagLogo = () => {
-    return (
-      <svg
-        width='24'
-        height='24'
-        viewBox='0 0 24 24'
-        fill='none'
-        xmlns='http://www.w3.org/2000/svg'
-        className='group'
-      >
-        <path
-          d='M8 6.5V5H4V7.5V16.5V19H8V17.5H5.5V6.5H8Z'
-          className='fill-[#B0A4E3] group-active:fill-[#9B7EDB]'
-        />
-        <path
-          d='M16 6.5V5H20V7.5V16.5V19H16V17.5H18.5V6.5H16Z'
-          className='fill-[#B0A4E3] group-active:fill-[#9B7EDB]'
-        />
-        <path
-          d='M9 9H11V11H9V9Z'
-          className='fill-[#B0A4E3] group-active:fill-[#9B7EDB]'
-        />
-        <path
-          d='M9 13H11V15H9V13Z'
-          className='fill-[#B0A4E3] group-active:fill-[#9B7EDB]'
-        />
-        <path
-          d='M13 9H15V11H13V9Z'
-          className='fill-[#B0A4E3] group-active:fill-[#9B7EDB]'
-        />
-        <path
-          d='M13 13H15V15H13V13Z'
-          className='fill-[#B0A4E3] group-active:fill-[#9B7EDB]'
-        />
-      </svg>
+    const {
+      activatedNode,
+      isOnConnect,
+      isOnGeneratingNewNode,
+      setNodeUneditable,
+      editNodeLabel,
+      preventInactivateNode,
+      allowInactivateNodeWhenClickOutside,
+      manageNodeasInput,
+      manageNodeasOutput,
+      activateNode,
+      inactivateNode,
+    } = useNodesPerFlowContext();
+
+    const { setNodes, setEdges, getEdges, getNode } = useReactFlow();
+
+    // 优化点 2: 将多个相关的 state 合并，减少 state 更新的复杂性
+    const [nodeState, setNodeState] = useState({
+      isTargetHandleTouched: false,
+      nodeLabel: label ?? id,
+      isLocalEdit: false,
+      isHovered: false,
+      isEditing: false,
+      vectorIndexingStatus: 'notStarted' as VectorIndexingStatus,
+      showSettingMenu: false,
+      useRichEditor: false,
+      userInput: 'input view' as string | undefined,
+    });
+
+    // 使用 refs 来引用 DOM 元素，避免因引用变化导致重渲染
+    const componentRef = useRef<HTMLDivElement | null>(null);
+    const contentRef = useRef<HTMLDivElement | null>(null);
+    const labelContainerRef = useRef<HTMLDivElement | null>(null);
+    const labelRef = useRef<HTMLInputElement | null>(null);
+    // 优化点 3: 使用 ref 标记初始渲染，用于延迟计算
+    const hasMountedRef = useRef(false);
+
+    const { getSourceNodeIdWithLabel, getTargetNodeIdWithLabel } =
+      useGetSourceTarget();
+    const sourceNodes = getSourceNodeIdWithLabel(id);
+    const targetNodes = getTargetNodeIdWithLabel(id);
+
+    // 优化点 4: 使用 useMemo 缓存边框颜色的计算逻辑
+    const borderColor = useMemo(() => {
+      if (isLoading) return 'border-[#FFA500]';
+      if (isWaitingForFlow) return 'border-[#39bc66]';
+      if (activatedNode?.id === id) return 'border-[#9B7EDB]';
+      if (nodeState.isHovered) return 'border-[#9B7EDB]';
+      return isOnConnect && nodeState.isTargetHandleTouched
+        ? 'border-main-orange'
+        : 'border-main-deep-grey';
+    }, [
+      isLoading,
+      isWaitingForFlow,
+      activatedNode?.id,
+      id,
+      nodeState.isHovered,
+      isOnConnect,
+      nodeState.isTargetHandleTouched,
+    ]);
+
+    // 优化点 4: 使用 useMemo 缓存整个容器的 className 字符串
+    const containerClassName = useMemo(
+      () =>
+        `w-full h-full min-w-[240px] min-h-[176px] border-[1px] rounded-[16px] px-[8px] pt-[8px] pb-[8px] ${borderColor} text-[#CDCDCD] bg-main-black-theme break-words font-plus-jakarta-sans text-base leading-5 font-[400] overflow-hidden json-block-node flex flex-col`,
+      [borderColor]
     );
-  };
 
-  // 计算 labelContainer 的 最大宽度，最大宽度是由外部的container 的宽度决定的，同时需要减去 32px, 因为右边有一个menuIcon, 需要 - 他的宽度和右边的padding
-  const calculateMaxLabelContainerWidth = () => {
-    if (contentRef.current) {
-      return `${contentRef.current.clientWidth - 32}px`;
-    }
-    return '100%';
-  };
+    // 优化点 4 & 5: 使用 useMemo 缓存 Handle 的样式对象，避免内联样式导致重渲染
+    const handleStyle = useMemo(
+      () => ({
+        position: 'absolute' as const,
+        width: 'calc(100%)',
+        height: 'calc(100%)',
+        top: '0',
+        left: '0',
+        borderRadius: '0',
+        transform: 'translate(0px, 0px)',
+        background: 'transparent',
+        border: '3px solid transparent',
+        zIndex: !isOnConnect ? -1 : 1,
+      }),
+      [isOnConnect]
+    );
 
-  const [userInput, setUserInput] = useState<string | undefined>('input view');
+    // 优化点 6: 使用 useCallback 缓存所有事件处理函数和内部函数
+    const handleMouseEnter = useCallback(() => {
+      setNodeState(prev => ({ ...prev, isHovered: true }));
+      activateNode(id);
+    }, [activateNode, id]);
 
-  const [showSettingMenu, setShowSettingMenu] = useState(false);
+    const handleMouseLeave = useCallback(() => {
+      setNodeState(prev => ({ ...prev, isHovered: false }));
+    }, []);
 
-  useEffect(() => {
-    console.log('jsonndoe isloading', isLoading);
-  }, []);
+    const handleTargetHandleMouseEnter = useCallback(() => {
+      setNodeState(prev => ({ ...prev, isTargetHandleTouched: true }));
+    }, []);
 
-  // 添加点击外部关闭菜单的逻辑
-  useEffect(() => {
-    if (!showSettingMenu) return;
+    const handleTargetHandleMouseLeave = useCallback(() => {
+      setNodeState(prev => ({ ...prev, isTargetHandleTouched: false }));
+    }, []);
 
-    const handleClickOutside = (e: MouseEvent) => {
-      // 检查点击是否在菜单外部
-      const targetElement = e.target as HTMLElement;
-      if (
-        showSettingMenu &&
-        !targetElement.closest('.indexing-menu-container')
-      ) {
-        setShowSettingMenu(false);
+    const onFocus = useCallback(() => {
+      preventInactivateNode();
+      componentRef.current?.classList.add('nodrag');
+    }, [preventInactivateNode]);
+
+    const onBlur = useCallback(() => {
+      allowInactivateNodeWhenClickOutside();
+      componentRef.current?.classList.remove('nodrag');
+      if (nodeState.isLocalEdit) {
+        editNodeLabel(id, nodeState.nodeLabel);
+        setNodeState(prev => ({ ...prev, isLocalEdit: false }));
       }
-    };
+    }, [
+      allowInactivateNodeWhenClickOutside,
+      editNodeLabel,
+      id,
+      nodeState.isLocalEdit,
+      nodeState.nodeLabel,
+    ]);
 
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, [showSettingMenu]);
+    const handleLabelChange = useCallback(
+      (e: React.ChangeEvent<HTMLInputElement>) => {
+        setNodeState(prev => ({
+          ...prev,
+          isLocalEdit: true,
+          nodeLabel: e.target.value,
+        }));
+      },
+      []
+    );
 
-  const { handleAddIndex, handleRemoveIndex } = useIndexingUtils();
+    const handleLabelFocus = useCallback(() => {
+      setNodeState(prev => ({ ...prev, isEditing: true }));
+      onFocus();
+    }, [onFocus]);
 
-  // 辅助函数：获取用户ID
-  const getUserId = async (): Promise<string | null> => {
-    if (!userId || userId.trim() === '') {
-      const res = await fetchUserId();
-      if (res) {
-        return res;
-      } else {
-        return null;
+    const handleLabelBlur = useCallback(() => {
+      setNodeState(prev => ({ ...prev, isEditing: false }));
+      if (nodeState.isLocalEdit) {
+        editNodeLabel(id, nodeState.nodeLabel);
+        setNodeState(prev => ({ ...prev, isLocalEdit: false }));
       }
-    }
-    return userId;
-  };
+      onBlur();
+    }, [editNodeLabel, id, nodeState.isLocalEdit, nodeState.nodeLabel, onBlur]);
 
-  // 更新的 onRemoveIndex 方法
-  const onRemoveIndex = async (index: number) => {
-    // 获取当前要删除的项
-    const itemToRemove = indexingList[index];
-
-    // 如果是向量索引类型，先显示"删除中"状态
-    if (itemToRemove && itemToRemove.type === 'vector') {
-      // 创建带有"删除中"状态的索引列表副本
-      const updatedList = [...indexingList];
-      (updatedList[index] as VectorIndexingItem).status = 'deleting';
-
-      // 立即更新UI显示删除中状态
-      setNodes(nodes =>
-        nodes.map(node =>
-          node.id === id
-            ? {
-                ...node,
-                data: {
-                  ...node.data,
-                  indexingList: updatedList,
-                },
-              }
-            : node
-        )
-      );
-    }
-
-    try {
-      // 调用删除函数，添加setVectorIndexingStatus参数
-      const { success, newList } = await handleRemoveIndex(
-        index,
-        indexingList,
-        id,
-        getUserId,
-        setVectorIndexingStatus // 添加缺少的参数
-      );
-
-      // 更新节点状态
-      setNodes(nodes =>
-        nodes.map(node =>
-          node.id === id
-            ? {
-                ...node,
-                data: {
-                  ...node.data,
-                  indexingList: newList,
-                },
-              }
-            : node
-        )
-      );
-    } catch (error) {
-      console.error('Error removing index:', error);
-
-      // 如果是向量索引且发生异常，将状态设为错误并保留该项
-      if (itemToRemove && itemToRemove.type === 'vector') {
-        const errorList = [...indexingList];
-        (errorList[index] as VectorIndexingItem).status = 'error';
-
-        setNodes(nodes =>
-          nodes.map(node =>
+    const updateNodeContent = useCallback(
+      (newValue: string) => {
+        setNodes(prevNodes =>
+          prevNodes.map(node =>
             node.id === id
               ? {
                   ...node,
-                  data: {
-                    ...node.data,
-                    indexingList: errorList,
-                  },
+                  data: { ...node.data, content: newValue },
                 }
               : node
           )
         );
+      },
+      [id, setNodes]
+    );
+
+    const calculateMaxLabelContainerWidth = useCallback(() => {
+      return contentRef.current
+        ? `${contentRef.current.clientWidth - 32}px`
+        : '100%';
+    }, []);
+
+    const renderTagLogo = useCallback(
+      () => (
+        <svg
+          width='24'
+          height='24'
+          viewBox='0 0 24 24'
+          fill='none'
+          xmlns='http://www.w3.org/2000/svg'
+          className='group'
+        >
+          <path
+            d='M8 6.5V5H4V7.5V16.5V19H8V17.5H5.5V6.5H8Z'
+            className='fill-[#B0A4E3] group-active:fill-[#9B7EDB]'
+          />
+          <path
+            d='M16 6.5V5H20V7.5V16.5V19H16V17.5H18.5V6.5H16Z'
+            className='fill-[#B0A4E3] group-active:fill-[#9B7EDB]'
+          />
+          <path
+            d='M9 9H11V11H9V9Z'
+            className='fill-[#B0A4E3] group-active:fill-[#9B7EDB]'
+          />
+          <path
+            d='M9 13H11V15H9V13Z'
+            className='fill-[#B0A4E3] group-active:fill-[#9B7EDB]'
+          />
+          <path
+            d='M13 9H15V11H13V9Z'
+            className='fill-[#B0A4E3] group-active:fill-[#9B7EDB]'
+          />
+          <path
+            d='M13 13H15V15H13V13Z'
+            className='fill-[#B0A4E3] group-active:fill-[#9B7EDB]'
+          />
+        </svg>
+      ),
+      []
+    );
+
+    const { handleAddIndex, handleRemoveIndex } = useIndexingUtils();
+
+    // 辅助函数：获取用户ID
+    const getUserId = useCallback(async (): Promise<string | null> => {
+      if (!userId || userId.trim() === '') {
+        const res = await fetchUserId();
+        return res || null;
       }
-    }
-  };
+      return userId;
+    }, [userId, fetchUserId]);
 
-  // 修改后的 onAddIndex 方法
-  const onAddIndex = async (newItem: IndexingItem) => {
-    // 如果是向量索引类型，先创建一个 processing 状态的临时项
-    if (newItem.type === 'vector') {
-      // 创建临时索引项
-      const temporaryItem: VectorIndexingItem = {
-        ...(newItem as VectorIndexingItem),
-        status: 'processing',
-        chunks: [],
-        index_name: '', // 初始为空，等待后端返回
-        collection_configs: {
-          set_name: '',
-          model: 'text-embedding-ada-002',
-          vdb_type: 'pgvector',
-          user_id: '',
-          collection_name: '',
-        },
-      };
+    // 更新的 onRemoveIndex 方法
+    const onRemoveIndex = useCallback(
+      async (index: number) => {
+        const itemToRemove = indexingList[index];
 
-      // 先将临时项添加到索引列表
-      const tempIndexingList = [...indexingList, temporaryItem];
-
-      // 立即更新 UI 显示处理中状态
-      setNodes(nodes =>
-        nodes.map(node =>
-          node.id === id
-            ? {
-                ...node,
-                data: {
-                  ...node.data,
-                  indexingList: tempIndexingList,
-                },
-              }
-            : node
-        )
-      );
-
-      // 调用 handleAddIndex 处理实际的索引创建
-      const finalIndexingList = await handleAddIndex(
-        id,
-        newItem,
-        indexingList,
-        setVectorIndexingStatus,
-        getUserId
-      );
-
-      // 如果成功获取到更新后的索引列表
-      if (finalIndexingList) {
-        // 找到新添加的索引项(最后一项)并确保其状态被正确更新为'done'
-        const updatedListWithStatus = [...finalIndexingList];
-        const lastIndex = updatedListWithStatus.length - 1;
-
-        if (
-          lastIndex >= 0 &&
-          updatedListWithStatus[lastIndex].type === 'vector'
-        ) {
-          (updatedListWithStatus[lastIndex] as VectorIndexingItem).status =
-            'done';
-        }
-
-        setNodes(nodes =>
-          nodes.map(node =>
-            node.id === id
-              ? {
-                  ...node,
-                  data: {
-                    ...node.data,
-                    indexingList: updatedListWithStatus,
-                  },
-                }
-              : node
-          )
-        );
-      } else {
-        // 如果索引创建失败，更新临时项的状态为错误
-        const errorIndexingList = [...tempIndexingList];
-        const errorItemIndex = errorIndexingList.length - 1;
-
-        if (
-          errorItemIndex >= 0 &&
-          errorIndexingList[errorItemIndex].type === 'vector'
-        ) {
-          (errorIndexingList[errorItemIndex] as VectorIndexingItem).status =
-            'error';
+        if (itemToRemove && itemToRemove.type === 'vector') {
+          const updatedList = [...indexingList];
+          (updatedList[index] as VectorIndexingItem).status = 'deleting';
 
           setNodes(nodes =>
             nodes.map(node =>
@@ -550,487 +352,623 @@ function JsonBlockNode({
                     ...node,
                     data: {
                       ...node.data,
-                      indexingList: errorIndexingList,
+                      indexingList: updatedList,
                     },
                   }
                 : node
             )
           );
         }
+
+        try {
+          const { success, newList } = await handleRemoveIndex(
+            index,
+            indexingList,
+            id,
+            getUserId,
+            (status: VectorIndexingStatus) =>
+              setNodeState(prev => ({
+                ...prev,
+                vectorIndexingStatus: status,
+              }))
+          );
+
+          setNodes(nodes =>
+            nodes.map(node =>
+              node.id === id
+                ? {
+                    ...node,
+                    data: {
+                      ...node.data,
+                      indexingList: newList,
+                    },
+                  }
+                : node
+            )
+          );
+        } catch (error) {
+          console.error('Error removing index:', error);
+
+          if (itemToRemove && itemToRemove.type === 'vector') {
+            const errorList = [...indexingList];
+            (errorList[index] as VectorIndexingItem).status = 'error';
+
+            setNodes(nodes =>
+              nodes.map(node =>
+                node.id === id
+                  ? {
+                      ...node,
+                      data: {
+                        ...node.data,
+                        indexingList: errorList,
+                      },
+                    }
+                  : node
+              )
+            );
+          }
+        }
+      },
+      [indexingList, id, setNodes, handleRemoveIndex, getUserId]
+    );
+
+    // 修改后的 onAddIndex 方法
+    const onAddIndex = useCallback(
+      async (newItem: IndexingItem) => {
+        if (newItem.type === 'vector') {
+          const temporaryItem: VectorIndexingItem = {
+            ...(newItem as VectorIndexingItem),
+            status: 'processing',
+            chunks: [],
+            index_name: '',
+            collection_configs: {
+              set_name: '',
+              model: 'text-embedding-ada-002',
+              vdb_type: 'pgvector',
+              user_id: '',
+              collection_name: '',
+            },
+          };
+
+          const tempIndexingList = [...indexingList, temporaryItem];
+
+          setNodes(nodes =>
+            nodes.map(node =>
+              node.id === id
+                ? {
+                    ...node,
+                    data: {
+                      ...node.data,
+                      indexingList: tempIndexingList,
+                    },
+                  }
+                : node
+            )
+          );
+
+          const finalIndexingList = await handleAddIndex(
+            id,
+            newItem,
+            indexingList,
+            (status: VectorIndexingStatus) =>
+              setNodeState(prev => ({
+                ...prev,
+                vectorIndexingStatus: status,
+              })),
+            getUserId
+          );
+
+          if (finalIndexingList) {
+            const updatedListWithStatus = [...finalIndexingList];
+            const lastIndex = updatedListWithStatus.length - 1;
+
+            if (
+              lastIndex >= 0 &&
+              updatedListWithStatus[lastIndex].type === 'vector'
+            ) {
+              (updatedListWithStatus[lastIndex] as VectorIndexingItem).status =
+                'done';
+            }
+
+            setNodes(nodes =>
+              nodes.map(node =>
+                node.id === id
+                  ? {
+                      ...node,
+                      data: {
+                        ...node.data,
+                        indexingList: updatedListWithStatus,
+                      },
+                    }
+                  : node
+              )
+            );
+          } else {
+            const errorIndexingList = [...tempIndexingList];
+            const errorItemIndex = errorIndexingList.length - 1;
+
+            if (
+              errorItemIndex >= 0 &&
+              errorIndexingList[errorItemIndex].type === 'vector'
+            ) {
+              (errorIndexingList[errorItemIndex] as VectorIndexingItem).status =
+                'error';
+
+              setNodes(nodes =>
+                nodes.map(node =>
+                  node.id === id
+                    ? {
+                        ...node,
+                        data: {
+                          ...node.data,
+                          indexingList: errorIndexingList,
+                        },
+                      }
+                    : node
+                )
+              );
+            }
+          }
+        } else {
+          const newIndexingList = await handleAddIndex(
+            id,
+            newItem,
+            indexingList,
+            (status: VectorIndexingStatus) =>
+              setNodeState(prev => ({
+                ...prev,
+                vectorIndexingStatus: status,
+              })),
+            getUserId
+          );
+
+          if (newIndexingList) {
+            setNodes(nodes =>
+              nodes.map(node =>
+                node.id === id
+                  ? {
+                      ...node,
+                      data: { ...node.data, indexingList: newIndexingList },
+                    }
+                  : node
+              )
+            );
+          }
+        }
+      },
+      [indexingList, id, setNodes, handleAddIndex, getUserId]
+    );
+
+    const toggleRichEditor = useCallback(() => {
+      setNodeState(prev => ({ ...prev, useRichEditor: !prev.useRichEditor }));
+    }, []);
+
+    // 优化点 3: 借鉴 TextBlockNode，延迟初始渲染时的副作用
+    useEffect(() => {
+      const checkAndSetNodeRole = () => {
+        const isAutoDetectInput =
+          sourceNodes.length === 0 && targetNodes.length > 0;
+        const isAutoDetectOutput =
+          targetNodes.length === 0 && sourceNodes.length > 0;
+
+        if (isAutoDetectInput && !isInput) {
+          manageNodeasInput(id);
+        } else if (isAutoDetectOutput && !isOutput) {
+          manageNodeasOutput(id);
+        } else if (
+          !isAutoDetectInput &&
+          !isAutoDetectOutput &&
+          (isInput || isOutput)
+        ) {
+          if (isInput) manageNodeasInput(id);
+          if (isOutput) manageNodeasOutput(id);
+        }
+      };
+
+      if (!hasMountedRef.current) {
+        hasMountedRef.current = true;
+        requestAnimationFrame(checkAndSetNodeRole);
+      } else {
+        checkAndSetNodeRole();
       }
-    } else {
-      // 如果不是向量索引类型，直接处理
-      const newIndexingList = await handleAddIndex(
-        id,
-        newItem,
-        indexingList,
-        setVectorIndexingStatus,
-        getUserId
-      );
+    }, [
+      sourceNodes.length,
+      targetNodes.length,
+      isInput,
+      isOutput,
+      id,
+      manageNodeasInput,
+      manageNodeasOutput,
+    ]);
 
-      if (newIndexingList) {
-        setNodes(nodes =>
-          nodes.map(node =>
-            node.id === id
-              ? {
-                  ...node,
-                  data: { ...node.data, indexingList: newIndexingList },
-                }
-              : node
-          )
-        );
+    // 管理外部点击事件
+    useEffect(() => {
+      const handleClickOutside = (e: MouseEvent) => {
+        if (
+          !labelContainerRef.current?.contains(e.target as HTMLElement) &&
+          !(e.target as HTMLElement).classList.contains('renameButton')
+        ) {
+          setNodeUneditable(id);
+        }
+      };
+      document.addEventListener('mousedown', handleClickOutside);
+      return () =>
+        document.removeEventListener('mousedown', handleClickOutside);
+    }, [id, setNodeUneditable]);
+
+    // 自动聚焦
+    useEffect(() => {
+      if (editable && labelRef.current) {
+        labelRef.current.focus();
+        const length = labelRef.current.value.length;
+        labelRef.current.setSelectionRange(length, length);
       }
-    }
-  };
+    }, [editable]);
 
-  // 添加视图切换状态
-  const [useRichEditor, setUseRichEditor] = useState(false); // 默认使用传统 JSONForm
+    // 同步外部 label 变化
+    useEffect(() => {
+      const currentLabel = getNode(id)?.data?.label;
+      if (
+        currentLabel !== undefined &&
+        currentLabel !== nodeState.nodeLabel &&
+        !nodeState.isLocalEdit
+      ) {
+        const labelString =
+          typeof currentLabel === 'string'
+            ? currentLabel
+            : String(currentLabel);
+        setNodeState(prev => ({ ...prev, nodeLabel: labelString }));
+      }
+    }, [label, id, getNode, nodeState.isLocalEdit, nodeState.nodeLabel]);
 
-  return (
-    <div
-      ref={componentRef}
-      className={`relative w-full h-full min-w-[240px] min-h-[176px] ${isOnGeneratingNewNode ? 'cursor-crosshair' : 'cursor-default'}`}
-      onMouseEnter={() => {
-        setIsHovered(true);
-        activateNode(id); // 鼠标悬浮时激活节点
-      }}
-      onMouseLeave={() => {
-        setIsHovered(false);
-      }}
-    >
-      {/* Add tags for input, output and locked states */}
-      <div className='absolute -top-[28px] h-[24px] left-0 z-10 flex gap-1.5'>
-        {isInput && (
-          <div className='px-2 py-0.5 rounded-[8px] flex items-center gap-1 text-[10px] font-bold bg-[#84EB89] text-black'>
-            <svg
-              width='16'
-              height='16'
-              viewBox='0 0 26 26'
-              fill='none'
-              xmlns='http://www.w3.org/2000/svg'
-            >
-              <rect
-                x='16'
-                y='7'
-                width='3'
-                height='12'
-                rx='1'
-                fill='currentColor'
-              />
-              <path
-                d='M5 13H14'
-                stroke='currentColor'
-                strokeWidth='2.5'
-                strokeLinecap='round'
-              />
-              <path
-                d='M10 9L14 13L10 17'
-                stroke='currentColor'
-                strokeWidth='2.5'
-                strokeLinecap='round'
-                strokeLinejoin='round'
-              />
-            </svg>
-            <span>INPUT</span>
-          </div>
-        )}
+    // 添加点击外部关闭菜单的逻辑
+    useEffect(() => {
+      if (!nodeState.showSettingMenu) return;
 
-        {isOutput && (
-          <div className='px-2 py-0.5 rounded-[8px] flex items-center gap-1 text-[10px] font-bold bg-[#FF9267] text-black'>
-            <svg
-              width='16'
-              height='16'
-              viewBox='0 0 26 26'
-              fill='none'
-              xmlns='http://www.w3.org/2000/svg'
-            >
-              <rect
-                x='7'
-                y='7'
-                width='3'
-                height='12'
-                rx='1'
-                fill='currentColor'
-              />
-              <path
-                d='M12 13H21'
-                stroke='currentColor'
-                strokeWidth='2.5'
-                strokeLinecap='round'
-              />
-              <path
-                d='M17 9L21 13L17 17'
-                stroke='currentColor'
-                strokeWidth='2.5'
-                strokeLinecap='round'
-                strokeLinejoin='round'
-              />
-            </svg>
-            <span>OUTPUT</span>
-          </div>
-        )}
+      const handleClickOutside = (e: MouseEvent) => {
+        const targetElement = e.target as HTMLElement;
+        if (
+          nodeState.showSettingMenu &&
+          !targetElement.closest('.indexing-menu-container')
+        ) {
+          setNodeState(prev => ({ ...prev, showSettingMenu: false }));
+        }
+      };
 
-        {locked && (
-          <div className='px-2 py-0.5 rounded-[8px] flex items-center gap-1 text-[10px] font-bold bg-[#3EDBC9] text-black'>
-            <svg
-              width='16'
-              height='16'
-              viewBox='0 0 16 16'
-              fill='none'
-              xmlns='http://www.w3.org/2000/svg'
-            >
-              <path
-                d='M5 7V5C5 3.34315 6.34315 2 8 2C9.65685 2 11 3.34315 11 5V7'
-                stroke='currentColor'
-                strokeWidth='1.5'
-                strokeLinecap='round'
-              />
-              <rect
-                x='4'
-                y='7'
-                width='8'
-                height='6'
-                rx='1'
-                fill='currentColor'
-              />
-            </svg>
-            <span>LOCKED</span>
-          </div>
-        )}
-      </div>
+      document.addEventListener('mousedown', handleClickOutside);
+      return () => {
+        document.removeEventListener('mousedown', handleClickOutside);
+      };
+    }, [nodeState.showSettingMenu]);
 
+    return (
       <div
-        ref={contentRef}
-        id={id}
-        className={`w-full h-full min-w-[240px] min-h-[176px] border-[1px] rounded-[16px] px-[8px] pt-[8px] pb-[8px] ${getBorderColor()} text-[#CDCDCD] bg-main-black-theme break-words font-plus-jakarta-sans text-base leading-5 font-[400] overflow-hidden json-block-node flex flex-col`}
+        ref={componentRef}
+        className={`relative w-full h-full min-w-[240px] min-h-[176px] ${
+          isOnGeneratingNewNode ? 'cursor-crosshair' : 'cursor-default'
+        }`}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
       >
-        {/* the top bar of a block */}
-        <div
-          ref={labelContainerRef}
-          className={`h-[24px] w-full max-w-full rounded-[4px] flex items-center justify-between mb-2`}
-        >
-          {/* top-left wrapper */}
-          <div
-            className='flex items-center gap-[8px] hover:cursor-grab active:cursor-grabbing group'
-            style={{
-              maxWidth: `calc(${calculateMaxLabelContainerWidth()} - 44px)`,
-            }}
-          >
-            <div className='min-w-[20px] min-h-[24px] flex items-center justify-center group-hover:text-[#CDCDCD] group-active:text-[#9B7EDB]'>
-              {renderTagLogo()}
+        {/* Tags for input, output and locked states */}
+        <div className='absolute -top-[28px] h-[24px] left-0 z-10 flex gap-1.5'>
+          {isInput && (
+            <div className='px-2 py-0.5 rounded-[8px] flex items-center gap-1 text-[10px] font-bold bg-[#84EB89] text-black'>
+              <svg
+                width='16'
+                height='16'
+                viewBox='0 0 26 26'
+                fill='none'
+                xmlns='http://www.w3.org/2000/svg'
+              >
+                <rect
+                  x='16'
+                  y='7'
+                  width='3'
+                  height='12'
+                  rx='1'
+                  fill='currentColor'
+                />
+                <path
+                  d='M5 13H14'
+                  stroke='currentColor'
+                  strokeWidth='2.5'
+                  strokeLinecap='round'
+                />
+                <path
+                  d='M10 9L14 13L10 17'
+                  stroke='currentColor'
+                  strokeWidth='2.5'
+                  strokeLinecap='round'
+                  strokeLinejoin='round'
+                />
+              </svg>
+              <span>INPUT</span>
             </div>
+          )}
 
-            {editable ? (
-              <input
-                ref={labelRef}
-                className={`
+          {isOutput && (
+            <div className='px-2 py-0.5 rounded-[8px] flex items-center gap-1 text-[10px] font-bold bg-[#FF9267] text-black'>
+              <svg
+                width='16'
+                height='16'
+                viewBox='0 0 26 26'
+                fill='none'
+                xmlns='http://www.w3.org/2000/svg'
+              >
+                <rect
+                  x='7'
+                  y='7'
+                  width='3'
+                  height='12'
+                  rx='1'
+                  fill='currentColor'
+                />
+                <path
+                  d='M12 13H21'
+                  stroke='currentColor'
+                  strokeWidth='2.5'
+                  strokeLinecap='round'
+                />
+                <path
+                  d='M17 9L21 13L17 17'
+                  stroke='currentColor'
+                  strokeWidth='2.5'
+                  strokeLinecap='round'
+                  strokeLinejoin='round'
+                />
+              </svg>
+              <span>OUTPUT</span>
+            </div>
+          )}
+
+          {locked && (
+            <div className='px-2 py-0.5 rounded-[8px] flex items-center gap-1 text-[10px] font-bold bg-[#3EDBC9] text-black'>
+              <svg
+                width='16'
+                height='16'
+                viewBox='0 0 16 16'
+                fill='none'
+                xmlns='http://www.w3.org/2000/svg'
+              >
+                <path
+                  d='M5 7V5C5 3.34315 6.34315 2 8 2C9.65685 2 11 3.34315 11 5V7'
+                  stroke='currentColor'
+                  strokeWidth='1.5'
+                  strokeLinecap='round'
+                />
+                <rect
+                  x='4'
+                  y='7'
+                  width='8'
+                  height='6'
+                  rx='1'
+                  fill='currentColor'
+                />
+              </svg>
+              <span>LOCKED</span>
+            </div>
+          )}
+        </div>
+
+        <div ref={contentRef} id={id} className={containerClassName}>
+          {/* the top bar of a block */}
+          <div
+            ref={labelContainerRef}
+            className={`h-[24px] w-full max-w-full rounded-[4px] flex items-center justify-between mb-2`}
+          >
+            {/* top-left wrapper */}
+            <div
+              className='flex items-center gap-[8px] hover:cursor-grab active:cursor-grabbing group'
+              style={{
+                maxWidth: `calc(${calculateMaxLabelContainerWidth()} - 44px)`,
+              }}
+            >
+              <div className='min-w-[20px] min-h-[24px] flex items-center justify-center group-hover:text-[#CDCDCD] group-active:text-[#9B7EDB]'>
+                {renderTagLogo()}
+              </div>
+
+              {editable ? (
+                <input
+                  ref={labelRef}
+                  className={`
                   flex items-center justify-start 
                   font-[600] text-[12px] leading-[18px] 
                   font-plus-jakarta-sans bg-transparent h-[18px] 
                   focus:outline-none truncate text-[#6D7177] group-hover:text-[#CDCDCD] group-active:text-[#9B7EDB]
                   w-full
                 `}
-                value={nodeLabel}
-                onChange={e => {
-                  setIsLocalEdit(true);
-                  setNodeLabel(e.target.value);
-                }}
-                onFocus={() => {
-                  setIsEditing(true);
-                  onFocus();
-                }}
-                onBlur={() => {
-                  setIsEditing(false);
-                  if (isLocalEdit) {
-                    editNodeLabel(id, nodeLabel);
-                    setIsLocalEdit(false);
-                  }
-                  onBlur();
-                }}
-              />
-            ) : (
-              <span
-                className={`
+                  value={nodeState.nodeLabel}
+                  onChange={handleLabelChange}
+                  onFocus={handleLabelFocus}
+                  onBlur={handleLabelBlur}
+                />
+              ) : (
+                <span
+                  className={`
                   flex items-center justify-start 
                   font-[600] text-[12px] leading-[18px] 
                   font-plus-jakarta-sans truncate text-[#6D7177] group-hover:text-[#CDCDCD] group-active:text-[#9B7EDB]
                 `}
-              >
-                {nodeLabel}
-              </span>
-            )}
-          </div>
+                >
+                  {nodeState.nodeLabel}
+                </span>
+              )}
+            </div>
 
-          {/* top-right toolbar */}
-          <div className='min-w-[60px] min-h-[24px] z-[100000] flex items-center justify-end gap-[8px]'>
-            {/* NodeToolBar */}
-            <NodeSettingsController nodeid={id} />
+            {/* top-right toolbar */}
+            <div className='min-w-[60px] min-h-[24px] z-[100000] flex items-center justify-end gap-[8px]'>
+              <NodeSettingsController nodeid={id} />
 
-            {/* 使用新的 NodeViewToggleButton 组件 */}
-            <NodeViewToggleButton
-              useRichEditor={useRichEditor}
-              onToggle={() => setUseRichEditor(!useRichEditor)}
-            /> 
-
-            {/* 使用 NodeIndexingButton 组件，传递所需的索引操作函数 */}
-            <NodeIndexingButton
-              nodeid={id}
-              indexingList={indexingList}
-              onAddIndex={onAddIndex}
-              onRemoveIndex={onRemoveIndex}
-            />
-
-            {/* 使用新的 NodeLoopButton 组件 */}
-            <NodeLoopButton nodeid={id} />
-          </div>
-        </div>
-
-        {/* JSON Editor - 根据状态切换不同的编辑器 */}
-        {isLoading ? (
-          <SkeletonLoadingIcon />
-        ) : (
-          <div
-            className={`flex-1 min-h-0 overflow-hidden`}
-            style={{
-              background: 'transparent',
-              boxShadow: 'none',
-            }}
-          >
-            {useRichEditor ? (
-              <RichJSONForm
-                preventParentDrag={onFocus}
-                allowParentDrag={onBlur}
-                placeholder='Create your JSON structure...'
-                value={content || ''}
-                onChange={updateNodeContent}
-                widthStyle={0} // 0 表示使用 100%
-                heightStyle={0} // 0 表示使用 100%
-                readonly={locked}
+              <NodeViewToggleButton
+                useRichEditor={nodeState.useRichEditor}
+                onToggle={toggleRichEditor}
               />
-            ) : (
-              <JSONForm
-                preventParentDrag={onFocus}
-                allowParentDrag={onBlur}
-                placeholder='{"key": "value"}'
-                value={content || ''}
-                onChange={updateNodeContent}
-                widthStyle={0} // 0 表示使用 100%
-                heightStyle={0} // 0 表示使用 100%
-                readonly={locked}
-              />
-            )}
-          </div>
-        )}
 
-        <NodeResizeControl
-          minWidth={240}
-          minHeight={176}
-          style={{
-            position: 'absolute',
-            right: '0px',
-            bottom: '0px',
-            cursor: 'se-resize',
-            background: 'transparent',
-            border: 'none',
-          }}
-        >
-          <div
+              <NodeIndexingButton
+                nodeid={id}
+                indexingList={indexingList}
+                onAddIndex={onAddIndex}
+                onRemoveIndex={onRemoveIndex}
+              />
+
+              <NodeLoopButton nodeid={id} />
+            </div>
+          </div>
+
+          {/* JSON Editor - 根据状态切换不同的编辑器 */}
+          {isLoading ? (
+            <SkeletonLoadingIcon />
+          ) : (
+            <div
+              className={`flex-1 min-h-0 overflow-hidden`}
+              style={{
+                background: 'transparent',
+                boxShadow: 'none',
+              }}
+            >
+              {nodeState.useRichEditor ? (
+                <RichJSONForm
+                  preventParentDrag={onFocus}
+                  allowParentDrag={onBlur}
+                  placeholder='Create your JSON structure...'
+                  value={content || ''}
+                  onChange={updateNodeContent}
+                  widthStyle={0}
+                  heightStyle={0}
+                  readonly={locked}
+                />
+              ) : (
+                <JSONForm
+                  preventParentDrag={onFocus}
+                  allowParentDrag={onBlur}
+                  placeholder='{"key": "value"}'
+                  value={content || ''}
+                  onChange={updateNodeContent}
+                  widthStyle={0}
+                  heightStyle={0}
+                  readonly={locked}
+                />
+              )}
+            </div>
+          )}
+
+          <NodeResizeControl
+            minWidth={240}
+            minHeight={176}
             style={{
               position: 'absolute',
-              visibility: `${activatedNode?.id === id ? 'visible' : 'hidden'}`,
               right: '0px',
               bottom: '0px',
-              display: 'flex',
-              justifyContent: 'center',
-              alignItems: 'center',
-              backgroundColor: 'transparent',
-              zIndex: '200000',
-              width: '26px',
-              height: '26px',
+              cursor: 'se-resize',
+              background: 'transparent',
+              border: 'none',
             }}
           >
-            <svg
-              width='26'
-              height='26'
-              viewBox='0 0 26 26'
-              fill='none'
-              xmlns='http://www.w3.org/2000/svg'
-              className='group active:group-[]:fill-[#9B7EDB]'
+            <div
+              style={{
+                position: 'absolute',
+                visibility: `${
+                  activatedNode?.id === id ? 'visible' : 'hidden'
+                }`,
+                right: '0px',
+                bottom: '0px',
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+                backgroundColor: 'transparent',
+                zIndex: '200000',
+                width: '26px',
+                height: '26px',
+              }}
             >
-              <path
-                d='M10 5.99998H12V7.99998H10V5.99998Z'
-                className='fill-[#6D7177] group-hover:fill-[#CDCDCD] group-active:fill-[#9B7EDB]'
-              />
-              <path
-                d='M10 2H12V4H10V2Z'
-                className='fill-[#6D7177] group-hover:fill-[#CDCDCD] group-active:fill-[#9B7EDB]'
-              />
-              <path
-                d='M6 5.99998H8V7.99998H6V5.99998Z'
-                className='fill-[#6D7177] group-hover:fill-[#CDCDCD] group-active:fill-[#9B7EDB]'
-              />
-              <path
-                d='M6 10H8V12H6V10Z'
-                className='fill-[#6D7177] group-hover:fill-[#CDCDCD] group-active:fill-[#9B7EDB]'
-              />
-              <path
-                d='M2 10H4V12H2V10Z'
-                className='fill-[#6D7177] group-hover:fill-[#CDCDCD] group-active:fill-[#9B7EDB]'
-              />
-              <path
-                d='M10 10H12V12H10V10Z'
-                className='fill-[#6D7177] group-hover:fill-[#CDCDCD] group-active:fill-[#9B7EDB]'
-              />
-            </svg>
-          </div>
-        </NodeResizeControl>
+              <svg
+                width='26'
+                height='26'
+                viewBox='0 0 26 26'
+                fill='none'
+                xmlns='http://www.w3.org/2000/svg'
+                className='group active:group-[]:fill-[#9B7EDB]'
+              >
+                <path
+                  d='M10 5.99998H12V7.99998H10V5.99998Z'
+                  className='fill-[#6D7177] group-hover:fill-[#CDCDCD] group-active:fill-[#9B7EDB]'
+                />
+                <path
+                  d='M10 2H12V4H10V2Z'
+                  className='fill-[#6D7177] group-hover:fill-[#CDCDCD] group-active:fill-[#9B7EDB]'
+                />
+                <path
+                  d='M6 5.99998H8V7.99998H6V5.99998Z'
+                  className='fill-[#6D7177] group-hover:fill-[#CDCDCD] group-active:fill-[#9B7EDB]'
+                />
+                <path
+                  d='M6 10H8V12H6V10Z'
+                  className='fill-[#6D7177] group-hover:fill-[#CDCDCD] group-active:fill-[#9B7EDB]'
+                />
+                <path
+                  d='M2 10H4V12H2V10Z'
+                  className='fill-[#6D7177] group-hover:fill-[#CDCDCD] group-active:fill-[#9B7EDB]'
+                />
+                <path
+                  d='M10 10H12V12H10V10Z'
+                  className='fill-[#6D7177] group-hover:fill-[#CDCDCD] group-active:fill-[#9B7EDB]'
+                />
+              </svg>
+            </div>
+          </NodeResizeControl>
 
-        <WhiteBallHandle
-          id={`${id}-a`}
-          type='source'
-          sourceNodeId={id}
-          isConnectable={isConnectable}
-          position={Position.Top}
-        />
-        <WhiteBallHandle
-          id={`${id}-b`}
-          type='source'
-          sourceNodeId={id}
-          isConnectable={isConnectable}
-          position={Position.Right}
-        />
-        <WhiteBallHandle
-          id={`${id}-c`}
-          type='source'
-          sourceNodeId={id}
-          isConnectable={isConnectable}
-          position={Position.Bottom}
-        />
-        <WhiteBallHandle
-          id={`${id}-d`}
-          type='source'
-          sourceNodeId={id}
-          isConnectable={isConnectable}
-          position={Position.Left}
-        />
-        <Handle
-          id={`${id}-a`}
-          type='target'
-          position={Position.Top}
-          style={{
-            position: 'absolute',
-            width: 'calc(100%)',
-            height: 'calc(100%)',
-            top: '0',
-            left: '0',
-            borderRadius: '0',
-            transform: 'translate(0px, 0px)',
-            background: 'transparent',
-            // border: isActivated ? "1px solid #4599DF" : "none",
-            border: '3px solid transparent',
-            zIndex: !isOnConnect ? '-1' : '1',
-            // maybe consider about using stored isActivated
-          }}
-          isConnectable={isConnectable}
-          onMouseEnter={() => setIsTargetHandleTouched(true)}
-          onMouseLeave={() => setIsTargetHandleTouched(false)}
-        />
-        <Handle
-          id={`${id}-b`}
-          type='target'
-          position={Position.Right}
-          style={{
-            position: 'absolute',
-            width: 'calc(100%)',
-            height: 'calc(100%)',
-            top: '0',
-            left: '0',
-            borderRadius: '0',
-            transform: 'translate(0px, 0px)',
-            background: 'transparent',
-            // border: isActivated ? "1px solid #4599DF" : "none",
-            border: '3px solid transparent',
-            zIndex: !isOnConnect ? '-1' : '1',
-            // maybe consider about using stored isActivated
-          }}
-          isConnectable={isConnectable}
-          onMouseEnter={() => setIsTargetHandleTouched(true)}
-          onMouseLeave={() => setIsTargetHandleTouched(false)}
-        />
-        <Handle
-          id={`${id}-c`}
-          type='target'
-          position={Position.Bottom}
-          style={{
-            position: 'absolute',
-            width: 'calc(100%)',
-            height: 'calc(100%)',
-            top: '0',
-            left: '0',
-            borderRadius: '0',
-            transform: 'translate(0px, 0px)',
-            background: 'transparent',
-            // border: isActivated ? "1px solid #4599DF" : "none",
-            border: '3px solid transparent',
-            zIndex: !isOnConnect ? '-1' : '1',
-            // maybe consider about using stored isActivated
-          }}
-          isConnectable={isConnectable}
-          onMouseEnter={() => setIsTargetHandleTouched(true)}
-          onMouseLeave={() => setIsTargetHandleTouched(false)}
-        />
-        <Handle
-          id={`${id}-d`}
-          type='target'
-          position={Position.Left}
-          style={{
-            position: 'absolute',
-            width: 'calc(100%)',
-            height: 'calc(100%)',
-            top: '0',
-            left: '0',
-            borderRadius: '0',
-            transform: 'translate(0px, 0px)',
-            background: 'transparent',
-            // border: isActivated ? "1px solid #4599DF" : "none",
-            border: '3px solid transparent',
-            zIndex: !isOnConnect ? '-1' : '1',
-            // maybe consider about using stored isActivated
-          }}
-          isConnectable={isConnectable}
-          onMouseEnter={() => setIsTargetHandleTouched(true)}
-          onMouseLeave={() => setIsTargetHandleTouched(false)}
-        />
+          {/* Source Handles */}
+          <WhiteBallHandle
+            id={`${id}-a`}
+            type='source'
+            sourceNodeId={id}
+            isConnectable={isConnectable}
+            position={Position.Top}
+          />
+          <WhiteBallHandle
+            id={`${id}-b`}
+            type='source'
+            sourceNodeId={id}
+            isConnectable={isConnectable}
+            position={Position.Right}
+          />
+          <WhiteBallHandle
+            id={`${id}-c`}
+            type='source'
+            sourceNodeId={id}
+            isConnectable={isConnectable}
+            position={Position.Bottom}
+          />
+          <WhiteBallHandle
+            id={`${id}-d`}
+            type='source'
+            sourceNodeId={id}
+            isConnectable={isConnectable}
+            position={Position.Left}
+          />
+
+          {/* Target Handles */}
+          {[Position.Top, Position.Right, Position.Bottom, Position.Left].map(
+            (pos, index) => (
+              <Handle
+                key={pos}
+                id={`${id}-${String.fromCharCode(97 + index)}`}
+                type='target'
+                position={pos}
+                style={handleStyle}
+                isConnectable={isConnectable}
+                onMouseEnter={handleTargetHandleMouseEnter}
+                onMouseLeave={handleTargetHandleMouseLeave}
+              />
+            )
+          )}
+        </div>
       </div>
+    );
+  }
+);
 
-      {/* Add the source/target nodes display at the bottom of the component */}
-
-      {/*
-      <div className="absolute left-0 -bottom-[2px] transform translate-y-full w-full flex gap-2 z-10">
-        {sourceNodes.length > 0 && (
-          <div className="w-[48%] bg-[#101010] rounded-lg border border-[#333333] p-1.5 shadow-lg">
-            <div className="text-xs text-[#A4C8F0] font-semibold pb-1 mb-1">
-              Source Nodes
-            </div>
-            <div className="flex flex-wrap gap-1.5">
-              {displaySourceNodeLabels()}
-            </div>
-          </div>
-        )}
-        {targetNodes.length > 0 && (
-          <div className="w-[48%] ml-auto bg-[#101010] rounded-lg border border-[#333333] p-1.5 shadow-lg">
-            <div className="text-xs text-[#A4C8F0] font-semibold pb-1 mb-1">
-              Target Nodes
-            </div>
-            <div className="flex flex-wrap gap-1.5">
-              {displayTargetNodeLabels()}
-            </div>
-          </div>
-        )}
-      </div>
-      */}
-    </div>
-  );
-}
+JsonBlockNode.displayName = 'JsonBlockNode';
 
 export default JsonBlockNode;

--- a/PuppyFlow/app/components/workflow/edgesNode/edgeNodesNew/ChunkingByCharacter.tsx
+++ b/PuppyFlow/app/components/workflow/edgesNode/edgeNodesNew/ChunkingByCharacter.tsx
@@ -1,5 +1,12 @@
 import { Handle, Position, NodeProps, Node } from '@xyflow/react';
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import React, {
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+  useMemo,
+  memo,
+} from 'react';
 import { useReactFlow } from '@xyflow/react';
 import { useNodesPerFlowContext } from '../../../states/NodesPerFlowContext';
 import InputOutputDisplay from './components/InputOutputDisplay';
@@ -18,6 +25,7 @@ export type ChunkingConfigNodeData = {
   subMenuType: string | null;
   sub_chunking_mode: 'size' | 'tokenizer' | undefined;
   content: string | null;
+  delimiters?: string[];
   extra_configs: {
     model: 'gpt-4o' | 'gpt-4-turbo' | 'gpt-4o-mini' | undefined;
     chunk_size: number | undefined;
@@ -28,606 +36,663 @@ export type ChunkingConfigNodeData = {
 
 type ChunkingByCharacterProps = NodeProps<Node<ChunkingConfigNodeData>>;
 
-// 添加 commonDelimiters 常量定义（放在组件外部）
-const commonDelimiters = [
-  { label: 'Comma (,)', value: ',' },
-  { label: 'Semicolon (;)', value: ';' },
-  { label: 'Enter (\\n)', value: '\n' },
-  { label: 'Tab (\\t)', value: '\t' },
-  { label: 'Space', value: ' ' },
-  { label: 'Period (.)', value: '.' },
-  { label: 'Pipe (|)', value: '|' },
-  { label: 'Dash (-)', value: '-' },
-];
+const ChunkingByCharacter: React.FC<ChunkingByCharacterProps> = memo(
+  ({ data: { subMenuType }, isConnectable, id }) => {
+    const {
+      isOnConnect,
+      activatedEdge,
+      isOnGeneratingNewNode,
+      clearEdgeActivation,
+      activateEdge,
+      clearAll,
+    } = useNodesPerFlowContext();
+    const [isTargetHandleTouched, setIsTargetHandleTouched] = useState(false);
+    const { getNode, getInternalNode, setNodes, setEdges } = useReactFlow();
+    const [isMenuOpen, setIsMenuOpen] = useState(false);
+    const [isHovered, setIsHovered] = useState(false);
+    const [isRunButtonHovered, setIsRunButtonHovered] = useState(false);
+    const [isLoading, setIsLoading] = useState(false);
+    const menuRef = useRef<HTMLUListElement>(null);
+    const newDelimiterRef = useRef<HTMLInputElement>(null);
+    const { getSourceNodeIdWithLabel, getTargetNodeIdWithLabel } =
+      useGetSourceTarget();
 
-function ChunkingByCharacter({
-  data: { subMenuType },
-  isConnectable,
-  id,
-}: ChunkingByCharacterProps) {
-  const {
-    isOnConnect,
-    activatedEdge,
-    isOnGeneratingNewNode,
-    clearEdgeActivation,
-    activateEdge,
-    clearAll,
-  } = useNodesPerFlowContext();
-  const [isTargetHandleTouched, setIsTargetHandleTouched] = useState(false);
-  const { getNode, getInternalNode, setNodes, setEdges } = useReactFlow();
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const [isHovered, setIsHovered] = useState(false);
-  const [isRunButtonHovered, setIsRunButtonHovered] = useState(false);
-  const [isLoading, setIsLoading] = useState(false);
-  const menuRef = useRef<HTMLUListElement>(null);
-  const newDelimiterRef = useRef<HTMLInputElement>(null);
-  const { getSourceNodeIdWithLabel, getTargetNodeIdWithLabel } =
-    useGetSourceTarget();
+    // 获取所有需要的依赖
+    const { streamResult, reportError, resetLoadingUI } =
+      useJsonConstructUtils();
+    const { getAuthHeaders } = useAppSettings();
 
-  // 获取所有需要的依赖
-  const { streamResult, reportError, resetLoadingUI } = useJsonConstructUtils();
-  const { getAuthHeaders } = useAppSettings();
+    // 使用 useRef 跟踪是否已挂载
+    const hasMountedRef = useRef(false);
 
-  // 使用 delimiters 状态
-  const [delimiters, setDelimiters] = useState<string[]>(() => {
-    // 尝试从不同的可能位置读取 delimiters 数据
-    const nodeData = getNode(id)?.data;
-    if (nodeData?.delimiters && Array.isArray(nodeData.delimiters)) {
-      return nodeData.delimiters;
-    }
-    if (nodeData?.content) {
-      try {
-        const parsedContent =
-          typeof nodeData.content === 'string'
-            ? JSON.parse(nodeData.content)
-            : nodeData.content;
-        if (Array.isArray(parsedContent)) {
-          return parsedContent;
-        }
-      } catch (e) {
-        console.warn('Failed to parse delimiters:', e);
+    // 添加 commonDelimiters 常量定义 - 使用 useMemo 缓存
+    const commonDelimiters = useMemo(
+      () => [
+        { label: 'Comma (,)', value: ',' },
+        { label: 'Semicolon (;)', value: ';' },
+        { label: 'Enter (\\n)', value: '\n' },
+        { label: 'Tab (\\t)', value: '\t' },
+        { label: 'Space', value: ' ' },
+        { label: 'Period (.)', value: '.' },
+        { label: 'Pipe (|)', value: '|' },
+        { label: 'Dash (-)', value: '-' },
+      ],
+      []
+    );
+
+    // 优化 delimiters 状态初始化 - 使用函数形式避免重复计算
+    const [delimiters, setDelimiters] = useState<string[]>(() => {
+      // 尝试从不同的可能位置读取 delimiters 数据
+      const nodeData = getNode(id)?.data;
+      if (nodeData?.delimiters && Array.isArray(nodeData.delimiters)) {
+        return nodeData.delimiters;
       }
-    }
-    return [',', ';', '\n']; // 默认值
-  });
-
-  // 每当 delimiters 变化时，更新节点数据
-  useEffect(() => {
-    const node = getNode(id);
-    if (node) {
-      // 更新节点数据，将 delimiters 保存到 node.data 对象中
-      setNodes(nodes =>
-        nodes.map(n => {
-          if (n.id === id) {
-            return {
-              ...n,
-              data: {
-                ...n.data,
-                delimiters: delimiters, // 保存 delimiters 数组
-                content: JSON.stringify(delimiters), // 为了向后兼容也保存在 content 中
-              },
-            };
+      if (nodeData?.content) {
+        try {
+          const parsedContent =
+            typeof nodeData.content === 'string'
+              ? JSON.parse(nodeData.content)
+              : nodeData.content;
+          if (Array.isArray(parsedContent)) {
+            return parsedContent;
           }
-          return n;
-        })
-      );
-    }
-  }, [delimiters, id, getNode, setNodes]);
+        } catch (e) {
+          console.warn('Failed to parse delimiters:', e);
+        }
+      }
+      return [',', ';', '\n']; // 默认值
+    });
 
-  // 创建执行上下文
-  const createExecutionContext = useCallback(
-    (): RunSingleEdgeNodeContext => ({
-      getNode,
-      setNodes,
-      setEdges,
-      getSourceNodeIdWithLabel,
-      getTargetNodeIdWithLabel,
+    // 状态管理
+    const [showDelimiterInput, setShowDelimiterInput] = useState(false);
+
+    // 创建执行上下文 - 使用 useCallback 缓存
+    const createExecutionContext = useCallback(
+      (): RunSingleEdgeNodeContext => ({
+        getNode,
+        setNodes,
+        setEdges,
+        getSourceNodeIdWithLabel,
+        getTargetNodeIdWithLabel,
+        clearAll,
+        streamResult,
+        reportError,
+        resetLoadingUI,
+        getAuthHeaders,
+      }),
+      [
+        getNode,
+        setNodes,
+        setEdges,
+        getSourceNodeIdWithLabel,
+        getTargetNodeIdWithLabel,
+        clearAll,
+        streamResult,
+        reportError,
+        resetLoadingUI,
+        getAuthHeaders,
+      ]
+    );
+
+    // 使用执行函数的 handleDataSubmit - 使用 useCallback 缓存
+    const handleDataSubmit = useCallback(async () => {
+      if (isLoading) return;
+
+      setIsLoading(true);
+      try {
+        const context = createExecutionContext();
+        await runSingleEdgeNode({
+          parentId: id,
+          targetNodeType: 'structured',
+          context,
+          // 可以选择不提供 constructJsonData，使用默认实现
+        });
+      } catch (error) {
+        console.error('执行失败:', error);
+      } finally {
+        setIsLoading(false);
+      }
+    }, [id, isLoading, createExecutionContext]);
+
+    // 添加新的分隔符 - 使用 useCallback 缓存
+    const addDelimiter = useCallback(
+      (value: string) => {
+        if (value && !delimiters.includes(value)) {
+          setDelimiters(prev => [...prev, value]);
+        }
+      },
+      [delimiters]
+    );
+
+    // 删除分隔符 - 使用 useCallback 缓存
+    const removeDelimiter = useCallback((index: number) => {
+      setDelimiters(prev => prev.filter((_, i) => i !== index));
+    }, []);
+
+    // 状态同步逻辑 - 使用 requestAnimationFrame 延迟执行，避免在节点创建时干扰
+    useEffect(() => {
+      if (!isOnGeneratingNewNode && hasMountedRef.current) {
+        requestAnimationFrame(() => {
+          const node = getNode(id);
+          if (node) {
+            // 更新节点数据，将 delimiters 保存到 node.data 对象中
+            setNodes(prevNodes =>
+              prevNodes.map(n => {
+                if (n.id === id) {
+                  return {
+                    ...n,
+                    data: {
+                      ...n.data,
+                      delimiters: delimiters, // 保存 delimiters 数组
+                      content: JSON.stringify(delimiters), // 为了向后兼容也保存在 content 中
+                    },
+                  };
+                }
+                return n;
+              })
+            );
+          }
+        });
+      }
+    }, [delimiters, isOnGeneratingNewNode, id, getNode, setNodes]);
+
+    // 组件初始化
+    useEffect(() => {
+      hasMountedRef.current = true;
+    }, []);
+
+    // 当显示输入框时，自动聚焦
+    useEffect(() => {
+      if (showDelimiterInput && newDelimiterRef.current) {
+        newDelimiterRef.current.focus();
+      }
+    }, [showDelimiterInput]);
+
+    // 初始化和清理 - 优化时序
+    useEffect(() => {
+      console.log(getInternalNode(id));
+
+      if (hasMountedRef.current && !isOnGeneratingNewNode) {
+        clearAll();
+        activateEdge(id);
+      }
+
+      return () => {
+        if (activatedEdge === id) {
+          clearEdgeActivation();
+        }
+      };
+    }, [
+      isOnGeneratingNewNode,
+      id,
       clearAll,
-      streamResult,
-      reportError,
-      resetLoadingUI,
-      getAuthHeaders,
-    }),
-    [
-      getNode,
-      setNodes,
-      setEdges,
-      getSourceNodeIdWithLabel,
-      getTargetNodeIdWithLabel,
-      clearAll,
-      streamResult,
-      reportError,
-      resetLoadingUI,
-      getAuthHeaders,
-    ]
-  );
+      activateEdge,
+      activatedEdge,
+      clearEdgeActivation,
+      getInternalNode,
+    ]);
 
-  // 使用执行函数的 handleDataSubmit
-  const handleDataSubmit = useCallback(async () => {
-    if (isLoading) return;
+    // 在组件顶部定义共享样式 - 使用 useMemo 缓存
+    const handleStyle = useMemo(
+      () => ({
+        position: 'absolute' as const,
+        width: 'calc(100%)',
+        height: 'calc(100%)',
+        top: '0',
+        left: '0',
+        borderRadius: '0',
+        transform: 'translate(0px, 0px)',
+        background: 'transparent',
+        border: '3px solid transparent',
+        zIndex: !isOnConnect ? '-1' : '1',
+      }),
+      [isOnConnect]
+    );
 
-    setIsLoading(true);
-    try {
-      const context = createExecutionContext();
-      await runSingleEdgeNode({
-        parentId: id,
-        targetNodeType: 'structured',
-        context,
-        // 可以选择不提供 constructJsonData，使用默认实现
-      });
-    } catch (error) {
-      console.error('执行失败:', error);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [id, isLoading, createExecutionContext]);
+    // 处理自定义分隔符输入 - 使用 useCallback 缓存
+    const handleCustomDelimiterInput = useCallback(
+      (e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === 'Enter' && e.currentTarget.value) {
+          addDelimiter(e.currentTarget.value);
+          e.currentTarget.value = '';
+          setShowDelimiterInput(false);
+        } else if (e.key === 'Escape') {
+          setShowDelimiterInput(false);
+        }
+      },
+      [addDelimiter]
+    );
 
-  // 添加新的分隔符
-  const addDelimiter = (value: string) => {
-    if (value && !delimiters.includes(value)) {
-      setDelimiters([...delimiters, value]);
-    }
-  };
+    // 特殊字符的显示映射 - 使用 useCallback 缓存
+    const delimiterDisplay = useCallback((delimiter: string) => {
+      switch (delimiter) {
+        case '\n':
+          return (
+            <span className='flex items-center gap-1'>
+              <svg
+                width='14'
+                height='14'
+                viewBox='0 0 14 14'
+                fill='none'
+                xmlns='http://www.w3.org/2000/svg'
+              >
+                <path
+                  d='M6 5L3 8L6 11'
+                  stroke='currentColor'
+                  strokeWidth='0.583333'
+                />
+                <path
+                  d='M3 8H11V3'
+                  stroke='currentColor'
+                  strokeWidth='0.583333'
+                />
+              </svg>
+              <span className='text-[10px]'>Enter</span>
+            </span>
+          );
+        case '\t':
+          return 'Tab';
+        case ' ':
+          return 'Space';
+        default:
+          return delimiter;
+      }
+    }, []);
 
-  // 删除分隔符
-  const removeDelimiter = (index: number) => {
-    setDelimiters(delimiters.filter((_, i) => i !== index));
-  };
+    // 辅助函数 - 使用 useCallback 缓存
+    const onFocus = useCallback(() => {
+      const curRef = menuRef.current;
+      if (curRef && !curRef.classList.contains('nodrag')) {
+        curRef.classList.add('nodrag');
+      }
+    }, []);
 
-  // 状态管理
-  const [showDelimiterInput, setShowDelimiterInput] = useState(false);
+    const onBlur = useCallback(() => {
+      const curRef = menuRef.current;
+      if (curRef) {
+        curRef.classList.remove('nodrag');
+      }
+    }, []);
 
-  // 当显示输入框时，自动聚焦
-  useEffect(() => {
-    if (showDelimiterInput && newDelimiterRef.current) {
-      newDelimiterRef.current.focus();
-    }
-  }, [showDelimiterInput]);
+    // UI 交互函数 - 使用 useCallback 缓存
+    const onClickButton = useCallback(() => {
+      setIsMenuOpen(!isMenuOpen);
 
-  // 初始化和清理
-  useEffect(() => {
-    console.log(getInternalNode(id));
-
-    if (!isOnGeneratingNewNode) {
-      clearAll();
-      activateEdge(id);
-    }
-
-    return () => {
+      if (isOnGeneratingNewNode) return;
       if (activatedEdge === id) {
         clearEdgeActivation();
+      } else {
+        clearAll();
+        activateEdge(id);
       }
-    };
-  }, []);
+    }, [
+      isMenuOpen,
+      isOnGeneratingNewNode,
+      activatedEdge,
+      id,
+      clearEdgeActivation,
+      clearAll,
+      activateEdge,
+    ]);
 
-  // 在组件顶部定义共享样式
-  const handleStyle = {
-    position: 'absolute' as const,
-    width: 'calc(100%)',
-    height: 'calc(100%)',
-    top: '0',
-    left: '0',
-    borderRadius: '0',
-    transform: 'translate(0px, 0px)',
-    background: 'transparent',
-    border: '3px solid transparent',
-    zIndex: !isOnConnect ? '-1' : '1',
-  };
+    // 添加停止函数 - 使用 useCallback 缓存
+    const onStopExecution = useCallback(() => {
+      console.log('Stop execution');
+      setIsLoading(false);
+    }, []);
 
-  // 处理自定义分隔符输入
-  const handleCustomDelimiterInput = (
-    e: React.KeyboardEvent<HTMLInputElement>
-  ) => {
-    if (e.key === 'Enter' && e.currentTarget.value) {
-      addDelimiter(e.currentTarget.value);
-      e.currentTarget.value = '';
-    } else if (e.key === 'Escape') {
-      setShowDelimiterInput(false);
-    }
-  };
+    // 缓存按钮样式 - 使用 useMemo 缓存
+    const runButtonStyle = useMemo(
+      () => ({
+        backgroundColor: isRunButtonHovered
+          ? isLoading
+            ? '#FFA73D'
+            : '#39BC66'
+          : '#181818',
+        borderColor: isRunButtonHovered
+          ? isLoading
+            ? '#FFA73D'
+            : '#39BC66'
+          : UI_COLORS.EDGENODE_BORDER_GREY,
+        color: isRunButtonHovered ? '#000' : UI_COLORS.EDGENODE_BORDER_GREY,
+      }),
+      [isRunButtonHovered, isLoading]
+    );
 
-  // 特殊字符的显示映射
-  const delimiterDisplay = (delimiter: string) => {
-    switch (delimiter) {
-      case '\n':
-        return (
-          <span className='flex items-center gap-1'>
-            <svg
-              width='14'
-              height='14'
-              viewBox='0 0 14 14'
-              fill='none'
-              xmlns='http://www.w3.org/2000/svg'
-            >
-              <path
-                d='M6 5L3 8L6 11'
-                stroke='currentColor'
-                strokeWidth='0.583333'
-              />
-              <path
-                d='M3 8H11V3'
-                stroke='currentColor'
-                strokeWidth='0.583333'
-              />
-            </svg>
-            <span className='text-[10px]'>Enter</span>
-          </span>
-        );
-      case '\t':
-        return 'Tab';
-      case ' ':
-        return 'Space';
-      default:
-        return delimiter;
-    }
-  };
-
-  const onFocus = () => {
-    const curRef = menuRef.current;
-    if (curRef && !curRef.classList.contains('nodrag')) {
-      curRef.classList.add('nodrag');
-    }
-  };
-
-  const onBlur = () => {
-    const curRef = menuRef.current;
-    if (curRef) {
-      curRef.classList.remove('nodrag');
-    }
-  };
-
-  return (
-    <div className='p-[3px] w-[80px] h-[48px] relative'>
-      {/* Invisible hover area between node and run button */}
-      <div
-        className='absolute -top-[40px] left-0 w-full h-[40px]'
-        onMouseEnter={() => setIsHovered(true)}
-        onMouseLeave={() => setIsHovered(false)}
-      />
-
-      {/* Run button positioned above the node - show when node or run button is hovered */}
-      <button
-        className={`absolute -top-[40px] left-1/2 transform -translate-x-1/2 w-[57px] h-[24px] rounded-[6px] border-[1px] text-[10px] font-[600] font-plus-jakarta-sans flex flex-row items-center justify-center gap-[4px] transition-all duration-200 ${
-          isHovered || isRunButtonHovered ? 'opacity-100' : 'opacity-0'
-        }`}
-        style={{
-          backgroundColor: isRunButtonHovered ? '#39BC66' : '#181818',
-          borderColor: isRunButtonHovered
-            ? '#39BC66'
-            : UI_COLORS.EDGENODE_BORDER_GREY,
-          color: isRunButtonHovered ? '#000' : UI_COLORS.EDGENODE_BORDER_GREY,
-        }}
-        onClick={handleDataSubmit}
-        disabled={isLoading}
-        onMouseEnter={() => setIsRunButtonHovered(true)}
-        onMouseLeave={() => setIsRunButtonHovered(false)}
-      >
-        <span>
-          {isLoading ? (
-            <svg className='animate-spin h-3 w-3' viewBox='0 0 24 24'>
-              <circle
-                className='opacity-25'
-                cx='12'
-                cy='12'
-                r='10'
-                stroke='currentColor'
-                strokeWidth='4'
-              ></circle>
-              <path
-                className='opacity-75'
-                fill='currentColor'
-                d='M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 714 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z'
-              ></path>
-            </svg>
-          ) : (
-            <svg
-              xmlns='http://www.w3.org/2000/svg'
-              width='6'
-              height='8'
-              viewBox='0 0 8 10'
-              fill='none'
-            >
-              <path d='M8 5L0 10V0L8 5Z' fill='currentColor' />
-            </svg>
-          )}
-        </span>
-        <span>{isLoading ? '' : 'Run'}</span>
-      </button>
-
-      <button
-        onClick={() => setIsMenuOpen(!isMenuOpen)}
-        onMouseEnter={() => setIsHovered(true)}
-        onMouseLeave={() => setIsHovered(false)}
-        className={`w-full h-full flex-shrink-0 rounded-[8px] border-[2px] bg-[#181818] flex items-center justify-center font-plus-jakarta-sans text-[10px] font-[700] edge-node transition-colors gap-[4px]`}
-        style={{
-          borderColor: isHovered
+    const mainButtonStyle = useMemo(
+      () => ({
+        borderColor: isLoading
+          ? '#FFA73D'
+          : isHovered
             ? UI_COLORS.LINE_ACTIVE
             : UI_COLORS.EDGENODE_BORDER_GREY,
-          color: isHovered
+        color: isLoading
+          ? '#FFA73D'
+          : isHovered
             ? UI_COLORS.LINE_ACTIVE
             : UI_COLORS.EDGENODE_BORDER_GREY,
-        }}
-      >
-        {/* Chunking By Character SVG icon */}
-        <svg
-          xmlns='http://www.w3.org/2000/svg'
-          width='10'
-          height='10'
-          viewBox='0 0 24 24'
-          fill='none'
-        >
-          <path
-            d='M13 3H7a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V9l-6-6z'
-            stroke='currentColor'
-            strokeWidth='1.5'
-          />
-          <path d='M13 3v6h6' stroke='currentColor' strokeWidth='1.5' />
-          <path
-            d='M9 14h6'
-            stroke='currentColor'
-            strokeWidth='1.5'
-            strokeLinecap='round'
-          />
-        </svg>
-        <div className='flex flex-col items-center justify-center leading-tight text-[9px]'>
-          <span>Chunk</span>
-          <span>Char</span>
-        </div>
-        {/* Source handles */}
-        <Handle
-          id={`${id}-a`}
-          className='edgeSrcHandle handle-with-icon handle-top'
-          type='source'
-          position={Position.Top}
-        />
-        <Handle
-          id={`${id}-b`}
-          className='edgeSrcHandle handle-with-icon handle-right'
-          type='source'
-          position={Position.Right}
-        />
-        <Handle
-          id={`${id}-c`}
-          className='edgeSrcHandle handle-with-icon handle-bottom'
-          type='source'
-          position={Position.Bottom}
-        />
-        <Handle
-          id={`${id}-d`}
-          className='edgeSrcHandle handle-with-icon handle-left'
-          type='source'
-          position={Position.Left}
+      }),
+      [isLoading, isHovered]
+    );
+
+    return (
+      <div className='p-[3px] w-[80px] h-[48px] relative'>
+        {/* Invisible hover area between node and run button */}
+        <div
+          className='absolute -top-[40px] left-0 w-full h-[40px]'
+          onMouseEnter={() => setIsHovered(true)}
+          onMouseLeave={() => setIsHovered(false)}
         />
 
-        {/* Target handles */}
-        <Handle
-          id={`${id}-a`}
-          type='target'
-          position={Position.Top}
-          style={handleStyle}
-          isConnectable={isConnectable}
-          onMouseEnter={() => setIsTargetHandleTouched(true)}
-          onMouseLeave={() => setIsTargetHandleTouched(false)}
-        />
-        <Handle
-          id={`${id}-b`}
-          type='target'
-          position={Position.Right}
-          style={handleStyle}
-          isConnectable={isConnectable}
-          onMouseEnter={() => setIsTargetHandleTouched(true)}
-          onMouseLeave={() => setIsTargetHandleTouched(false)}
-        />
-        <Handle
-          id={`${id}-c`}
-          type='target'
-          position={Position.Bottom}
-          style={handleStyle}
-          isConnectable={isConnectable}
-          onMouseEnter={() => setIsTargetHandleTouched(true)}
-          onMouseLeave={() => setIsTargetHandleTouched(false)}
-        />
-        <Handle
-          id={`${id}-d`}
-          type='target'
-          position={Position.Left}
-          style={handleStyle}
-          isConnectable={isConnectable}
-          onMouseEnter={() => setIsTargetHandleTouched(true)}
-          onMouseLeave={() => setIsTargetHandleTouched(false)}
-        />
-      </button>
-
-      {/* Configuration Menu (integrated directly) */}
-      {isMenuOpen && (
-        <ul
-          ref={menuRef}
-          className='absolute top-[64px] text-white w-[448px] rounded-[16px] border-[1px] bg-[#1A1A1A] p-[12px] font-plus-jakarta-sans flex flex-col gap-[16px] border-box shadow-lg'
-          style={{
-            borderColor: UI_COLORS.EDGENODE_BORDER_GREY,
-          }}
+        {/* Run button positioned above the node - show when node or run button is hovered */}
+        <button
+          className={`absolute -top-[40px] left-1/2 transform -translate-x-1/2 w-[57px] h-[24px] rounded-[6px] border-[1px] text-[10px] font-[600] font-plus-jakarta-sans flex flex-row items-center justify-center gap-[4px] transition-all duration-200 ${
+            isHovered || isRunButtonHovered ? 'opacity-100' : 'opacity-0'
+          }`}
+          style={runButtonStyle}
+          onClick={isLoading ? onStopExecution : handleDataSubmit}
+          disabled={false}
+          onMouseEnter={() => setIsRunButtonHovered(true)}
+          onMouseLeave={() => setIsRunButtonHovered(false)}
         >
-          <li className='flex h-[28px] gap-1 items-center justify-between font-plus-jakarta-sans'>
-            <div className='flex flex-row gap-[12px]'>
-              <div className='flex flex-row gap-[8px] justify-center items-center'>
-                <div className='w-[24px] h-[24px] border-[1px] border-main-grey bg-main-black-theme rounded-[8px] flex items-center justify-center'>
-                  <svg
-                    xmlns='http://www.w3.org/2000/svg'
-                    width='12'
-                    height='12'
-                    viewBox='0 0 24 24'
-                    fill='none'
-                  >
-                    <path
-                      d='M13 3H7a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V9l-6-6z'
-                      stroke='#CDCDCD'
-                      strokeWidth='1.5'
-                    />
-                    <path d='M13 3v6h6' stroke='#CDCDCD' strokeWidth='1.5' />
-                    <path
-                      d='M9 14h6'
-                      stroke='#CDCDCD'
-                      strokeWidth='1.5'
-                      strokeLinecap='round'
-                    />
-                  </svg>
-                </div>
-                <div className='flex items-center justify-center text-[14px] font-[600] text-main-grey font-plus-jakarta-sans leading-normal'>
-                  Chunk By Character
-                </div>
-              </div>
-            </div>
-            <div className='flex flex-row gap-[8px] items-center justify-between'>
-              <button
-                className='w-[57px] h-[24px] rounded-[8px] bg-[#39BC66] text-[#000] text-[12px] font-[600] font-plus-jakarta-sans flex flex-row items-center justify-center gap-[7px]'
-                onClick={handleDataSubmit}
-                disabled={isLoading}
+          <span>
+            {isLoading ? (
+              <svg width='6' height='6' viewBox='0 0 6 6' fill='none'>
+                <rect width='6' height='6' fill='currentColor' />
+              </svg>
+            ) : (
+              <svg
+                xmlns='http://www.w3.org/2000/svg'
+                width='6'
+                height='8'
+                viewBox='0 0 8 10'
+                fill='none'
               >
-                <span>
-                  {isLoading ? (
-                    <svg className='animate-spin h-4 w-4' viewBox='0 0 24 24'>
-                      <circle
-                        className='opacity-25'
-                        cx='12'
-                        cy='12'
-                        r='10'
-                        stroke='currentColor'
-                        strokeWidth='4'
-                      ></circle>
-                      <path
-                        className='opacity-75'
-                        fill='currentColor'
-                        d='M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 714 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z'
-                      ></path>
-                    </svg>
-                  ) : (
+                <path d='M8 5L0 10V0L8 5Z' fill='currentColor' />
+              </svg>
+            )}
+          </span>
+          <span>{isLoading ? 'Stop' : 'Run'}</span>
+        </button>
+
+        <button
+          onClick={onClickButton}
+          onMouseEnter={() => setIsHovered(true)}
+          onMouseLeave={() => setIsHovered(false)}
+          className={`w-full h-full flex-shrink-0 rounded-[8px] border-[2px] bg-[#181818] flex items-center justify-center font-plus-jakarta-sans text-[10px] font-[700] edge-node transition-colors gap-[4px]`}
+          style={mainButtonStyle}
+        >
+          {/* Chunking By Character SVG icon */}
+          <svg
+            xmlns='http://www.w3.org/2000/svg'
+            width='10'
+            height='10'
+            viewBox='0 0 24 24'
+            fill='none'
+          >
+            <path
+              d='M13 3H7a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V9l-6-6z'
+              stroke='currentColor'
+              strokeWidth='1.5'
+            />
+            <path d='M13 3v6h6' stroke='currentColor' strokeWidth='1.5' />
+            <path
+              d='M9 14h6'
+              stroke='currentColor'
+              strokeWidth='1.5'
+              strokeLinecap='round'
+            />
+          </svg>
+          <div className='flex flex-col items-center justify-center leading-tight text-[9px]'>
+            <span>Chunk</span>
+            <span>Char</span>
+          </div>
+          {/* Source handles */}
+          <Handle
+            id={`${id}-a`}
+            className='edgeSrcHandle handle-with-icon handle-top'
+            type='source'
+            position={Position.Top}
+          />
+          <Handle
+            id={`${id}-b`}
+            className='edgeSrcHandle handle-with-icon handle-right'
+            type='source'
+            position={Position.Right}
+          />
+          <Handle
+            id={`${id}-c`}
+            className='edgeSrcHandle handle-with-icon handle-bottom'
+            type='source'
+            position={Position.Bottom}
+          />
+          <Handle
+            id={`${id}-d`}
+            className='edgeSrcHandle handle-with-icon handle-left'
+            type='source'
+            position={Position.Left}
+          />
+
+          {/* Target handles */}
+          <Handle
+            id={`${id}-a`}
+            type='target'
+            position={Position.Top}
+            style={handleStyle}
+            isConnectable={isConnectable}
+            onMouseEnter={() => setIsTargetHandleTouched(true)}
+            onMouseLeave={() => setIsTargetHandleTouched(false)}
+          />
+          <Handle
+            id={`${id}-b`}
+            type='target'
+            position={Position.Right}
+            style={handleStyle}
+            isConnectable={isConnectable}
+            onMouseEnter={() => setIsTargetHandleTouched(true)}
+            onMouseLeave={() => setIsTargetHandleTouched(false)}
+          />
+          <Handle
+            id={`${id}-c`}
+            type='target'
+            position={Position.Bottom}
+            style={handleStyle}
+            isConnectable={isConnectable}
+            onMouseEnter={() => setIsTargetHandleTouched(true)}
+            onMouseLeave={() => setIsTargetHandleTouched(false)}
+          />
+          <Handle
+            id={`${id}-d`}
+            type='target'
+            position={Position.Left}
+            style={handleStyle}
+            isConnectable={isConnectable}
+            onMouseEnter={() => setIsTargetHandleTouched(true)}
+            onMouseLeave={() => setIsTargetHandleTouched(false)}
+          />
+        </button>
+
+        {/* Configuration Menu (integrated directly) */}
+        {isMenuOpen && (
+          <ul
+            ref={menuRef}
+            className='absolute top-[64px] text-white w-[448px] rounded-[16px] border-[1px] bg-[#1A1A1A] p-[12px] font-plus-jakarta-sans flex flex-col gap-[16px] border-box shadow-lg'
+            style={{
+              borderColor: UI_COLORS.EDGENODE_BORDER_GREY,
+            }}
+          >
+            <li className='flex h-[28px] gap-1 items-center justify-between font-plus-jakarta-sans'>
+              <div className='flex flex-row gap-[12px]'>
+                <div className='flex flex-row gap-[8px] justify-center items-center'>
+                  <div className='w-[24px] h-[24px] border-[1px] border-main-grey bg-main-black-theme rounded-[8px] flex items-center justify-center'>
                     <svg
                       xmlns='http://www.w3.org/2000/svg'
-                      width='8'
-                      height='10'
-                      viewBox='0 0 8 10'
-                      fill='none'
-                    >
-                      <path d='M8 5L0 10V0L8 5Z' fill='black' />
-                    </svg>
-                  )}
-                </span>
-                <span>{isLoading ? '' : 'Run'}</span>
-              </button>
-            </div>
-          </li>
-
-          {/* Input/Output display */}
-          <li>
-            <InputOutputDisplay
-              parentId={id}
-              getNode={getNode}
-              getSourceNodeIdWithLabel={getSourceNodeIdWithLabel}
-              getTargetNodeIdWithLabel={getTargetNodeIdWithLabel}
-              supportedInputTypes={['text']}
-              supportedOutputTypes={['structured']}
-              inputNodeCategory='blocknode'
-              outputNodeCategory='blocknode'
-            />
-          </li>
-
-          <li className='flex flex-col gap-2'>
-            <div className='flex items-center gap-2'>
-              <label className='text-[12px] font-semibold text-[#6D7177]'>
-                Delimiters
-              </label>
-              <div className='w-[5px] h-[5px] rounded-full bg-[#FF4D4D]'></div>
-            </div>
-
-            <div className='bg-[#1E1E1E] rounded-[8px] p-[5px] border-[1px] border-[#6D7177]/30 hover:border-[#6D7177]/50 transition-colors'>
-              <div className='flex flex-wrap gap-2 items-center'>
-                {delimiters.map((delimiter, index) => (
-                  <div
-                    key={index}
-                    className='flex items-center bg-[#252525] rounded-md 
-                                                    border border-[#FF9B4D]/30 hover:border-[#FF9B4D]/50 
-                                                    transition-colors group'
-                  >
-                    <span className='text-[10px] text-[#FF9B4D] px-2 py-1'>
-                      {delimiterDisplay(delimiter)}
-                    </span>
-                    <button
-                      onClick={() => removeDelimiter(index)}
-                      className='text-[#6D7177] hover:text-[#ff6b6b] transition-colors 
-                                                        px-1 py-1 opacity-0 group-hover:opacity-100'
-                    >
-                      <svg
-                        xmlns='http://www.w3.org/2000/svg'
-                        width='10'
-                        height='10'
-                        viewBox='0 0 24 24'
-                        fill='none'
-                        stroke='currentColor'
-                        strokeWidth='2'
-                        strokeLinecap='round'
-                        strokeLinejoin='round'
-                      >
-                        <line x1='18' y1='6' x2='6' y2='18'></line>
-                        <line x1='6' y1='6' x2='18' y2='18'></line>
-                      </svg>
-                    </button>
-                  </div>
-                ))}
-
-                {showDelimiterInput ? (
-                  <div
-                    className='h-[24px] bg-[#252525] rounded-md 
-                                                    border border-[#FF9B4D]/30 
-                                                    flex items-center'
-                  >
-                    <input
-                      ref={newDelimiterRef}
-                      type='text'
-                      placeholder='Type...'
-                      className='w-[80px] h-full bg-transparent border-none outline-none px-2
-                                                        text-[10px] text-[#CDCDCD]'
-                      onKeyDown={handleCustomDelimiterInput}
-                      onBlur={() => setShowDelimiterInput(false)}
-                      onFocus={onFocus}
-                    />
-                  </div>
-                ) : (
-                  <button
-                    onClick={() => setShowDelimiterInput(true)}
-                    className='w-[24px] h-[24px] flex items-center justify-center rounded-md
-                                                    bg-[#252525] border border-[#6D7177]/30 
-                                                    text-[#6D7177] 
-                                                    hover:border-[#6D7177]/50 hover:bg-[#252525]/80 
-                                                    transition-colors'
-                  >
-                    <svg
                       width='12'
                       height='12'
                       viewBox='0 0 24 24'
                       fill='none'
-                      stroke='currentColor'
                     >
                       <path
-                        d='M12 5v14M5 12h14'
-                        strokeWidth='2'
+                        d='M13 3H7a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V9l-6-6z'
+                        stroke='#CDCDCD'
+                        strokeWidth='1.5'
+                      />
+                      <path d='M13 3v6h6' stroke='#CDCDCD' strokeWidth='1.5' />
+                      <path
+                        d='M9 14h6'
+                        stroke='#CDCDCD'
+                        strokeWidth='1.5'
                         strokeLinecap='round'
                       />
                     </svg>
-                  </button>
-                )}
+                  </div>
+                  <div className='flex items-center justify-center text-[14px] font-[600] text-main-grey font-plus-jakarta-sans leading-normal'>
+                    Chunk By Character
+                  </div>
+                </div>
               </div>
-            </div>
+              <div className='flex flex-row gap-[8px] items-center justify-between'>
+                <button
+                  className='w-[57px] h-[24px] rounded-[8px] text-[#000] text-[12px] font-[600] font-plus-jakarta-sans flex flex-row items-center justify-center gap-[7px]'
+                  style={{
+                    backgroundColor: isLoading ? '#FFA73D' : '#39BC66',
+                  }}
+                  onClick={isLoading ? onStopExecution : handleDataSubmit}
+                  disabled={false}
+                >
+                  <span>
+                    {isLoading ? (
+                      <svg width='8' height='8' viewBox='0 0 8 8' fill='none'>
+                        <rect width='8' height='8' fill='currentColor' />
+                      </svg>
+                    ) : (
+                      <svg
+                        xmlns='http://www.w3.org/2000/svg'
+                        width='8'
+                        height='10'
+                        viewBox='0 0 8 10'
+                        fill='none'
+                      >
+                        <path d='M8 5L0 10V0L8 5Z' fill='black' />
+                      </svg>
+                    )}
+                  </span>
+                  <span>{isLoading ? 'Stop' : 'Run'}</span>
+                </button>
+              </div>
+            </li>
 
-            <div className='mt-1'>
-              <div className='text-[10px] text-[#6D7177] mb-2'>
-                Common delimiters:
+            {/* Input/Output display */}
+            <li>
+              <InputOutputDisplay
+                parentId={id}
+                getNode={getNode}
+                getSourceNodeIdWithLabel={getSourceNodeIdWithLabel}
+                getTargetNodeIdWithLabel={getTargetNodeIdWithLabel}
+                supportedInputTypes={['text']}
+                supportedOutputTypes={['structured']}
+                inputNodeCategory='blocknode'
+                outputNodeCategory='blocknode'
+              />
+            </li>
+
+            <li className='flex flex-col gap-2'>
+              <div className='flex items-center gap-2'>
+                <label className='text-[12px] font-semibold text-[#6D7177]'>
+                  Delimiters
+                </label>
+                <div className='w-[5px] h-[5px] rounded-full bg-[#FF4D4D]'></div>
               </div>
-              <div className='flex flex-wrap gap-2'>
-                {commonDelimiters.map(delimiter => (
-                  <button
-                    key={delimiter.value}
-                    onClick={() => addDelimiter(delimiter.value)}
-                    className={`px-2 py-1 rounded-md text-[10px] transition-colors
+
+              <div className='bg-[#1E1E1E] rounded-[8px] p-[5px] border-[1px] border-[#6D7177]/30 hover:border-[#6D7177]/50 transition-colors'>
+                <div className='flex flex-wrap gap-2 items-center'>
+                  {delimiters.map((delimiter, index) => (
+                    <div
+                      key={index}
+                      className='flex items-center bg-[#252525] rounded-md 
+                                                    border border-[#FF9B4D]/30 hover:border-[#FF9B4D]/50 
+                                                    transition-colors group'
+                    >
+                      <span className='text-[10px] text-[#FF9B4D] px-2 py-1'>
+                        {delimiterDisplay(delimiter)}
+                      </span>
+                      <button
+                        onClick={() => removeDelimiter(index)}
+                        className='text-[#6D7177] hover:text-[#ff6b6b] transition-colors 
+                                                        px-1 py-1 opacity-0 group-hover:opacity-100'
+                      >
+                        <svg
+                          xmlns='http://www.w3.org/2000/svg'
+                          width='10'
+                          height='10'
+                          viewBox='0 0 24 24'
+                          fill='none'
+                          stroke='currentColor'
+                          strokeWidth='2'
+                          strokeLinecap='round'
+                          strokeLinejoin='round'
+                        >
+                          <line x1='18' y1='6' x2='6' y2='18'></line>
+                          <line x1='6' y1='6' x2='18' y2='18'></line>
+                        </svg>
+                      </button>
+                    </div>
+                  ))}
+
+                  {showDelimiterInput ? (
+                    <div
+                      className='h-[24px] bg-[#252525] rounded-md 
+                                                    border border-[#FF9B4D]/30 
+                                                    flex items-center'
+                    >
+                      <input
+                        ref={newDelimiterRef}
+                        type='text'
+                        placeholder='Type...'
+                        className='w-[80px] h-full bg-transparent border-none outline-none px-2
+                                                        text-[10px] text-[#CDCDCD]'
+                        onKeyDown={handleCustomDelimiterInput}
+                        onBlur={() => setShowDelimiterInput(false)}
+                        onFocus={onFocus}
+                      />
+                    </div>
+                  ) : (
+                    <button
+                      onClick={() => setShowDelimiterInput(true)}
+                      className='w-[24px] h-[24px] flex items-center justify-center rounded-md
+                                                    bg-[#252525] border border-[#6D7177]/30 
+                                                    text-[#6D7177] 
+                                                    hover:border-[#6D7177]/50 hover:bg-[#252525]/80 
+                                                    transition-colors'
+                    >
+                      <svg
+                        width='12'
+                        height='12'
+                        viewBox='0 0 24 24'
+                        fill='none'
+                        stroke='currentColor'
+                      >
+                        <path
+                          d='M12 5v14M5 12h14'
+                          strokeWidth='2'
+                          strokeLinecap='round'
+                        />
+                      </svg>
+                    </button>
+                  )}
+                </div>
+              </div>
+
+              <div className='mt-1'>
+                <div className='text-[10px] text-[#6D7177] mb-2'>
+                  Common delimiters:
+                </div>
+                <div className='flex flex-wrap gap-2'>
+                  {commonDelimiters.map(delimiter => (
+                    <button
+                      key={delimiter.value}
+                      onClick={() => addDelimiter(delimiter.value)}
+                      className={`px-2 py-1 rounded-md text-[10px] transition-colors
                                                     ${
                                                       delimiters.includes(
                                                         delimiter.value
@@ -635,17 +700,19 @@ function ChunkingByCharacter({
                                                         ? 'bg-[#252525] text-[#CDCDCD] border border-[#6D7177]/50'
                                                         : 'bg-[#1E1E1E] text-[#6D7177] border border-[#6D7177]/30 hover:bg-[#252525] hover:text-[#CDCDCD]'
                                                     }`}
-                  >
-                    {delimiter.label}
-                  </button>
-                ))}
+                    >
+                      {delimiter.label}
+                    </button>
+                  ))}
+                </div>
               </div>
-            </div>
-          </li>
-        </ul>
-      )}
-    </div>
-  );
-}
+            </li>
+          </ul>
+        )}
+      </div>
+    );
+  }
+);
 
+ChunkingByCharacter.displayName = 'ChunkingByCharacter';
 export default ChunkingByCharacter;

--- a/PuppyFlow/app/components/workflow/edgesNode/edgeNodesNew/Convert2Structured.tsx
+++ b/PuppyFlow/app/components/workflow/edgesNode/edgeNodesNew/Convert2Structured.tsx
@@ -1,7 +1,12 @@
 import { Handle, Position, NodeProps, Node, useReactFlow } from '@xyflow/react';
 import { useNodesPerFlowContext } from '@/app/components/states/NodesPerFlowContext';
-import React, { useState, useEffect, useRef, useCallback } from 'react';
-import { markerEnd } from '../../connectionLineStyles/ConfigToTargetEdge';
+import React, {
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+  useMemo,
+} from 'react';
 import { PuppyDropdown } from '../../../misc/PuppyDropDown';
 import InputOutputDisplay from './components/InputOutputDisplay';
 import { UI_COLORS } from '@/app/utils/colors';
@@ -33,722 +38,731 @@ export type ModifyConfigNodeData = {
 
 type ModifyConfigNodeProps = NodeProps<Node<ModifyConfigNodeData>>;
 
-function Convert2Structured({
-  data,
-  isConnectable,
-  id,
-}: ModifyConfigNodeProps) {
-  const {
-    isOnConnect,
-    activatedEdge,
-    isOnGeneratingNewNode,
-    clearEdgeActivation,
-    activateEdge,
-    clearAll,
-  } = useNodesPerFlowContext();
-  const [isTargetHandleTouched, setIsTargetHandleTouched] = useState(false);
-  const { getNode, getInternalNode, setNodes, setEdges } = useReactFlow();
-  const { getSourceNodeIdWithLabel, getTargetNodeIdWithLabel } =
-    useGetSourceTarget();
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const [isHovered, setIsHovered] = useState(false);
-  const [isRunButtonHovered, setIsRunButtonHovered] = useState(false);
-  const [isLoading, setIsLoading] = useState(false);
-  const menuRef = useRef<HTMLUListElement>(null);
-  const [showDelimiterInput, setShowDelimiterInput] = useState(false);
-  const newDelimiterRef = useRef<HTMLInputElement>(null);
+const Convert2Structured: React.FC<ModifyConfigNodeProps> = React.memo(
+  ({ data, isConnectable, id }) => {
+    const {
+      isOnConnect,
+      activatedEdge,
+      isOnGeneratingNewNode,
+      clearEdgeActivation,
+      activateEdge,
+      clearAll,
+    } = useNodesPerFlowContext();
+    const [isTargetHandleTouched, setIsTargetHandleTouched] = useState(false);
+    const { getNode, getInternalNode, setNodes, setEdges } = useReactFlow();
+    const { getSourceNodeIdWithLabel, getTargetNodeIdWithLabel } =
+      useGetSourceTarget();
+    const [isMenuOpen, setIsMenuOpen] = useState(false);
+    const [isHovered, setIsHovered] = useState(false);
+    const [isRunButtonHovered, setIsRunButtonHovered] = useState(false);
+    const [isLoading, setIsLoading] = useState(false);
+    const menuRef = useRef<HTMLUListElement>(null);
+    const [showDelimiterInput, setShowDelimiterInput] = useState(false);
+    const newDelimiterRef = useRef<HTMLInputElement>(null);
 
-  // 获取所有需要的依赖
-  const { streamResult, reportError, resetLoadingUI } = useJsonConstructUtils();
-  const { getAuthHeaders } = useAppSettings();
+    // 获取所有需要的依赖
+    const { streamResult, reportError, resetLoadingUI } =
+      useJsonConstructUtils();
+    const { getAuthHeaders } = useAppSettings();
 
-  // 常量定义
-  const INTO_DICT_TYPE = 'wrap into dict';
-  const INTO_LIST_TYPE = 'wrap into list';
-  const JSON_TYPE = 'JSON';
-  const BY_LEN_TYPE = 'split by length';
-  const BY_CHAR_TYPE = 'split by character';
+    // 使用 useRef 跟踪是否已挂载
+    const hasMountedRef = useRef(false);
 
-  // 添加 commonDelimiters 常量定义
-  const commonDelimiters = [
-    { label: 'Comma (,)', value: ',' },
-    { label: 'Semicolon (;)', value: ';' },
-    { label: 'Enter (\\n)', value: '\n' },
-    { label: 'Tab (\\t)', value: '\t' },
-    { label: 'Space', value: ' ' },
-    { label: 'Period (.)', value: '.' },
-    { label: 'Pipe (|)', value: '|' },
-    { label: 'Dash (-)', value: '-' },
-  ];
+    // 常量定义 - 使用 useMemo 缓存
+    const modeConstants = useMemo(
+      () => ({
+        INTO_DICT_TYPE: 'wrap into dict',
+        INTO_LIST_TYPE: 'wrap into list',
+        JSON_TYPE: 'JSON',
+        BY_LEN_TYPE: 'split by length',
+        BY_CHAR_TYPE: 'split by character',
+      }),
+      []
+    );
 
-  // 加载配置值
-  const [execMode, setExecMode] = useState(
-    (getNode(id)?.data as any)?.execMode || JSON_TYPE
-  );
-  const [wrapInto, setWrapInto] = useState(
-    typeof (getNode(id)?.data?.extra_configs as any)?.dict_key === 'string'
-      ? (getNode(id)?.data?.extra_configs as any)?.dict_key
-      : ''
-  );
-  const [deliminator, setDeliminator] = useState(
-    typeof (getNode(id)?.data?.extra_configs as any)?.list_separator ===
+    const {
+      INTO_DICT_TYPE,
+      INTO_LIST_TYPE,
+      JSON_TYPE,
+      BY_LEN_TYPE,
+      BY_CHAR_TYPE,
+    } = modeConstants;
+
+    // 添加 commonDelimiters 常量定义 - 使用 useMemo 缓存
+    const commonDelimiters = useMemo(
+      () => [
+        { label: 'Comma (,)', value: ',' },
+        { label: 'Semicolon (;)', value: ';' },
+        { label: 'Enter (\\n)', value: '\n' },
+        { label: 'Tab (\\t)', value: '\t' },
+        { label: 'Space', value: ' ' },
+        { label: 'Period (.)', value: '.' },
+        { label: 'Pipe (|)', value: '|' },
+        { label: 'Dash (-)', value: '-' },
+      ],
+      []
+    );
+
+    // 优化状态初始化 - 使用函数形式避免重复计算
+    const [execMode, setExecMode] = useState(
+      () => (getNode(id)?.data as any)?.execMode || JSON_TYPE
+    );
+
+    const [wrapInto, setWrapInto] = useState(() =>
+      typeof (getNode(id)?.data?.extra_configs as any)?.dict_key === 'string'
+        ? (getNode(id)?.data?.extra_configs as any)?.dict_key
+        : ''
+    );
+
+    const [deliminator, setDeliminator] = useState(() =>
+      typeof (getNode(id)?.data?.extra_configs as any)?.list_separator ===
       'string'
-      ? (getNode(id)?.data?.extra_configs as any)?.list_separator
-      : `[",",";",".","\\n"]`
-  );
-  const [bylen, setBylen] = useState<number>(
-    typeof (getNode(id)?.data?.extra_configs as any)?.length_separator ===
+        ? (getNode(id)?.data?.extra_configs as any)?.list_separator
+        : `[",",";",".","\\n"]`
+    );
+
+    const [bylen, setBylen] = useState<number>(() =>
+      typeof (getNode(id)?.data?.extra_configs as any)?.length_separator ===
       'number'
-      ? (getNode(id)?.data?.extra_configs as any)?.length_separator
-      : 10
-  );
+        ? (getNode(id)?.data?.extra_configs as any)?.length_separator
+        : 10
+    );
 
-  const [delimiters, setDelimiters] = useState<string[]>(() => {
-    try {
-      const parsedDeliminator = JSON.parse(deliminator);
-      return Array.isArray(parsedDeliminator)
-        ? parsedDeliminator
-        : [',', ';', '.', '\n'];
-    } catch (e) {
-      return [',', ';', '.', '\n'];
-    }
-  });
+    // 优化 delimiters 状态初始化 - 使用 useMemo 缓存解析逻辑
+    const [delimiters, setDelimiters] = useState<string[]>(() => {
+      try {
+        const parsedDeliminator = JSON.parse(deliminator);
+        return Array.isArray(parsedDeliminator)
+          ? parsedDeliminator
+          : [',', ';', '.', '\n'];
+      } catch (e) {
+        return [',', ';', '.', '\n'];
+      }
+    });
 
-  // 创建执行上下文
-  const createExecutionContext = useCallback(
-    (): RunSingleEdgeNodeContext => ({
-      getNode,
-      setNodes,
-      setEdges,
-      getSourceNodeIdWithLabel,
-      getTargetNodeIdWithLabel,
-      clearAll,
-      streamResult,
-      reportError,
-      resetLoadingUI,
-      getAuthHeaders,
-    }),
-    [
-      getNode,
-      setNodes,
-      setEdges,
-      getSourceNodeIdWithLabel,
-      getTargetNodeIdWithLabel,
-      clearAll,
-      streamResult,
-      reportError,
-      resetLoadingUI,
-      getAuthHeaders,
-    ]
-  );
+    // 创建执行上下文 - 使用 useCallback 缓存
+    const createExecutionContext = useCallback(
+      (): RunSingleEdgeNodeContext => ({
+        getNode,
+        setNodes,
+        setEdges,
+        getSourceNodeIdWithLabel,
+        getTargetNodeIdWithLabel,
+        clearAll,
+        streamResult,
+        reportError,
+        resetLoadingUI,
+        getAuthHeaders,
+      }),
+      [
+        getNode,
+        setNodes,
+        setEdges,
+        getSourceNodeIdWithLabel,
+        getTargetNodeIdWithLabel,
+        clearAll,
+        streamResult,
+        reportError,
+        resetLoadingUI,
+        getAuthHeaders,
+      ]
+    );
 
-  // 使用执行函数的 handleDataSubmit
-  const handleDataSubmit = useCallback(async () => {
-    if (isLoading) return;
+    // 使用执行函数的 handleDataSubmit - 使用 useCallback 缓存
+    const handleDataSubmit = useCallback(async () => {
+      if (isLoading) return;
 
-    setIsLoading(true);
-    try {
-      const context = createExecutionContext();
-      await runSingleEdgeNode({
-        parentId: id,
-        targetNodeType: 'structured',
-        context,
-        // 可以选择不提供 constructJsonData，使用默认实现
-      });
-    } catch (error) {
-      console.error('执行失败:', error);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [id, isLoading, createExecutionContext]);
+      setIsLoading(true);
+      try {
+        const context = createExecutionContext();
+        await runSingleEdgeNode({
+          parentId: id,
+          targetNodeType: 'structured',
+          context,
+        });
+      } catch (error) {
+        console.error('执行失败:', error);
+      } finally {
+        setIsLoading(false);
+      }
+    }, [id, isLoading, createExecutionContext]);
 
-  useEffect(() => {
-    console.log(getInternalNode(id));
+    // 辅助函数 - 使用 useCallback 缓存
+    const onFocus = useCallback(() => {
+      const curRef = menuRef.current;
+      if (curRef && !curRef.classList.contains('nodrag')) {
+        curRef.classList.add('nodrag');
+      }
+    }, []);
 
-    if (!isOnGeneratingNewNode) {
-      clearAll();
-      activateEdge(id);
-    }
+    const onBlur = useCallback(() => {
+      const curRef = menuRef.current;
+      if (curRef) {
+        curRef.classList.remove('nodrag');
+      }
+    }, []);
 
-    return () => {
+    // 状态同步逻辑 - 使用 requestAnimationFrame 延迟执行，避免在节点创建时干扰
+    useEffect(() => {
+      if (!isOnGeneratingNewNode && hasMountedRef.current) {
+        requestAnimationFrame(() => {
+          const node = getNode(id);
+          if (node) {
+            setNodes(prevNodes =>
+              prevNodes.map(n => {
+                if (n.id === id) {
+                  return {
+                    ...n,
+                    data: {
+                      ...n.data,
+                      execMode: execMode,
+                      extra_configs: {
+                        ...(n.data?.extra_configs || {}),
+                        list_separator: deliminator,
+                        dict_key: wrapInto,
+                        length_separator: bylen,
+                      },
+                    },
+                  };
+                }
+                return n;
+              })
+            );
+          }
+        });
+      }
+    }, [execMode, deliminator, bylen, wrapInto, isOnGeneratingNewNode]);
+
+    // 组件初始化
+    useEffect(() => {
+      hasMountedRef.current = true;
+    }, []);
+
+    useEffect(() => {
+      if (hasMountedRef.current && !isOnGeneratingNewNode) {
+        clearAll();
+        activateEdge(id);
+      }
+
+      return () => {
+        if (activatedEdge === id) {
+          clearEdgeActivation();
+        }
+      };
+    }, [isOnGeneratingNewNode]);
+
+    // 当显示输入框时，自动聚焦
+    useEffect(() => {
+      if (showDelimiterInput && newDelimiterRef.current) {
+        newDelimiterRef.current.focus();
+      }
+    }, [showDelimiterInput]);
+
+    // 处理自定义分隔符输入 - 使用 useCallback 缓存
+    const handleCustomDelimiterInput = useCallback(
+      (e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === 'Enter' && e.currentTarget.value) {
+          addDelimiter(e.currentTarget.value);
+          e.currentTarget.value = '';
+          setShowDelimiterInput(false);
+        } else if (e.key === 'Escape') {
+          setShowDelimiterInput(false);
+        }
+      },
+      []
+    );
+
+    // UI 交互函数 - 使用 useCallback 缓存
+    const onClickButton = useCallback(() => {
+      setIsMenuOpen(!isMenuOpen);
+
+      if (isOnGeneratingNewNode) return;
       if (activatedEdge === id) {
         clearEdgeActivation();
+      } else {
+        clearAll();
+        activateEdge(id);
       }
-    };
-  }, []);
+    }, [
+      isMenuOpen,
+      isOnGeneratingNewNode,
+      activatedEdge,
+      id,
+      clearEdgeActivation,
+      clearAll,
+      activateEdge,
+    ]);
 
-  // 辅助函数
-  const onFocus = () => {
-    const curRef = menuRef.current;
-    if (curRef && !curRef.classList.contains('nodrag')) {
-      curRef.classList.add('nodrag');
-    }
-  };
+    // 执行函数 - 使用 useCallback 缓存
+    const onDataSubmit = useCallback(() => {
+      handleDataSubmit();
+    }, [handleDataSubmit]);
 
-  const onBlur = () => {
-    const curRef = menuRef.current;
-    if (curRef) {
-      curRef.classList.remove('nodrag');
-    }
-  };
+    // 添加新的分隔符 - 使用 useCallback 缓存
+    const addDelimiter = useCallback(
+      (value: string) => {
+        if (value && !delimiters.includes(value)) {
+          const newDelimiters = [...delimiters, value];
+          setDelimiters(newDelimiters);
+          setDeliminator(JSON.stringify(newDelimiters));
+        }
+      },
+      [delimiters]
+    );
 
-  // 状态同步到 ReactFlow
-  useEffect(() => {
-    const node = getNode(id);
-    if (node) {
-      setNodes(prevNodes =>
-        prevNodes.map(n => {
-          if (n.id === id) {
-            return {
-              ...n,
-              data: {
-                ...n.data,
-                // 保存 execMode 到 data 对象中
-                execMode: execMode,
-                extra_configs: {
-                  ...(n.data?.extra_configs || {}),
-                  list_separator: deliminator,
-                  dict_key: wrapInto,
-                  length_separator: bylen,
-                },
-              },
-            };
-          }
-          return n;
-        })
-      );
-    }
-  }, [execMode, deliminator, bylen, wrapInto, id, setNodes, getNode]);
+    // 删除分隔符 - 使用 useCallback 缓存
+    const removeDelimiter = useCallback(
+      (index: number) => {
+        const newDelimiters = delimiters.filter((_, i) => i !== index);
+        setDelimiters(newDelimiters);
+        setDeliminator(JSON.stringify(newDelimiters));
+      },
+      [delimiters]
+    );
 
-  // 当显示输入框时，自动聚焦
-  useEffect(() => {
-    if (showDelimiterInput && newDelimiterRef.current) {
-      newDelimiterRef.current.focus();
-    }
-  }, [showDelimiterInput]);
+    // 特殊字符的显示映射 - 使用 useCallback 缓存
+    const delimiterDisplay = useCallback((delimiter: string) => {
+      switch (delimiter) {
+        case '\n':
+          return (
+            <span className='flex items-center gap-1'>
+              <svg width='14' height='14' viewBox='0 0 14 14' fill='none'>
+                <path
+                  d='M6 5L3 8L6 11'
+                  stroke='currentColor'
+                  strokeWidth='0.583333'
+                />
+                <path
+                  d='M3 8H11V3'
+                  stroke='currentColor'
+                  strokeWidth='0.583333'
+                />
+              </svg>
+              <span className='text-[10px]'>Enter</span>
+            </span>
+          );
+        case '\t':
+          return 'Tab';
+        case ' ':
+          return 'Space';
+        default:
+          return delimiter;
+      }
+    }, []);
 
-  // 处理自定义分隔符输入
-  const handleCustomDelimiterInput = (
-    e: React.KeyboardEvent<HTMLInputElement>
-  ) => {
-    if (e.key === 'Enter' && e.currentTarget.value) {
-      addDelimiter(e.currentTarget.value);
-      e.currentTarget.value = '';
-      setShowDelimiterInput(false);
-    } else if (e.key === 'Escape') {
-      setShowDelimiterInput(false);
-    }
-  };
+    // 在组件顶部定义共享样式 - 使用 useMemo 缓存
+    const handleStyle = useMemo(
+      () => ({
+        position: 'absolute' as const,
+        width: 'calc(100%)',
+        height: 'calc(100%)',
+        top: '0',
+        left: '0',
+        borderRadius: '0',
+        transform: 'translate(0px, 0px)',
+        background: 'transparent',
+        border: '3px solid transparent',
+        zIndex: !isOnConnect ? '-1' : '1',
+      }),
+      [isOnConnect]
+    );
 
-  const onClickButton = () => {
-    setIsMenuOpen(!isMenuOpen);
+    // 添加停止函数 - 使用 useCallback 缓存
+    const onStopExecution = useCallback(() => {
+      console.log('Stop execution');
+      setIsLoading(false);
+    }, []);
 
-    if (isOnGeneratingNewNode) return;
-    if (activatedEdge === id) {
-      clearEdgeActivation();
-    } else {
-      clearAll();
-      activateEdge(id);
-    }
-  };
+    // 缓存按钮样式 - 使用 useMemo 缓存
+    const runButtonStyle = useMemo(
+      () => ({
+        backgroundColor: isRunButtonHovered
+          ? isLoading
+            ? '#FFA73D'
+            : '#39BC66'
+          : '#181818',
+        borderColor: isRunButtonHovered
+          ? isLoading
+            ? '#FFA73D'
+            : '#39BC66'
+          : UI_COLORS.EDGENODE_BORDER_GREY,
+        color: isRunButtonHovered ? '#000' : UI_COLORS.EDGENODE_BORDER_GREY,
+      }),
+      [isRunButtonHovered, isLoading]
+    );
 
-  // 执行函数
-  const onDataSubmit = () => {
-    handleDataSubmit();
-  };
+    const mainButtonStyle = useMemo(
+      () => ({
+        borderColor: isLoading
+          ? '#FFA73D'
+          : isHovered
+            ? UI_COLORS.LINE_ACTIVE
+            : UI_COLORS.EDGENODE_BORDER_GREY,
+        color: isLoading
+          ? '#FFA73D'
+          : isHovered
+            ? UI_COLORS.LINE_ACTIVE
+            : UI_COLORS.EDGENODE_BORDER_GREY,
+      }),
+      [isLoading, isHovered]
+    );
 
-  // 添加新的分隔符
-  const addDelimiter = (value: string) => {
-    if (value && !delimiters.includes(value)) {
-      const newDelimiters = [...delimiters, value];
-      setDelimiters(newDelimiters);
-      setDeliminator(JSON.stringify(newDelimiters));
-    }
-  };
+    return (
+      <div className='p-[3px] w-[80px] h-[48px] relative'>
+        {/* Invisible hover area between node and run button */}
+        <div
+          className='absolute -top-[40px] left-0 w-full h-[40px]'
+          onMouseEnter={() => setIsHovered(true)}
+          onMouseLeave={() => setIsHovered(false)}
+        />
 
-  // 删除分隔符
-  const removeDelimiter = (index: number) => {
-    const newDelimiters = delimiters.filter((_, i) => i !== index);
-    setDelimiters(newDelimiters);
-    setDeliminator(JSON.stringify(newDelimiters));
-  };
-
-  // 特殊字符的显示映射
-  const delimiterDisplay = (delimiter: string) => {
-    switch (delimiter) {
-      case '\n':
-        return (
-          <span className='flex items-center gap-1'>
-            <svg
-              width='14'
-              height='14'
-              viewBox='0 0 14 14'
-              fill='none'
-              xmlns='http://www.w3.org/2000/svg'
-            >
-              <path
-                d='M6 5L3 8L6 11'
-                stroke='currentColor'
-                strokeWidth='0.583333'
-              />
-              <path
-                d='M3 8H11V3'
-                stroke='currentColor'
-                strokeWidth='0.583333'
-              />
-            </svg>
-            <span className='text-[10px]'>Enter</span>
+        {/* Run button positioned above the node - show when node or run button is hovered */}
+        <button
+          className={`absolute -top-[40px] left-1/2 transform -translate-x-1/2 w-[57px] h-[24px] rounded-[6px] border-[1px] text-[10px] font-[600] font-plus-jakarta-sans flex flex-row items-center justify-center gap-[4px] transition-all duration-200 ${
+            isHovered || isRunButtonHovered ? 'opacity-100' : 'opacity-0'
+          }`}
+          style={runButtonStyle}
+          onClick={isLoading ? onStopExecution : handleDataSubmit}
+          disabled={false}
+          onMouseEnter={() => setIsRunButtonHovered(true)}
+          onMouseLeave={() => setIsRunButtonHovered(false)}
+        >
+          <span>
+            {isLoading ? (
+              <svg width='6' height='6' viewBox='0 0 6 6' fill='none'>
+                <rect width='6' height='6' fill='currentColor' />
+              </svg>
+            ) : (
+              <svg width='6' height='8' viewBox='0 0 8 10' fill='none'>
+                <path d='M8 5L0 10V0L8 5Z' fill='currentColor' />
+              </svg>
+            )}
           </span>
-        );
-      case '\t':
-        return 'Tab';
-      case ' ':
-        return 'Space';
-      default:
-        return delimiter;
-    }
-  };
+          <span>{isLoading ? 'Stop' : 'Run'}</span>
+        </button>
 
-  // 在组件顶部定义共享样式
-  const handleStyle = {
-    position: 'absolute' as const,
-    width: 'calc(100%)',
-    height: 'calc(100%)',
-    top: '0',
-    left: '0',
-    borderRadius: '0',
-    transform: 'translate(0px, 0px)',
-    background: 'transparent',
-    border: '3px solid transparent',
-    zIndex: !isOnConnect ? '-1' : '1',
-  };
-
-  return (
-    <div className='p-[3px] w-[80px] h-[48px] relative'>
-      {/* Invisible hover area between node and run button */}
-      <div
-        className='absolute -top-[40px] left-0 w-full h-[40px]'
-        onMouseEnter={() => setIsHovered(true)}
-        onMouseLeave={() => setIsHovered(false)}
-      />
-
-      {/* Run button positioned above the node - show when node or run button is hovered */}
-      <button
-        className={`absolute -top-[40px] left-1/2 transform -translate-x-1/2 w-[57px] h-[24px] rounded-[6px] border-[1px] text-[10px] font-[600] font-plus-jakarta-sans flex flex-row items-center justify-center gap-[4px] transition-all duration-200 ${
-          isHovered || isRunButtonHovered ? 'opacity-100' : 'opacity-0'
-        }`}
-        style={{
-          backgroundColor: isRunButtonHovered ? '#39BC66' : '#181818',
-          borderColor: isRunButtonHovered
-            ? '#39BC66'
-            : UI_COLORS.EDGENODE_BORDER_GREY,
-          color: isRunButtonHovered ? '#000' : UI_COLORS.EDGENODE_BORDER_GREY,
-        }}
-        onClick={handleDataSubmit}
-        disabled={isLoading}
-        onMouseEnter={() => setIsRunButtonHovered(true)}
-        onMouseLeave={() => setIsRunButtonHovered(false)}
-      >
-        <span>
-          {isLoading ? (
-            <svg className='animate-spin h-3 w-3' viewBox='0 0 24 24'>
-              <circle
-                className='opacity-25'
-                cx='12'
-                cy='12'
-                r='10'
-                stroke='currentColor'
-                strokeWidth='4'
-              ></circle>
-              <path
-                className='opacity-75'
-                fill='currentColor'
-                d='M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 714 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z'
-              ></path>
-            </svg>
-          ) : (
-            <svg
-              xmlns='http://www.w3.org/2000/svg'
-              width='6'
-              height='8'
-              viewBox='0 0 8 10'
-              fill='none'
-            >
-              <path d='M8 5L0 10V0L8 5Z' fill='currentColor' />
-            </svg>
-          )}
-        </span>
-        <span>{isLoading ? '' : 'Run'}</span>
-      </button>
-
-      {/* Main button */}
-      <button
-        onClick={onClickButton}
-        onMouseEnter={() => setIsHovered(true)}
-        onMouseLeave={() => setIsHovered(false)}
-        className={`w-full h-full flex-shrink-0 rounded-[8px] border-[2px] bg-[#181818] flex items-center justify-center font-plus-jakarta-sans text-[10px] font-[700] edge-node transition-colors gap-[4px]`}
-        style={{
-          borderColor: isHovered
-            ? UI_COLORS.LINE_ACTIVE
-            : UI_COLORS.EDGENODE_BORDER_GREY,
-          color: isHovered
-            ? UI_COLORS.LINE_ACTIVE
-            : UI_COLORS.EDGENODE_BORDER_GREY,
-        }}
-      >
-        {/* Convert to Structured SVG icon */}
-        <svg
-          xmlns='http://www.w3.org/2000/svg'
-          width='10'
-          height='10'
-          viewBox='0 0 14 14'
-          fill='none'
+        {/* Main button */}
+        <button
+          onClick={onClickButton}
+          onMouseEnter={() => setIsHovered(true)}
+          onMouseLeave={() => setIsHovered(false)}
+          className={`w-full h-full flex-shrink-0 rounded-[8px] border-[2px] bg-[#181818] flex items-center justify-center font-plus-jakarta-sans text-[10px] font-[700] edge-node transition-colors gap-[4px]`}
+          style={mainButtonStyle}
         >
-          <path d='M12 2L2 12' stroke='currentColor' strokeWidth='1.5' />
-          <path d='M12 2L8 2' stroke='currentColor' strokeWidth='1.5' />
-          <path d='M12 2L12 6' stroke='currentColor' strokeWidth='1.5' />
-          <path d='M2 12L6 12' stroke='currentColor' strokeWidth='1.5' />
-          <path d='M2 12L2 8' stroke='currentColor' strokeWidth='1.5' />
-        </svg>
-        <div className='flex flex-col items-center justify-center leading-tight text-[9px]'>
-          <span>Convert</span>
-          <span>Struct</span>
-        </div>
+          {/* Convert to Structured SVG icon */}
+          <svg width='10' height='10' viewBox='0 0 14 14' fill='none'>
+            <path d='M12 2L2 12' stroke='currentColor' strokeWidth='1.5' />
+            <path d='M12 2L8 2' stroke='currentColor' strokeWidth='1.5' />
+            <path d='M12 2L12 6' stroke='currentColor' strokeWidth='1.5' />
+            <path d='M2 12L6 12' stroke='currentColor' strokeWidth='1.5' />
+            <path d='M2 12L2 8' stroke='currentColor' strokeWidth='1.5' />
+          </svg>
+          <div className='flex flex-col items-center justify-center leading-tight text-[9px]'>
+            <span>Convert</span>
+            <span>Struct</span>
+          </div>
 
-        <Handle
-          id={`${id}-a`}
-          className='edgeSrcHandle handle-with-icon handle-top'
-          type='source'
-          position={Position.Top}
-        />
-        <Handle
-          id={`${id}-b`}
-          className='edgeSrcHandle handle-with-icon handle-right'
-          type='source'
-          position={Position.Right}
-        />
-        <Handle
-          id={`${id}-c`}
-          className='edgeSrcHandle handle-with-icon handle-bottom'
-          type='source'
-          position={Position.Bottom}
-        />
-        <Handle
-          id={`${id}-d`}
-          className='edgeSrcHandle handle-with-icon handle-left'
-          type='source'
-          position={Position.Left}
-        />
+          {/* Source Handles */}
+          <Handle
+            id={`${id}-a`}
+            className='edgeSrcHandle handle-with-icon handle-top'
+            type='source'
+            position={Position.Top}
+          />
+          <Handle
+            id={`${id}-b`}
+            className='edgeSrcHandle handle-with-icon handle-right'
+            type='source'
+            position={Position.Right}
+          />
+          <Handle
+            id={`${id}-c`}
+            className='edgeSrcHandle handle-with-icon handle-bottom'
+            type='source'
+            position={Position.Bottom}
+          />
+          <Handle
+            id={`${id}-d`}
+            className='edgeSrcHandle handle-with-icon handle-left'
+            type='source'
+            position={Position.Left}
+          />
 
-        <Handle
-          id={`${id}-a`}
-          type='target'
-          position={Position.Top}
-          style={handleStyle}
-          isConnectable={isConnectable}
-          onMouseEnter={() => setIsTargetHandleTouched(true)}
-          onMouseLeave={() => setIsTargetHandleTouched(false)}
-        />
-        <Handle
-          id={`${id}-b`}
-          type='target'
-          position={Position.Right}
-          style={handleStyle}
-          isConnectable={isConnectable}
-          onMouseEnter={() => setIsTargetHandleTouched(true)}
-          onMouseLeave={() => setIsTargetHandleTouched(false)}
-        />
-        <Handle
-          id={`${id}-c`}
-          type='target'
-          position={Position.Bottom}
-          style={handleStyle}
-          isConnectable={isConnectable}
-          onMouseEnter={() => setIsTargetHandleTouched(true)}
-          onMouseLeave={() => setIsTargetHandleTouched(false)}
-        />
-        <Handle
-          id={`${id}-d`}
-          type='target'
-          position={Position.Left}
-          style={handleStyle}
-          isConnectable={isConnectable}
-          onMouseEnter={() => setIsTargetHandleTouched(true)}
-          onMouseLeave={() => setIsTargetHandleTouched(false)}
-        />
-      </button>
+          {/* Target Handles */}
+          <Handle
+            id={`${id}-a`}
+            type='target'
+            position={Position.Top}
+            style={handleStyle}
+            isConnectable={isConnectable}
+            onMouseEnter={() => setIsTargetHandleTouched(true)}
+            onMouseLeave={() => setIsTargetHandleTouched(false)}
+          />
+          <Handle
+            id={`${id}-b`}
+            type='target'
+            position={Position.Right}
+            style={handleStyle}
+            isConnectable={isConnectable}
+            onMouseEnter={() => setIsTargetHandleTouched(true)}
+            onMouseLeave={() => setIsTargetHandleTouched(false)}
+          />
+          <Handle
+            id={`${id}-c`}
+            type='target'
+            position={Position.Bottom}
+            style={handleStyle}
+            isConnectable={isConnectable}
+            onMouseEnter={() => setIsTargetHandleTouched(true)}
+            onMouseLeave={() => setIsTargetHandleTouched(false)}
+          />
+          <Handle
+            id={`${id}-d`}
+            type='target'
+            position={Position.Left}
+            style={handleStyle}
+            isConnectable={isConnectable}
+            onMouseEnter={() => setIsTargetHandleTouched(true)}
+            onMouseLeave={() => setIsTargetHandleTouched(false)}
+          />
+        </button>
 
-      {/* Configuration Menu (integrated directly) */}
-      {isMenuOpen && (
-        <ul
-          ref={menuRef}
-          className='absolute top-[64px] text-white w-[384px] rounded-[16px] border-[1px] bg-[#1A1A1A] p-[12px] font-plus-jakarta-sans flex flex-col gap-[16px] shadow-lg'
-          style={{
-            borderColor: UI_COLORS.EDGENODE_BORDER_GREY,
-          }}
-        >
-          <li className='flex h-[28px] gap-1 items-center justify-between font-plus-jakarta-sans'>
-            <div className='flex flex-row gap-[12px]'>
-              <div className='flex flex-row gap-[8px] justify-center items-center'>
-                <div className='w-[24px] h-[24px] border-[1px] border-main-grey bg-main-black-theme rounded-[8px] flex items-center justify-center'>
-                  <svg
-                    xmlns='http://www.w3.org/2000/svg'
-                    width='14'
-                    height='14'
-                    viewBox='0 0 14 14'
-                    fill='none'
-                  >
-                    <path d='M12 2L2 12' stroke='#CDCDCD' strokeWidth='1.5' />
-                    <path d='M12 2L8 2' stroke='#CDCDCD' strokeWidth='1.5' />
-                    <path d='M12 2L12 6' stroke='#CDCDCD' strokeWidth='1.5' />
-                    <path d='M2 12L6 12' stroke='#CDCDCD' strokeWidth='1.5' />
-                    <path d='M2 12L2 8' stroke='#CDCDCD' strokeWidth='1.5' />
-                  </svg>
-                </div>
-                <div className='flex items-center justify-center text-[14px] font-semibold text-main-grey font-plus-jakarta-sans leading-normal'>
-                  Convert to Structured
+        {/* Configuration Menu */}
+        {isMenuOpen && (
+          <ul
+            ref={menuRef}
+            className='absolute top-[64px] text-white w-[384px] rounded-[16px] border-[1px] bg-[#1A1A1A] p-[12px] font-plus-jakarta-sans flex flex-col gap-[16px] shadow-lg'
+            style={{
+              borderColor: UI_COLORS.EDGENODE_BORDER_GREY,
+            }}
+          >
+            <li className='flex h-[28px] gap-1 items-center justify-between font-plus-jakarta-sans'>
+              <div className='flex flex-row gap-[12px]'>
+                <div className='flex flex-row gap-[8px] justify-center items-center'>
+                  <div className='w-[24px] h-[24px] border-[1px] border-main-grey bg-main-black-theme rounded-[8px] flex items-center justify-center'>
+                    <svg width='14' height='14' viewBox='0 0 14 14' fill='none'>
+                      <path d='M12 2L2 12' stroke='#CDCDCD' strokeWidth='1.5' />
+                      <path d='M12 2L8 2' stroke='#CDCDCD' strokeWidth='1.5' />
+                      <path d='M12 2L12 6' stroke='#CDCDCD' strokeWidth='1.5' />
+                      <path d='M2 12L6 12' stroke='#CDCDCD' strokeWidth='1.5' />
+                      <path d='M2 12L2 8' stroke='#CDCDCD' strokeWidth='1.5' />
+                    </svg>
+                  </div>
+                  <div className='flex items-center justify-center text-[14px] font-semibold text-main-grey font-plus-jakarta-sans leading-normal'>
+                    Convert to Structured
+                  </div>
                 </div>
               </div>
-            </div>
-            <div className='w-[57px] h-[26px]'>
-              <button
-                className='w-full h-full rounded-[8px] bg-[#39BC66] text-[#000] text-[12px] font-semibold font-plus-jakarta-sans flex flex-row items-center justify-center gap-[7px]'
-                onClick={onDataSubmit}
-                disabled={isLoading}
-              >
-                <span>
-                  {isLoading ? (
-                    <svg className='animate-spin h-4 w-4' viewBox='0 0 24 24'>
-                      <circle
-                        className='opacity-25'
-                        cx='12'
-                        cy='12'
-                        r='10'
-                        stroke='currentColor'
-                        strokeWidth='4'
-                      ></circle>
-                      <path
-                        className='opacity-75'
-                        fill='currentColor'
-                        d='M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 714 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z'
-                      ></path>
-                    </svg>
-                  ) : (
-                    <svg
-                      xmlns='http://www.w3.org/2000/svg'
-                      width='8'
-                      height='10'
-                      viewBox='0 0 8 10'
-                      fill='none'
-                    >
-                      <path d='M8 5L0 10V0L8 5Z' fill='black' />
-                    </svg>
-                  )}
-                </span>
-                <span>{isLoading ? '' : 'Run'}</span>
-              </button>
-            </div>
-          </li>
-
-          <li>
-            <InputOutputDisplay
-              parentId={id}
-              getNode={getNode}
-              getSourceNodeIdWithLabel={getSourceNodeIdWithLabel}
-              getTargetNodeIdWithLabel={getTargetNodeIdWithLabel}
-              supportedInputTypes={['text']}
-              supportedOutputTypes={['structured']}
-              inputNodeCategory='blocknode'
-              outputNodeCategory='blocknode'
-            />
-          </li>
-
-          {/* Mode selector menu */}
-          <li className='flex flex-col gap-2'>
-            <div className='flex items-center gap-2'>
-              <label className='text-[13px] font-semibold text-[#6D7177]'>
-                Mode
-              </label>
-              <div className='w-[5px] h-[5px] rounded-full bg-[#FF4D4D]'></div>
-            </div>
-            <div className='flex gap-2 bg-[#252525] rounded-[8px] border-[1px] border-[#6D7177]/30 hover:border-[#6D7177]/50 transition-colors'>
-              <PuppyDropdown
-                options={[
-                  INTO_DICT_TYPE,
-                  INTO_LIST_TYPE,
-                  JSON_TYPE,
-                  BY_LEN_TYPE,
-                  BY_CHAR_TYPE,
-                ]}
-                onSelect={(option: string) => {
-                  setExecMode(option);
-                }}
-                selectedValue={execMode}
-                listWidth={'200px'}
-              />
-            </div>
-          </li>
-
-          {execMode === INTO_DICT_TYPE && (
-            <li className='flex flex-col gap-2'>
-              <div className='flex items-center gap-2'>
-                <label className='text-[12px] font-medium text-[#6D7177]'>
-                  Key
-                </label>
-                <div className='w-[5px] h-[5px] rounded-full bg-[#FF4D4D]'></div>
+              <div className='w-[57px] h-[26px]'>
+                <button
+                  className='w-full h-full rounded-[8px] text-[#000] text-[12px] font-semibold font-plus-jakarta-sans flex flex-row items-center justify-center gap-[7px]'
+                  style={{
+                    backgroundColor: isLoading ? '#FFA73D' : '#39BC66',
+                  }}
+                  onClick={isLoading ? onStopExecution : onDataSubmit}
+                  disabled={false}
+                >
+                  <span>
+                    {isLoading ? (
+                      <svg width='8' height='8' viewBox='0 0 8 8' fill='none'>
+                        <rect width='8' height='8' fill='currentColor' />
+                      </svg>
+                    ) : (
+                      <svg width='8' height='10' viewBox='0 0 8 10' fill='none'>
+                        <path d='M8 5L0 10V0L8 5Z' fill='black' />
+                      </svg>
+                    )}
+                  </span>
+                  <span>{isLoading ? 'Stop' : 'Run'}</span>
+                </button>
               </div>
-              <input
-                value={wrapInto}
-                onChange={e => setWrapInto(e.target.value)}
-                type='string'
-                className='w-full h-[32px] px-3 bg-[#252525] rounded-[6px] border-[1px] border-[#6D7177]/30 
-                                            text-[#CDCDCD] text-[12px] font-medium appearance-none cursor-pointer 
-                                            hover:border-[#6D7177]/50 transition-colors'
-                autoComplete='off'
-                onMouseDownCapture={onFocus}
-                onBlur={onBlur}
+            </li>
+
+            <li>
+              <InputOutputDisplay
+                parentId={id}
+                getNode={getNode}
+                getSourceNodeIdWithLabel={getSourceNodeIdWithLabel}
+                getTargetNodeIdWithLabel={getTargetNodeIdWithLabel}
+                supportedInputTypes={['text']}
+                supportedOutputTypes={['structured']}
+                inputNodeCategory='blocknode'
+                outputNodeCategory='blocknode'
               />
             </li>
-          )}
 
-          {execMode === BY_CHAR_TYPE && (
+            {/* Mode selector menu */}
             <li className='flex flex-col gap-2'>
               <div className='flex items-center gap-2'>
-                <label className='text-[12px] font-medium text-[#6D7177]'>
-                  Delimiters
+                <label className='text-[13px] font-semibold text-[#6D7177]'>
+                  Mode
                 </label>
                 <div className='w-[5px] h-[5px] rounded-full bg-[#FF4D4D]'></div>
               </div>
-              <div className='bg-[#1E1E1E] rounded-[8px] p-[5px] border-[1px] border-[#6D7177]/30 hover:border-[#6D7177]/50 transition-colors'>
-                <div className='flex flex-wrap gap-2 items-center'>
-                  {delimiters.map((delimiter, index) => (
-                    <div
-                      key={index}
-                      className='flex items-center bg-[#252525] rounded-md 
+              <div className='flex gap-2 bg-[#252525] rounded-[8px] border-[1px] border-[#6D7177]/30 hover:border-[#6D7177]/50 transition-colors'>
+                <PuppyDropdown
+                  options={[
+                    INTO_DICT_TYPE,
+                    INTO_LIST_TYPE,
+                    JSON_TYPE,
+                    BY_LEN_TYPE,
+                    BY_CHAR_TYPE,
+                  ]}
+                  onSelect={(option: string) => {
+                    setExecMode(option);
+                  }}
+                  selectedValue={execMode}
+                  listWidth={'200px'}
+                />
+              </div>
+            </li>
+
+            {execMode === INTO_DICT_TYPE && (
+              <li className='flex flex-col gap-2'>
+                <div className='flex items-center gap-2'>
+                  <label className='text-[12px] font-medium text-[#6D7177]'>
+                    Key
+                  </label>
+                  <div className='w-[5px] h-[5px] rounded-full bg-[#FF4D4D]'></div>
+                </div>
+                <input
+                  value={wrapInto}
+                  onChange={e => setWrapInto(e.target.value)}
+                  type='string'
+                  className='w-full h-[32px] px-3 bg-[#252525] rounded-[6px] border-[1px] border-[#6D7177]/30 
+                                            text-[#CDCDCD] text-[12px] font-medium appearance-none cursor-pointer 
+                                            hover:border-[#6D7177]/50 transition-colors'
+                  autoComplete='off'
+                  onMouseDownCapture={onFocus}
+                  onBlur={onBlur}
+                />
+              </li>
+            )}
+
+            {execMode === BY_CHAR_TYPE && (
+              <li className='flex flex-col gap-2'>
+                <div className='flex items-center gap-2'>
+                  <label className='text-[12px] font-medium text-[#6D7177]'>
+                    Delimiters
+                  </label>
+                  <div className='w-[5px] h-[5px] rounded-full bg-[#FF4D4D]'></div>
+                </div>
+                <div className='bg-[#1E1E1E] rounded-[8px] p-[5px] border-[1px] border-[#6D7177]/30 hover:border-[#6D7177]/50 transition-colors'>
+                  <div className='flex flex-wrap gap-2 items-center'>
+                    {delimiters.map((delimiter, index) => (
+                      <div
+                        key={index}
+                        className='flex items-center bg-[#252525] rounded-md 
                                                         border border-[#FF9B4D]/30 hover:border-[#FF9B4D]/50 
                                                         transition-colors group'
-                    >
-                      <span className='text-[10px] text-[#FF9B4D] px-2 py-1'>
-                        {delimiterDisplay(delimiter)}
-                      </span>
-                      <button
-                        onClick={() => removeDelimiter(index)}
-                        className='text-[#6D7177] hover:text-[#ff6b6b] transition-colors 
+                      >
+                        <span className='text-[10px] text-[#FF9B4D] px-2 py-1'>
+                          {delimiterDisplay(delimiter)}
+                        </span>
+                        <button
+                          onClick={() => removeDelimiter(index)}
+                          className='text-[#6D7177] hover:text-[#ff6b6b] transition-colors 
                                                             px-1 py-1 opacity-0 group-hover:opacity-100'
+                        >
+                          <svg
+                            width='10'
+                            height='10'
+                            viewBox='0 0 24 24'
+                            fill='none'
+                            stroke='currentColor'
+                          >
+                            <line x1='18' y1='6' x2='6' y2='18'></line>
+                            <line x1='6' y1='6' x2='18' y2='18'></line>
+                          </svg>
+                        </button>
+                      </div>
+                    ))}
+
+                    {showDelimiterInput ? (
+                      <div className='h-[24px] bg-[#252525] rounded-md border border-[#FF9B4D]/30 flex items-center'>
+                        <input
+                          ref={newDelimiterRef}
+                          type='text'
+                          placeholder='Type...'
+                          className='w-[80px] h-full bg-transparent border-none outline-none px-2 text-[10px] text-[#CDCDCD]'
+                          onKeyDown={handleCustomDelimiterInput}
+                          onBlur={() => setShowDelimiterInput(false)}
+                          onFocus={onFocus}
+                        />
+                      </div>
+                    ) : (
+                      <button
+                        onClick={() => setShowDelimiterInput(true)}
+                        className='w-[24px] h-[24px] flex items-center justify-center rounded-md bg-[#252525] border border-[#6D7177]/30 text-[#6D7177] hover:border-[#6D7177]/50 hover:bg-[#252525]/80 transition-colors'
                       >
                         <svg
-                          xmlns='http://www.w3.org/2000/svg'
-                          width='10'
-                          height='10'
+                          width='12'
+                          height='12'
                           viewBox='0 0 24 24'
                           fill='none'
                           stroke='currentColor'
-                          strokeWidth='2'
-                          strokeLinecap='round'
-                          strokeLinejoin='round'
                         >
-                          <line x1='18' y1='6' x2='6' y2='18'></line>
-                          <line x1='6' y1='6' x2='18' y2='18'></line>
+                          <path
+                            d='M12 5v14M5 12h14'
+                            strokeWidth='2'
+                            strokeLinecap='round'
+                          />
                         </svg>
                       </button>
-                    </div>
-                  ))}
+                    )}
+                  </div>
+                </div>
 
-                  {showDelimiterInput ? (
-                    <div
-                      className='h-[24px] bg-[#252525] rounded-md 
-                                                        border border-[#FF9B4D]/30 
-                                                        flex items-center'
-                    >
-                      <input
-                        ref={newDelimiterRef}
-                        type='text'
-                        placeholder='Type...'
-                        className='w-[80px] h-full bg-transparent border-none outline-none px-2
-                                                            text-[10px] text-[#CDCDCD]'
-                        onKeyDown={handleCustomDelimiterInput}
-                        onBlur={() => setShowDelimiterInput(false)}
-                        onFocus={onFocus}
-                      />
-                    </div>
-                  ) : (
-                    <button
-                      onClick={() => setShowDelimiterInput(true)}
-                      className='w-[24px] h-[24px] flex items-center justify-center rounded-md
-                                                        bg-[#252525] border border-[#6D7177]/30 
-                                                        text-[#6D7177] 
-                                                        hover:border-[#6D7177]/50 hover:bg-[#252525]/80 
-                                                        transition-colors'
-                    >
-                      <svg
-                        width='12'
-                        height='12'
-                        viewBox='0 0 24 24'
-                        fill='none'
-                        stroke='currentColor'
+                <div className='mt-1'>
+                  <div className='text-[10px] text-[#6D7177] mb-2'>
+                    Common delimiters:
+                  </div>
+                  <div className='flex flex-wrap gap-2'>
+                    {commonDelimiters.map(delimiter => (
+                      <button
+                        key={delimiter.value}
+                        onClick={() => addDelimiter(delimiter.value)}
+                        className={`px-2 py-1 rounded-md text-[10px] transition-colors ${
+                          delimiters.includes(delimiter.value)
+                            ? 'bg-[#252525] text-[#CDCDCD] border border-[#6D7177]/50'
+                            : 'bg-[#1E1E1E] text-[#6D7177] border border-[#6D7177]/30 hover:bg-[#252525] hover:text-[#CDCDCD]'
+                        }`}
                       >
-                        <path
-                          d='M12 5v14M5 12h14'
-                          strokeWidth='2'
-                          strokeLinecap='round'
-                        />
-                      </svg>
-                    </button>
-                  )}
+                        {delimiter.label}
+                      </button>
+                    ))}
+                  </div>
                 </div>
-              </div>
+              </li>
+            )}
 
-              <div className='mt-1'>
-                <div className='text-[10px] text-[#6D7177] mb-2'>
-                  Common delimiters:
+            {execMode === BY_LEN_TYPE && (
+              <li className='flex flex-col gap-2'>
+                <div className='flex items-center gap-2'>
+                  <label className='text-[12px] font-medium text-[#6D7177]'>
+                    Length
+                  </label>
+                  <div className='w-[5px] h-[5px] rounded-full bg-[#FF4D4D]'></div>
                 </div>
-                <div className='flex flex-wrap gap-2'>
-                  {commonDelimiters.map(delimiter => (
-                    <button
-                      key={delimiter.value}
-                      onClick={() => addDelimiter(delimiter.value)}
-                      className={`px-2 py-1 rounded-md text-[10px] transition-colors
-                                                        ${
-                                                          delimiters.includes(
-                                                            delimiter.value
-                                                          )
-                                                            ? 'bg-[#252525] text-[#CDCDCD] border border-[#6D7177]/50'
-                                                            : 'bg-[#1E1E1E] text-[#6D7177] border border-[#6D7177]/30 hover:bg-[#252525] hover:text-[#CDCDCD]'
-                                                        }`}
-                    >
-                      {delimiter.label}
-                    </button>
-                  ))}
-                </div>
-              </div>
-            </li>
-          )}
-
-          {execMode === BY_LEN_TYPE && (
-            <li className='flex flex-col gap-2'>
-              <div className='flex items-center gap-2'>
-                <label className='text-[12px] font-medium text-[#6D7177]'>
-                  Length
-                </label>
-                <div className='w-[5px] h-[5px] rounded-full bg-[#FF4D4D]'></div>
-              </div>
-              <input
-                value={bylen}
-                onChange={e => setBylen(parseInt(e.target.value))}
-                type='number'
-                className='w-full h-[32px] px-3 bg-[#252525] rounded-[6px] border-[1px] border-[#6D7177]/30 
+                <input
+                  value={bylen}
+                  onChange={e => setBylen(parseInt(e.target.value))}
+                  type='number'
+                  className='w-full h-[32px] px-3 bg-[#252525] rounded-[6px] border-[1px] border-[#6D7177]/30 
                                             text-[#CDCDCD] text-[12px] font-medium appearance-none cursor-pointer 
                                             hover:border-[#6D7177]/50 transition-colors'
-                autoComplete='off'
-                onMouseDownCapture={onFocus}
-                onBlur={onBlur}
-              />
-            </li>
-          )}
-        </ul>
-      )}
-    </div>
-  );
-}
+                  autoComplete='off'
+                  onMouseDownCapture={onFocus}
+                  onBlur={onBlur}
+                />
+              </li>
+            )}
+          </ul>
+        )}
+      </div>
+    );
+  }
+);
 
+Convert2Structured.displayName = 'Convert2Structured';
 export default Convert2Structured;

--- a/PuppyFlow/app/components/workflow/edgesNode/edgeNodesNew/EditStructured.tsx
+++ b/PuppyFlow/app/components/workflow/edgesNode/edgeNodesNew/EditStructured.tsx
@@ -1,6 +1,12 @@
 import { Handle, Position, NodeProps, Node, useReactFlow } from '@xyflow/react';
 import { useNodesPerFlowContext } from '@/app/components/states/NodesPerFlowContext';
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import React, {
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+  useMemo,
+} from 'react';
 import InputOutputDisplay from './components/InputOutputDisplay';
 import { PuppyDropdown } from '../../../misc/PuppyDropDown';
 import { nanoid } from 'nanoid';
@@ -37,844 +43,790 @@ type PathNode = {
   children: PathNode[];
 };
 
-function EditStructured({ data, isConnectable, id }: ModifyConfigNodeProps) {
-  const {
-    isOnConnect,
-    activatedEdge,
-    isOnGeneratingNewNode,
-    clearEdgeActivation,
-    activateEdge,
-    clearAll,
-  } = useNodesPerFlowContext();
-  const [isTargetHandleTouched, setIsTargetHandleTouched] = useState(false);
-  const { getNode, getInternalNode, setNodes, setEdges } = useReactFlow();
-  const { getSourceNodeIdWithLabel, getTargetNodeIdWithLabel } =
-    useGetSourceTarget();
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const [isHovered, setIsHovered] = useState(false);
-  const [isRunButtonHovered, setIsRunButtonHovered] = useState(false);
-  const [isLoading, setIsLoading] = useState(false);
-  const menuRef = useRef<HTMLUListElement>(null);
+const EditStructured: React.FC<ModifyConfigNodeProps> = React.memo(
+  ({ data, isConnectable, id }) => {
+    const {
+      isOnConnect,
+      activatedEdge,
+      isOnGeneratingNewNode,
+      clearEdgeActivation,
+      activateEdge,
+      clearAll,
+    } = useNodesPerFlowContext();
+    const [isTargetHandleTouched, setIsTargetHandleTouched] = useState(false);
+    const { getNode, getInternalNode, setNodes, setEdges } = useReactFlow();
+    const { getSourceNodeIdWithLabel, getTargetNodeIdWithLabel } =
+      useGetSourceTarget();
+    const [isMenuOpen, setIsMenuOpen] = useState(false);
+    const [isHovered, setIsHovered] = useState(false);
+    const [isRunButtonHovered, setIsRunButtonHovered] = useState(false);
+    const [isLoading, setIsLoading] = useState(false);
+    const menuRef = useRef<HTMLUListElement>(null);
 
-  // 获取所有需要的依赖
-  const { streamResult, reportError, resetLoadingUI } = useJsonConstructUtils();
-  const { getAuthHeaders } = useAppSettings();
+    // 获取所有需要的依赖
+    const { streamResult, reportError, resetLoadingUI } =
+      useJsonConstructUtils();
+    const { getAuthHeaders } = useAppSettings();
 
-  // 常量定义
-  const MODIFY_GET_TYPE = 'get';
-  const MODIFY_DEL_TYPE = 'delete';
-  const MODIFY_REPL_TYPE = 'replace';
-  const MODIFY_GET_ALL_KEYS = 'get_keys';
-  const MODIFY_GET_ALL_VAL = 'get_values';
+    // 使用 useRef 跟踪是否已挂载
+    const hasMountedRef = useRef(false);
 
-  // 首先定义 getConfigDataa 函数，避免在使用前访问错误
-  const getConfigDataa = (): Array<{ key: string; value: string }> =>
-    (getNode(id)?.data.getConfigData as Array<{
-      key: string;
-      value: string;
-    }>) || [
-      {
-        key: 'key',
-        value: '',
-      },
-    ];
-
-  // 辅助函数 - 设置配置数据
-  const setGetConfigDataa = (
-    resolveData: (
-      data: { key: string; value: string }[]
-    ) => { key: string; value: string }[]
-  ) => {
-    setNodes(prevNodes =>
-      prevNodes.map(node => {
-        if (node.id === id) {
-          return {
-            ...node,
-            data: {
-              ...node.data,
-              getConfigData: resolveData(getConfigDataa()),
-            },
-          };
-        }
-        return node;
-      })
+    // 常量定义 - 使用 useMemo 缓存
+    const modeConstants = useMemo(
+      () => ({
+        MODIFY_GET_TYPE: 'get',
+        MODIFY_DEL_TYPE: 'delete',
+        MODIFY_REPL_TYPE: 'replace',
+        MODIFY_GET_ALL_KEYS: 'get_keys',
+        MODIFY_GET_ALL_VAL: 'get_values',
+      }),
+      []
     );
-  };
 
-  // 状态管理
-  const [execMode, setExecMode] = useState(
-    (getNode(id)?.data.type as string) || MODIFY_GET_TYPE
-  );
+    const {
+      MODIFY_GET_TYPE,
+      MODIFY_DEL_TYPE,
+      MODIFY_REPL_TYPE,
+      MODIFY_GET_ALL_KEYS,
+      MODIFY_GET_ALL_VAL,
+    } = modeConstants;
 
-  const [paramv, setParamv] = useState('');
+    // 首先定义 getConfigDataa 函数，避免在使用前访问错误 - 使用 useCallback 缓存
+    const getConfigDataa = useCallback(
+      (): Array<{ key: string; value: string }> =>
+        (getNode(id)?.data.getConfigData as Array<{
+          key: string;
+          value: string;
+        }>) || [
+          {
+            key: 'key',
+            value: '',
+          },
+        ],
+      [getNode, id]
+    );
 
-  // Add this new state for tree path structure - 现在可以安全使用 getConfigDataa
-  const [pathTree, setPathTree] = useState<PathNode[]>(() => {
-    // Try to convert existing flat path to tree structure if available
-    const existingData = getConfigDataa();
-    if (existingData && existingData.length > 0) {
-      // Create a simple tree with the existing path items
-      const rootNode: PathNode = {
-        id: nanoid(6),
-        key: existingData[0]?.key || 'key',
-        value: existingData[0]?.value || '',
-        children: [],
-      };
+    // 辅助函数 - 设置配置数据 - 使用 useCallback 缓存
+    const setGetConfigDataa = useCallback(
+      (
+        resolveData: (
+          data: { key: string; value: string }[]
+        ) => { key: string; value: string }[]
+      ) => {
+        setNodes(prevNodes =>
+          prevNodes.map(node => {
+            if (node.id === id) {
+              return {
+                ...node,
+                data: {
+                  ...node.data,
+                  getConfigData: resolveData(getConfigDataa()),
+                },
+              };
+            }
+            return node;
+          })
+        );
+      },
+      [setNodes, id, getConfigDataa]
+    );
 
-      let currentNode = rootNode;
-      for (let i = 1; i < existingData.length; i++) {
-        const item = existingData[i];
-        if (item) {
-          const newNode: PathNode = {
-            id: nanoid(6),
-            key: item.key || 'key',
-            value: item.value || '',
-            children: [],
-          };
-          currentNode.children.push(newNode);
-          currentNode = newNode;
+    // 优化状态初始化 - 使用函数形式避免重复计算
+    const [execMode, setExecMode] = useState(
+      () => (getNode(id)?.data.type as string) || MODIFY_GET_TYPE
+    );
+
+    const [paramv, setParamv] = useState('');
+
+    // Add this new state for tree path structure - 现在可以安全使用 getConfigDataa
+    const [pathTree, setPathTree] = useState<PathNode[]>(() => {
+      // Try to convert existing flat path to tree structure if available
+      const existingData = getConfigDataa();
+      if (existingData && existingData.length > 0) {
+        // Create a simple tree with the existing path items
+        const rootNode: PathNode = {
+          id: nanoid(6),
+          key: existingData[0]?.key || 'key',
+          value: existingData[0]?.value || '',
+          children: [],
+        };
+
+        let currentNode = rootNode;
+        for (let i = 1; i < existingData.length; i++) {
+          const item = existingData[i];
+          if (item) {
+            const newNode: PathNode = {
+              id: nanoid(6),
+              key: item.key || 'key',
+              value: item.value || '',
+              children: [],
+            };
+            currentNode.children.push(newNode);
+            currentNode = newNode;
+          }
         }
+
+        return [rootNode];
       }
 
-      return [rootNode];
-    }
+      // Default empty tree with one root node
+      return [
+        {
+          id: nanoid(6),
+          key: 'key',
+          value: '',
+          children: [],
+        },
+      ];
+    });
 
-    // Default empty tree with one root node
-    return [
-      {
-        id: nanoid(6),
-        key: 'key',
-        value: '',
-        children: [],
+    // 创建执行上下文 - 使用 useCallback 缓存
+    const createExecutionContext = useCallback(
+      (): RunSingleEdgeNodeContext => ({
+        getNode,
+        setNodes,
+        setEdges,
+        getSourceNodeIdWithLabel,
+        getTargetNodeIdWithLabel,
+        clearAll,
+        streamResult,
+        reportError,
+        resetLoadingUI,
+        getAuthHeaders,
+      }),
+      [
+        getNode,
+        setNodes,
+        setEdges,
+        getSourceNodeIdWithLabel,
+        getTargetNodeIdWithLabel,
+        clearAll,
+        streamResult,
+        reportError,
+        resetLoadingUI,
+        getAuthHeaders,
+      ]
+    );
+
+    // 使用执行函数的 handleDataSubmit - 使用 useCallback 缓存
+    const handleDataSubmit = useCallback(async () => {
+      if (isLoading) return;
+
+      setIsLoading(true);
+      try {
+        const context = createExecutionContext();
+        await runSingleEdgeNode({
+          parentId: id,
+          targetNodeType: 'structured',
+          context,
+          // 可以选择不提供 constructJsonData，使用默认实现
+        });
+      } catch (error) {
+        console.error('执行失败:', error);
+      } finally {
+        setIsLoading(false);
+      }
+    }, [id, isLoading, createExecutionContext]);
+
+    // 组件初始化
+    useEffect(() => {
+      hasMountedRef.current = true;
+    }, []);
+
+    useEffect(() => {
+      console.log(getInternalNode(id));
+
+      if (hasMountedRef.current && !isOnGeneratingNewNode) {
+        clearAll();
+        activateEdge(id);
+      }
+
+      return () => {
+        if (activatedEdge === id) {
+          clearEdgeActivation();
+        }
+      };
+    }, [isOnGeneratingNewNode]);
+
+    // 辅助函数 - 使用 useCallback 缓存
+    const onFocus = useCallback(() => {
+      const curRef = menuRef.current;
+      if (curRef && !curRef.classList.contains('nodrag')) {
+        curRef.classList.add('nodrag');
+      }
+    }, []);
+
+    const onBlur = useCallback(() => {
+      const curRef = menuRef.current;
+      if (curRef) {
+        curRef.classList.remove('nodrag');
+      }
+    }, []);
+
+    // 状态同步到 ReactFlow - 使用 requestAnimationFrame 延迟执行，避免在节点创建时干扰
+    useEffect(() => {
+      if (!isOnGeneratingNewNode && hasMountedRef.current) {
+        requestAnimationFrame(() => {
+          setNodes(prevNodes =>
+            prevNodes.map(node => {
+              if (node.id === id) {
+                return { ...node, data: { ...node.data, type: execMode } };
+              }
+              return node;
+            })
+          );
+        });
+      }
+    }, [execMode, isOnGeneratingNewNode]);
+
+    // Function to flatten the tree structure into a path array - 使用 useCallback 缓存
+    const flattenPathTree = useCallback(
+      (nodes: PathNode[]): { key: string; value: string }[] => {
+        const result: { key: string; value: string }[] = [];
+
+        const traverse = (node: PathNode) => {
+          result.push({ key: node.key, value: node.value });
+          if (node.children.length > 0) {
+            traverse(node.children[0]); // We only follow the first child in each level
+          }
+        };
+
+        if (nodes.length > 0) {
+          traverse(nodes[0]);
+        }
+
+        return result;
       },
-    ];
-  });
+      []
+    );
 
-  // 创建执行上下文
-  const createExecutionContext = useCallback(
-    (): RunSingleEdgeNodeContext => ({
-      getNode,
-      setNodes,
-      setEdges,
-      getSourceNodeIdWithLabel,
-      getTargetNodeIdWithLabel,
-      clearAll,
-      streamResult,
-      reportError,
-      resetLoadingUI,
-      getAuthHeaders,
-    }),
-    [
-      getNode,
-      setNodes,
-      setEdges,
-      getSourceNodeIdWithLabel,
-      getTargetNodeIdWithLabel,
-      clearAll,
-      streamResult,
-      reportError,
-      resetLoadingUI,
-      getAuthHeaders,
-    ]
-  );
+    useEffect(() => {
+      if (!isOnGeneratingNewNode && hasMountedRef.current) {
+        requestAnimationFrame(() => {
+          const flatPath = flattenPathTree(pathTree);
+          setGetConfigDataa(() => flatPath);
+        });
+      }
+    }, [pathTree, flattenPathTree, setGetConfigDataa, isOnGeneratingNewNode]);
 
-  // 使用执行函数的 handleDataSubmit
-  const handleDataSubmit = useCallback(async () => {
-    if (isLoading) return;
+    const onClickButton = useCallback(() => {
+      setIsMenuOpen(!isMenuOpen);
 
-    setIsLoading(true);
-    try {
-      const context = createExecutionContext();
-      await runSingleEdgeNode({
-        parentId: id,
-        targetNodeType: 'structured',
-        context,
-        // 可以选择不提供 constructJsonData，使用默认实现
-      });
-    } catch (error) {
-      console.error('执行失败:', error);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [id, isLoading, createExecutionContext]);
-
-  useEffect(() => {
-    console.log(getInternalNode(id));
-
-    if (!isOnGeneratingNewNode) {
-      clearAll();
-      activateEdge(id);
-    }
-
-    return () => {
+      if (isOnGeneratingNewNode) return;
       if (activatedEdge === id) {
         clearEdgeActivation();
+      } else {
+        clearAll();
+        activateEdge(id);
       }
-    };
-  }, []);
+    }, [
+      isMenuOpen,
+      isOnGeneratingNewNode,
+      activatedEdge,
+      id,
+      clearEdgeActivation,
+      clearAll,
+      activateEdge,
+    ]);
 
-  // 辅助函数
-  const onFocus = () => {
-    const curRef = menuRef.current;
-    if (curRef && !curRef.classList.contains('nodrag')) {
-      curRef.classList.add('nodrag');
-    }
-  };
+    // 修改提交函数，增加数据保存逻辑 - 使用 useCallback 缓存
+    const onDataSubmit = useCallback(() => {
+      const flatPath = flattenPathTree(pathTree);
 
-  const onBlur = () => {
-    const curRef = menuRef.current;
-    if (curRef) {
-      curRef.classList.remove('nodrag');
-    }
-  };
+      // 先保存当前状态到节点数据
+      setNodes(prevNodes =>
+        prevNodes.map(node => {
+          if (node.id === id) {
+            return {
+              ...node,
+              data: {
+                ...node.data,
+                type: execMode,
+                getConfigData: flatPath,
+                paramv: paramv,
+              },
+            };
+          }
+          return node;
+        })
+      );
 
-  // 状态同步到 ReactFlow
-  useEffect(() => {
-    setNodes(prevNodes =>
-      prevNodes.map(node => {
-        if (node.id === id) {
-          return { ...node, data: { ...node.data, type: execMode } };
-        }
-        return node;
-      })
-    );
-  }, [execMode]);
+      // 然后调用通用处理函数
+      handleDataSubmit();
+    }, [
+      flattenPathTree,
+      pathTree,
+      setNodes,
+      id,
+      execMode,
+      paramv,
+      handleDataSubmit,
+    ]);
 
-  useEffect(() => {
-    const flatPath = flattenPathTree(pathTree);
-    setGetConfigDataa(() => flatPath);
-  }, [pathTree]);
-
-  const onClickButton = () => {
-    setIsMenuOpen(!isMenuOpen);
-
-    if (isOnGeneratingNewNode) return;
-    if (activatedEdge === id) {
-      clearEdgeActivation();
-    } else {
-      clearAll();
-      activateEdge(id);
-    }
-  };
-
-  // 修改提交函数，增加数据保存逻辑
-  const onDataSubmit = () => {
-    const flatPath = flattenPathTree(pathTree);
-
-    // 先保存当前状态到节点数据
-    setNodes(prevNodes =>
-      prevNodes.map(node => {
-        if (node.id === id) {
-          return {
-            ...node,
-            data: {
-              ...node.data,
-              type: execMode,
-              getConfigData: flatPath,
-              paramv: paramv,
-            },
-          };
-        }
-        return node;
-      })
+    // 在组件顶部定义共享样式 - 使用 useMemo 缓存
+    const handleStyle = useMemo(
+      () => ({
+        position: 'absolute' as const,
+        width: 'calc(100%)',
+        height: 'calc(100%)',
+        top: '0',
+        left: '0',
+        borderRadius: '0',
+        transform: 'translate(0px, 0px)',
+        background: 'transparent',
+        border: '3px solid transparent',
+        zIndex: !isOnConnect ? '-1' : '1',
+      }),
+      [isOnConnect]
     );
 
-    // 然后调用通用处理函数
-    handleDataSubmit();
-  };
+    // 添加停止函数 - 使用 useCallback 缓存
+    const onStopExecution = useCallback(() => {
+      console.log('Stop execution');
+      setIsLoading(false);
+    }, []);
 
-  // 在组件顶部定义共享样式
-  const handleStyle = {
-    position: 'absolute' as const,
-    width: 'calc(100%)',
-    height: 'calc(100%)',
-    top: '0',
-    left: '0',
-    borderRadius: '0',
-    transform: 'translate(0px, 0px)',
-    background: 'transparent',
-    border: '3px solid transparent',
-    zIndex: !isOnConnect ? '-1' : '1',
-  };
+    // 缓存按钮样式 - 使用 useMemo 缓存
+    const runButtonStyle = useMemo(
+      () => ({
+        backgroundColor: isRunButtonHovered
+          ? isLoading
+            ? '#FFA73D'
+            : '#39BC66'
+          : '#181818',
+        borderColor: isRunButtonHovered
+          ? isLoading
+            ? '#FFA73D'
+            : '#39BC66'
+          : UI_COLORS.EDGENODE_BORDER_GREY,
+        color: isRunButtonHovered ? '#000' : UI_COLORS.EDGENODE_BORDER_GREY,
+      }),
+      [isRunButtonHovered, isLoading]
+    );
 
-  // Function to flatten the tree structure into a path array
-  const flattenPathTree = (
-    nodes: PathNode[]
-  ): { key: string; value: string }[] => {
-    const result: { key: string; value: string }[] = [];
-
-    const traverse = (node: PathNode) => {
-      result.push({ key: node.key, value: node.value });
-      if (node.children.length > 0) {
-        traverse(node.children[0]); // We only follow the first child in each level
-      }
-    };
-
-    if (nodes.length > 0) {
-      traverse(nodes[0]);
-    }
-
-    return result;
-  };
-
-  return (
-    <div className='p-[3px] w-[80px] h-[48px] relative'>
-      {/* Invisible hover area between node and run button */}
-      <div
-        className='absolute -top-[40px] left-0 w-full h-[40px]'
-        onMouseEnter={() => setIsHovered(true)}
-        onMouseLeave={() => setIsHovered(false)}
-      />
-
-      {/* Run button positioned above the node - show when node or run button is hovered */}
-      <button
-        className={`absolute -top-[40px] left-1/2 transform -translate-x-1/2 w-[57px] h-[24px] rounded-[6px] border-[1px] text-[10px] font-[600] font-plus-jakarta-sans flex flex-row items-center justify-center gap-[4px] transition-all duration-200 ${
-          isHovered || isRunButtonHovered ? 'opacity-100' : 'opacity-0'
-        }`}
-        style={{
-          backgroundColor: isRunButtonHovered ? '#39BC66' : '#181818',
-          borderColor: isRunButtonHovered
-            ? '#39BC66'
-            : UI_COLORS.EDGENODE_BORDER_GREY,
-          color: isRunButtonHovered ? '#000' : UI_COLORS.EDGENODE_BORDER_GREY,
-        }}
-        onClick={onDataSubmit}
-        disabled={isLoading}
-        onMouseEnter={() => setIsRunButtonHovered(true)}
-        onMouseLeave={() => setIsRunButtonHovered(false)}
-      >
-        <span>
-          {isLoading ? (
-            <svg className='animate-spin h-3 w-3' viewBox='0 0 24 24'>
-              <circle
-                className='opacity-25'
-                cx='12'
-                cy='12'
-                r='10'
-                stroke='currentColor'
-                strokeWidth='4'
-              ></circle>
-              <path
-                className='opacity-75'
-                fill='currentColor'
-                d='M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 714 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z'
-              ></path>
-            </svg>
-          ) : (
-            <svg
-              xmlns='http://www.w3.org/2000/svg'
-              width='6'
-              height='8'
-              viewBox='0 0 8 10'
-              fill='none'
-            >
-              <path d='M8 5L0 10V0L8 5Z' fill='currentColor' />
-            </svg>
-          )}
-        </span>
-        <span>{isLoading ? '' : 'Run'}</span>
-      </button>
-
-      <button
-        onClick={onClickButton}
-        onMouseEnter={() => setIsHovered(true)}
-        onMouseLeave={() => setIsHovered(false)}
-        className={`w-full h-full flex-shrink-0 rounded-[8px] border-[2px] bg-[#181818] flex items-center justify-center font-plus-jakarta-sans text-[10px] font-[700] edge-node transition-colors gap-[4px]`}
-        style={{
-          borderColor: isHovered
+    const mainButtonStyle = useMemo(
+      () => ({
+        borderColor: isLoading
+          ? '#FFA73D'
+          : isHovered
             ? UI_COLORS.LINE_ACTIVE
             : UI_COLORS.EDGENODE_BORDER_GREY,
-          color: isHovered
+        color: isLoading
+          ? '#FFA73D'
+          : isHovered
             ? UI_COLORS.LINE_ACTIVE
             : UI_COLORS.EDGENODE_BORDER_GREY,
-        }}
-      >
-        {/* Edit Structured SVG icon */}
-        <svg
-          xmlns='http://www.w3.org/2000/svg'
-          width='10'
-          height='10'
-          viewBox='0 0 14 14'
-          fill='none'
-        >
-          <path
-            d='M8.5 2.5L11.5 5.5L5 12H2V9L8.5 2.5Z'
-            stroke='currentColor'
-            strokeWidth='1.5'
-          />
-          <path
-            d='M8.5 2.5L9.5 1.5L12.5 4.5L11.5 5.5'
-            stroke='currentColor'
-            strokeWidth='1.5'
-          />
-        </svg>
-        <div className='flex flex-col items-center justify-center leading-tight text-[9px]'>
-          <span>Edit</span>
-          <span>Struct</span>
-        </div>
-
-        <Handle
-          id={`${id}-a`}
-          className='edgeSrcHandle handle-with-icon handle-top'
-          type='source'
-          position={Position.Top}
-        />
-        <Handle
-          id={`${id}-b`}
-          className='edgeSrcHandle handle-with-icon handle-right'
-          type='source'
-          position={Position.Right}
-        />
-        <Handle
-          id={`${id}-c`}
-          className='edgeSrcHandle handle-with-icon handle-bottom'
-          type='source'
-          position={Position.Bottom}
-        />
-        <Handle
-          id={`${id}-d`}
-          className='edgeSrcHandle handle-with-icon handle-left'
-          type='source'
-          position={Position.Left}
-        />
-
-        <Handle
-          id={`${id}-a`}
-          type='target'
-          position={Position.Top}
-          style={handleStyle}
-          isConnectable={isConnectable}
-          onMouseEnter={() => setIsTargetHandleTouched(true)}
-          onMouseLeave={() => setIsTargetHandleTouched(false)}
-        />
-        <Handle
-          id={`${id}-b`}
-          type='target'
-          position={Position.Right}
-          style={handleStyle}
-          isConnectable={isConnectable}
-          onMouseEnter={() => setIsTargetHandleTouched(true)}
-          onMouseLeave={() => setIsTargetHandleTouched(false)}
-        />
-        <Handle
-          id={`${id}-c`}
-          type='target'
-          position={Position.Bottom}
-          style={handleStyle}
-          isConnectable={isConnectable}
-          onMouseEnter={() => setIsTargetHandleTouched(true)}
-          onMouseLeave={() => setIsTargetHandleTouched(false)}
-        />
-        <Handle
-          id={`${id}-d`}
-          type='target'
-          position={Position.Left}
-          style={handleStyle}
-          isConnectable={isConnectable}
-          onMouseEnter={() => setIsTargetHandleTouched(true)}
-          onMouseLeave={() => setIsTargetHandleTouched(false)}
-        />
-      </button>
-
-      {/* Configuration Menu */}
-      {isMenuOpen && (
-        <ul
-          ref={menuRef}
-          className='absolute top-[64px] text-white w-[416px] rounded-[16px] border-[1px] bg-[#1A1A1A] p-[12px] font-plus-jakarta-sans flex flex-col gap-[16px] shadow-lg'
-          style={{
-            borderColor: UI_COLORS.EDGENODE_BORDER_GREY,
-          }}
-        >
-          <li className='flex h-[28px] gap-1 items-center justify-between font-plus-jakarta-sans'>
-            <div className='flex flex-row gap-[12px]'>
-              <div className='flex flex-row gap-[8px] justify-center items-center'>
-                <div className='w-[24px] h-[24px] border-[1px] border-main-grey bg-main-black-theme rounded-[8px] flex items-center justify-center'>
-                  <svg
-                    xmlns='http://www.w3.org/2000/svg'
-                    width='14'
-                    height='14'
-                    viewBox='0 0 14 14'
-                    fill='none'
-                  >
-                    <path
-                      d='M8.5 2.5L11.5 5.5L5 12H2V9L8.5 2.5Z'
-                      stroke='#CDCDCD'
-                      strokeWidth='1.5'
-                    />
-                    <path
-                      d='M8.5 2.5L9.5 1.5L12.5 4.5L11.5 5.5'
-                      stroke='#CDCDCD'
-                      strokeWidth='1.5'
-                    />
-                  </svg>
-                </div>
-                <div className='flex items-center justify-center text-[14px] font-semibold text-main-grey font-plus-jakarta-sans leading-normal'>
-                  Edit Structured
-                </div>
-              </div>
-            </div>
-            <div className='flex flex-row gap-[8px] items-center justify-center'>
-              <button
-                className='w-[57px] h-[26px] rounded-[8px] bg-[#39BC66] text-[#000] text-[12px] font-semibold font-plus-jakarta-sans flex flex-row items-center justify-center gap-[7px]'
-                onClick={onDataSubmit}
-                disabled={isLoading}
-              >
-                <span>
-                  {isLoading ? (
-                    <svg className='animate-spin h-4 w-4' viewBox='0 0 24 24'>
-                      <circle
-                        className='opacity-25'
-                        cx='12'
-                        cy='12'
-                        r='10'
-                        stroke='currentColor'
-                        strokeWidth='4'
-                      ></circle>
-                      <path
-                        className='opacity-75'
-                        fill='currentColor'
-                        d='M4 12a8 8 0 718-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 714 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z'
-                      ></path>
-                    </svg>
-                  ) : (
-                    <svg
-                      xmlns='http://www.w3.org/2000/svg'
-                      width='8'
-                      height='10'
-                      viewBox='0 0 8 10'
-                      fill='none'
-                    >
-                      <path d='M8 5L0 10V0L8 5Z' fill='black' />
-                    </svg>
-                  )}
-                </span>
-                <span>{isLoading ? '' : 'Run'}</span>
-              </button>
-            </div>
-          </li>
-
-          <li>
-            <InputOutputDisplay
-              parentId={id}
-              getNode={getNode}
-              getSourceNodeIdWithLabel={getSourceNodeIdWithLabel}
-              getTargetNodeIdWithLabel={getTargetNodeIdWithLabel}
-              supportedInputTypes={['structured']}
-              supportedOutputTypes={['structured']}
-              inputNodeCategory='blocknode'
-              outputNodeCategory='blocknode'
-            />
-          </li>
-
-          <li className='flex flex-col gap-2'>
-            <div className='flex items-center gap-2'>
-              <label className='text-[13px] font-semibold text-[#6D7177]'>
-                Mode
-              </label>
-              <div className='w-[5px] h-[5px] rounded-full bg-[#FF4D4D]'></div>
-            </div>
-            <div className='flex gap-2 bg-[#1E1E1E] rounded-[8px] border-[1px] border-[#6D7177]/30 hover:border-[#6D7177]/50 transition-colors'>
-              <PuppyDropdown
-                options={[
-                  MODIFY_GET_TYPE,
-                  MODIFY_DEL_TYPE,
-                  MODIFY_REPL_TYPE,
-                  MODIFY_GET_ALL_KEYS,
-                  MODIFY_GET_ALL_VAL,
-                ]}
-                onSelect={(option: string) => setExecMode(option)}
-                selectedValue={execMode}
-                listWidth={'200px'}
-                mapValueTodisplay={(v: string) => {
-                  if (v === MODIFY_GET_ALL_KEYS) return 'get all keys';
-                  if (v === MODIFY_GET_ALL_VAL) return 'get all values';
-                  return v;
-                }}
-              />
-            </div>
-          </li>
-
-          {!(
-            execMode === MODIFY_GET_ALL_KEYS || execMode === MODIFY_GET_ALL_VAL
-          ) && (
-            <li className='flex flex-col gap-2'>
-              <div className='flex items-center gap-2'>
-                <label className='text-[13px] font-semibold text-[#6D7177]'>
-                  Path
-                </label>
-                <div className='w-[5px] h-[5px] rounded-full bg-[#FF4D4D]'></div>
-              </div>
-              <div className='flex flex-col gap-4 p-2 bg-[#1E1E1E] rounded-[8px] border-[1px] border-[#6D7177]/30'>
-                <TreePathEditor paths={pathTree} setPaths={setPathTree} />
-              </div>
-            </li>
-          )}
-
-          {execMode === MODIFY_REPL_TYPE && (
-            <li className='flex flex-col gap-2'>
-              <div className='flex items-center gap-2'>
-                <label className='text-[12px] font-medium text-[#6D7177]'>
-                  Replace With
-                </label>
-                <div className='w-[5px] h-[5px] rounded-full bg-[#FF4D4D]'></div>
-              </div>
-              <input
-                value={paramv}
-                onChange={e => setParamv(e.target.value)}
-                type='string'
-                className='w-full h-[32px] px-3 bg-[#252525] rounded-[6px] border-[1px] border-[#6D7177]/30 
-                                        text-[#CDCDCD] text-[12px] font-medium appearance-none cursor-pointer 
-                                        hover:border-[#6D7177]/50 transition-colors'
-                autoComplete='off'
-                onFocus={onFocus}
-                onBlur={onBlur}
-              />
-            </li>
-          )}
-        </ul>
-      )}
-    </div>
-  );
-}
-
-// TreePathEditor Component
-const TreePathEditor = ({
-  paths,
-  setPaths,
-}: {
-  paths: PathNode[];
-  setPaths: React.Dispatch<React.SetStateAction<PathNode[]>>;
-}) => {
-  const addNode = (parentId: string) => {
-    setPaths(prevPaths => {
-      const newPaths = JSON.parse(JSON.stringify(prevPaths));
-      const findAndAddNode = (nodes: PathNode[]) => {
-        for (let node of nodes) {
-          if (node.id === parentId) {
-            node.children.push({
-              id: nanoid(6),
-              key: 'key',
-              value: '',
-              children: [],
-            });
-            return true;
-          }
-          if (node.children.length && findAndAddNode(node.children)) {
-            return true;
-          }
-        }
-        return false;
-      };
-      findAndAddNode(newPaths);
-      return newPaths;
-    });
-  };
-
-  const deleteNode = (nodeId: string) => {
-    setPaths(prevPaths => {
-      const newPaths = JSON.parse(JSON.stringify(prevPaths));
-      const findAndDeleteNode = (nodes: PathNode[]) => {
-        for (let i = 0; i < nodes.length; i++) {
-          if (nodes[i].id === nodeId) {
-            nodes.splice(i, 1);
-            return true;
-          }
-          if (
-            nodes[i].children.length &&
-            findAndDeleteNode(nodes[i].children)
-          ) {
-            return true;
-          }
-        }
-        return false;
-      };
-      findAndDeleteNode(newPaths);
-      return newPaths;
-    });
-  };
-
-  const updateNodeValue = (nodeId: string, value: string) => {
-    setPaths(prevPaths => {
-      const newPaths = JSON.parse(JSON.stringify(prevPaths));
-      const findAndUpdateNode = (nodes: PathNode[]) => {
-        for (let node of nodes) {
-          if (node.id === nodeId) {
-            node.value = value;
-            return true;
-          }
-          if (node.children.length && findAndUpdateNode(node.children)) {
-            return true;
-          }
-        }
-        return false;
-      };
-      findAndUpdateNode(newPaths);
-      return newPaths;
-    });
-  };
-
-  const updateNodeKey = (nodeId: string, key: string) => {
-    setPaths(prevPaths => {
-      const newPaths = JSON.parse(JSON.stringify(prevPaths));
-      const findAndUpdateNode = (nodes: PathNode[]) => {
-        for (let node of nodes) {
-          if (node.id === nodeId) {
-            node.key = key;
-            return true;
-          }
-          if (node.children.length && findAndUpdateNode(node.children)) {
-            return true;
-          }
-        }
-        return false;
-      };
-      findAndUpdateNode(newPaths);
-      return newPaths;
-    });
-  };
-
-  const renderNode = (node: PathNode, level = 0) => {
-    const isLeafNode = node.children.length === 0;
+      }),
+      [isLoading, isHovered]
+    );
 
     return (
-      <div key={node.id} className='relative group'>
-        <div className='relative' style={{ marginLeft: `${level * 32}px` }}>
-          {/* SVG connector lines for non-root nodes */}
-          {level > 0 && (
-            <svg
-              className='absolute -left-[16px] top-[-6px]'
-              width='17'
-              height='21'
-              viewBox='0 0 17 21'
-              fill='none'
-            >
-              <path
-                d='M1 0L1 20H17'
-                stroke='#6D7177'
-                strokeWidth='1'
-                strokeOpacity='0.5'
+      <div className='p-[3px] w-[80px] h-[48px] relative'>
+        {/* Invisible hover area between node and run button */}
+        <div
+          className='absolute -top-[40px] left-0 w-full h-[40px]'
+          onMouseEnter={() => setIsHovered(true)}
+          onMouseLeave={() => setIsHovered(false)}
+        />
+
+        {/* Run button positioned above the node - show when node or run button is hovered */}
+        <button
+          className={`absolute -top-[40px] left-1/2 transform -translate-x-1/2 w-[57px] h-[24px] rounded-[6px] border-[1px] text-[10px] font-[600] font-plus-jakarta-sans flex flex-row items-center justify-center gap-[4px] transition-all duration-200 ${
+            isHovered || isRunButtonHovered ? 'opacity-100' : 'opacity-0'
+          }`}
+          style={runButtonStyle}
+          onClick={isLoading ? onStopExecution : onDataSubmit}
+          disabled={false}
+          onMouseEnter={() => setIsRunButtonHovered(true)}
+          onMouseLeave={() => setIsRunButtonHovered(false)}
+        >
+          <span>
+            {isLoading ? (
+              <svg width='6' height='6' viewBox='0 0 6 6' fill='none'>
+                <rect width='6' height='6' fill='currentColor' />
+              </svg>
+            ) : (
+              <svg
+                xmlns='http://www.w3.org/2000/svg'
+                width='6'
+                height='8'
+                viewBox='0 0 8 10'
                 fill='none'
-              />
-            </svg>
-          )}
-
-          <div className='flex items-center gap-2 mb-1.5'>
-            <div className='flex-1 relative h-[32px] bg-[#252525] rounded-[6px] border-[1px] border-[#6D7177]/30 hover:border-[#6D7177]/50 transition-colors overflow-hidden'>
-              <input
-                value={node.value}
-                onChange={e => updateNodeValue(node.id, e.target.value)}
-                className='w-full h-full bg-transparent border-none outline-none pl-[72px] pr-2
-                         text-[#CDCDCD] text-[12px] font-medium appearance-none'
-                placeholder={
-                  node.key === 'num' ? 'Enter number...' : 'Enter key...'
-                }
-              />
-
-              {/* Floating type selector */}
-              <div
-                className={`absolute left-[6px] top-1/2 -translate-y-1/2 h-[20px] flex items-center 
-                           px-2 rounded-[4px] cursor-pointer transition-colors
-                           ${
-                             node.key === 'key'
-                               ? 'bg-[#2D2544] border border-[#9B6DFF]/30 hover:border-[#9B6DFF]/50 hover:bg-[#2D2544]/80'
-                               : 'bg-[#443425] border border-[#FF9B4D]/30 hover:border-[#FF9B4D]/50 hover:bg-[#443425]/80'
-                           }`}
-                onClick={() => {
-                  updateNodeKey(node.id, node.key === 'key' ? 'num' : 'key');
-                }}
               >
-                <div
-                  className={`text-[10px] font-semibold min-w-[24px] text-center
-                               ${
-                                 node.key === 'key'
-                                   ? 'text-[#9B6DFF]'
-                                   : 'text-[#FF9B4D]'
-                               }`}
-                >
-                  {node.key}
+                <path d='M8 5L0 10V0L8 5Z' fill='currentColor' />
+              </svg>
+            )}
+          </span>
+          <span>{isLoading ? 'Stop' : 'Run'}</span>
+        </button>
+
+        <button
+          onClick={onClickButton}
+          onMouseEnter={() => setIsHovered(true)}
+          onMouseLeave={() => setIsHovered(false)}
+          className={`w-full h-full flex-shrink-0 rounded-[8px] border-[2px] bg-[#181818] flex items-center justify-center font-plus-jakarta-sans text-[10px] font-[700] edge-node transition-colors gap-[4px]`}
+          style={mainButtonStyle}
+        >
+          {/* Edit Structured SVG icon */}
+          <svg
+            xmlns='http://www.w3.org/2000/svg'
+            width='10'
+            height='10'
+            viewBox='0 0 14 14'
+            fill='none'
+          >
+            <path
+              d='M8.5 2.5L11.5 5.5L5 12H2V9L8.5 2.5Z'
+              stroke='currentColor'
+              strokeWidth='1.5'
+            />
+            <path
+              d='M8.5 2.5L9.5 1.5L12.5 4.5L11.5 5.5'
+              stroke='currentColor'
+              strokeWidth='1.5'
+            />
+          </svg>
+          <div className='flex flex-col items-center justify-center leading-tight text-[9px]'>
+            <span>Edit</span>
+            <span>Struct</span>
+          </div>
+
+          <Handle
+            id={`${id}-a`}
+            className='edgeSrcHandle handle-with-icon handle-top'
+            type='source'
+            position={Position.Top}
+          />
+          <Handle
+            id={`${id}-b`}
+            className='edgeSrcHandle handle-with-icon handle-right'
+            type='source'
+            position={Position.Right}
+          />
+          <Handle
+            id={`${id}-c`}
+            className='edgeSrcHandle handle-with-icon handle-bottom'
+            type='source'
+            position={Position.Bottom}
+          />
+          <Handle
+            id={`${id}-d`}
+            className='edgeSrcHandle handle-with-icon handle-left'
+            type='source'
+            position={Position.Left}
+          />
+
+          <Handle
+            id={`${id}-a`}
+            type='target'
+            position={Position.Top}
+            style={handleStyle}
+            isConnectable={isConnectable}
+            onMouseEnter={() => setIsTargetHandleTouched(true)}
+            onMouseLeave={() => setIsTargetHandleTouched(false)}
+          />
+          <Handle
+            id={`${id}-b`}
+            type='target'
+            position={Position.Right}
+            style={handleStyle}
+            isConnectable={isConnectable}
+            onMouseEnter={() => setIsTargetHandleTouched(true)}
+            onMouseLeave={() => setIsTargetHandleTouched(false)}
+          />
+          <Handle
+            id={`${id}-c`}
+            type='target'
+            position={Position.Bottom}
+            style={handleStyle}
+            isConnectable={isConnectable}
+            onMouseEnter={() => setIsTargetHandleTouched(true)}
+            onMouseLeave={() => setIsTargetHandleTouched(false)}
+          />
+          <Handle
+            id={`${id}-d`}
+            type='target'
+            position={Position.Left}
+            style={handleStyle}
+            isConnectable={isConnectable}
+            onMouseEnter={() => setIsTargetHandleTouched(true)}
+            onMouseLeave={() => setIsTargetHandleTouched(false)}
+          />
+        </button>
+
+        {/* Configuration Menu */}
+        {isMenuOpen && (
+          <ul
+            ref={menuRef}
+            className='absolute top-[64px] text-white w-[416px] rounded-[16px] border-[1px] bg-[#1A1A1A] p-[12px] font-plus-jakarta-sans flex flex-col gap-[16px] shadow-lg'
+            style={{
+              borderColor: UI_COLORS.EDGENODE_BORDER_GREY,
+            }}
+          >
+            <li className='flex h-[28px] gap-1 items-center justify-between font-plus-jakarta-sans'>
+              <div className='flex flex-row gap-[12px]'>
+                <div className='flex flex-row gap-[8px] justify-center items-center'>
+                  <div className='w-[24px] h-[24px] border-[1px] border-main-grey bg-main-black-theme rounded-[8px] flex items-center justify-center'>
+                    <svg
+                      xmlns='http://www.w3.org/2000/svg'
+                      width='14'
+                      height='14'
+                      viewBox='0 0 14 14'
+                      fill='none'
+                    >
+                      <path
+                        d='M8.5 2.5L11.5 5.5L5 12H2V9L8.5 2.5Z'
+                        stroke='#CDCDCD'
+                        strokeWidth='1.5'
+                      />
+                      <path
+                        d='M8.5 2.5L9.5 1.5L12.5 4.5L11.5 5.5'
+                        stroke='#CDCDCD'
+                        strokeWidth='1.5'
+                      />
+                    </svg>
+                  </div>
+                  <div className='flex items-center justify-center text-[14px] font-semibold text-main-grey font-plus-jakarta-sans leading-normal'>
+                    Edit Structured
+                  </div>
                 </div>
               </div>
-            </div>
+              <div className='flex flex-row gap-[8px] items-center justify-center'>
+                <button
+                  className='w-[57px] h-[26px] rounded-[8px] text-[#000] text-[12px] font-semibold font-plus-jakarta-sans flex flex-row items-center justify-center gap-[7px]'
+                  style={{
+                    backgroundColor: isLoading ? '#FFA73D' : '#39BC66',
+                  }}
+                  onClick={isLoading ? onStopExecution : onDataSubmit}
+                  disabled={false}
+                >
+                  <span>
+                    {isLoading ? (
+                      <svg width='8' height='8' viewBox='0 0 8 8' fill='none'>
+                        <rect width='8' height='8' fill='currentColor' />
+                      </svg>
+                    ) : (
+                      <svg
+                        xmlns='http://www.w3.org/2000/svg'
+                        width='8'
+                        height='10'
+                        viewBox='0 0 8 10'
+                        fill='none'
+                      >
+                        <path d='M8 5L0 10V0L8 5Z' fill='black' />
+                      </svg>
+                    )}
+                  </span>
+                  <span>{isLoading ? 'Stop' : 'Run'}</span>
+                </button>
+              </div>
+            </li>
 
-            <button
-              onClick={() => deleteNode(node.id)}
-              className='p-0.5 w-6 h-6 flex items-center justify-center text-[#6D7177] hover:text-[#ff4d4d] transition-colors'
-            >
-              <svg
-                width='14'
-                height='14'
-                viewBox='0 0 24 24'
-                fill='none'
-                stroke='currentColor'
-              >
-                <path
-                  d='M18 6L6 18M6 6l12 12'
-                  strokeWidth='2'
-                  strokeLinecap='round'
+            {/* Input/Output display */}
+            <li>
+              <InputOutputDisplay
+                parentId={id}
+                getNode={getNode}
+                getSourceNodeIdWithLabel={getSourceNodeIdWithLabel}
+                getTargetNodeIdWithLabel={getTargetNodeIdWithLabel}
+                supportedInputTypes={['structured']}
+                supportedOutputTypes={['structured']}
+              />
+            </li>
+
+            {/* Mode Selection */}
+            <li className='flex flex-col gap-[8px]'>
+              <label className='text-[12px] font-semibold text-[#6D7177]'>
+                Mode
+              </label>
+              <div className='flex flex-row gap-[8px]'>
+                <PuppyDropdown
+                  options={[
+                    MODIFY_GET_TYPE,
+                    MODIFY_DEL_TYPE,
+                    MODIFY_REPL_TYPE,
+                    MODIFY_GET_ALL_KEYS,
+                    MODIFY_GET_ALL_VAL,
+                  ]}
+                  onSelect={(option: string) => {
+                    setExecMode(option);
+                  }}
+                  selectedValue={execMode}
+                  optionBadge={false}
+                  listWidth='200px'
+                  buttonHeight='32px'
+                  buttonBgColor='#252525'
+                  containerClassnames='w-full'
+                  showDropdownIcon={true}
                 />
-              </svg>
-            </button>
-          </div>
-        </div>
+              </div>
+            </li>
 
-        <div className='relative'>
-          {node.children.map(child => renderNode(child, level + 1))}
+            {/* Path Configuration */}
+            {(execMode === MODIFY_GET_TYPE ||
+              execMode === MODIFY_DEL_TYPE ||
+              execMode === MODIFY_REPL_TYPE) && (
+              <li className='flex flex-col gap-[8px]'>
+                <label className='text-[12px] font-semibold text-[#6D7177]'>
+                  Path
+                </label>
+                <div className='flex flex-col gap-[4px] p-[8px] bg-[#252525] rounded-[8px] border-[1px] border-[#6D7177]/30'>
+                  {pathTree.map((node, index) => (
+                    <PathTreeComponent
+                      key={node.id}
+                      node={node}
+                      onUpdate={updatedNode => {
+                        setPathTree([updatedNode]);
+                      }}
+                      onFocus={onFocus}
+                      onBlur={onBlur}
+                    />
+                  ))}
+                </div>
+              </li>
+            )}
 
-          {isLeafNode && level < 5 && (
-            <div
-              className='flex items-center'
-              style={{ marginLeft: `${level * 32 + 32}px` }}
-            >
-              <button
-                onClick={() => addNode(node.id)}
-                className='w-6 h-6 flex items-center justify-center rounded-md
-                          bg-[#252525] border-[1px] border-[#6D7177]/30
-                          text-[#6D7177]
-                          hover:border-[#6D7177]/50 hover:bg-[#1E1E1E] 
-                          transition-colors'
-              >
-                <svg width='10' height='10' viewBox='0 0 14 14'>
-                  <path
-                    d='M7 0v14M0 7h14'
-                    stroke='currentColor'
-                    strokeWidth='2'
-                  />
-                </svg>
-              </button>
-            </div>
-          )}
-        </div>
+            {/* Replace Value Input */}
+            {execMode === MODIFY_REPL_TYPE && (
+              <li className='flex flex-col gap-[8px]'>
+                <label className='text-[12px] font-semibold text-[#6D7177]'>
+                  Replace Value
+                </label>
+                <input
+                  type='text'
+                  value={paramv}
+                  onChange={e => setParamv(e.target.value)}
+                  className='w-full h-[32px] px-[12px] bg-[#252525] border-[1px] border-[#6D7177]/30 rounded-[8px] text-[#CDCDCD] text-[12px] placeholder-[#6D7177] outline-none focus:border-[#6D7177]/50'
+                  placeholder='Enter replacement value...'
+                  onFocus={onFocus}
+                  onBlur={onBlur}
+                />
+              </li>
+            )}
+          </ul>
+        )}
       </div>
     );
-  };
+  }
+);
+
+// PathTreeComponent 组件 - 使用 React.memo 优化
+const PathTreeComponent: React.FC<{
+  node: PathNode;
+  onUpdate: (node: PathNode) => void;
+  onFocus: () => void;
+  onBlur: () => void;
+}> = React.memo(({ node, onUpdate, onFocus, onBlur }) => {
+  const updateNode = useCallback(
+    (updates: Partial<PathNode>) => {
+      onUpdate({ ...node, ...updates });
+    },
+    [node, onUpdate]
+  );
+
+  const updateChild = useCallback(
+    (childIndex: number, updatedChild: PathNode) => {
+      const newChildren = [...node.children];
+      newChildren[childIndex] = updatedChild;
+      updateNode({ children: newChildren });
+    },
+    [node.children, updateNode]
+  );
+
+  const addChild = useCallback(() => {
+    const newChild: PathNode = {
+      id: nanoid(6),
+      key: 'key',
+      value: '',
+      children: [],
+    };
+    updateNode({ children: [...node.children, newChild] });
+  }, [node.children, updateNode]);
+
+  const removeChild = useCallback(
+    (childIndex: number) => {
+      const newChildren = node.children.filter((_, i) => i !== childIndex);
+      updateNode({ children: newChildren });
+    },
+    [node.children, updateNode]
+  );
 
   return (
-    <div className='flex flex-col gap-3'>
-      {paths.length === 0 ? (
+    <div className='flex flex-col gap-[4px]'>
+      <div className='flex gap-[8px] items-center'>
+        <PuppyDropdown
+          options={['key', 'num']}
+          onSelect={(option: string) => updateNode({ key: option })}
+          selectedValue={node.key}
+          optionBadge={false}
+          listWidth='80px'
+          buttonHeight='28px'
+          buttonBgColor='#1A1A1A'
+          containerClassnames='w-[80px]'
+          showDropdownIcon={true}
+        />
+        <input
+          type='text'
+          value={node.value}
+          onChange={e => updateNode({ value: e.target.value })}
+          className='flex-1 h-[28px] px-[8px] bg-[#1A1A1A] border-[1px] border-[#6D7177]/30 rounded-[6px] text-[#CDCDCD] text-[11px] placeholder-[#6D7177] outline-none focus:border-[#6D7177]/50'
+          placeholder={node.key === 'key' ? 'Enter key...' : 'Enter index...'}
+          onFocus={onFocus}
+          onBlur={onBlur}
+        />
         <button
-          onClick={() =>
-            setPaths([{ id: nanoid(6), key: 'key', value: '', children: [] }])
-          }
-          className='w-full h-[32px] flex items-center justify-center gap-2 rounded-[6px] 
-                   border border-[#6D7177]/30 bg-[#252525] text-[#CDCDCD] text-[12px] font-medium 
-                   hover:border-[#6D7177]/50 hover:bg-[#1E1E1E] transition-colors'
+          onClick={addChild}
+          className='w-[28px] h-[28px] flex items-center justify-center text-[#6D7177] hover:text-[#CDCDCD] border border-[#6D7177]/30 hover:border-[#6D7177]/50 rounded-[6px] bg-[#1A1A1A] hover:bg-[#252525] transition-colors'
         >
           <svg
             width='12'
             height='12'
             viewBox='0 0 24 24'
             fill='none'
-            stroke='#6D7177'
+            stroke='currentColor'
           >
             <path d='M12 5v14M5 12h14' strokeWidth='2' strokeLinecap='round' />
           </svg>
-          Create Root Node
         </button>
-      ) : (
-        paths.map(path => renderNode(path))
+        {node.children.length > 0 && (
+          <button
+            onClick={() => removeChild(node.children.length - 1)}
+            className='w-[28px] h-[28px] flex items-center justify-center text-[#6D7177] hover:text-[#ff4d4d] border border-[#6D7177]/30 hover:border-[#ff4d4d]/50 rounded-[6px] bg-[#1A1A1A] hover:bg-[#252525] transition-colors'
+          >
+            <svg
+              width='12'
+              height='12'
+              viewBox='0 0 24 24'
+              fill='none'
+              stroke='currentColor'
+            >
+              <path
+                d='M18 6L6 18M6 6l12 12'
+                strokeWidth='2'
+                strokeLinecap='round'
+              />
+            </svg>
+          </button>
+        )}
+      </div>
+      {node.children.length > 0 && (
+        <div className='ml-[16px] border-l-[1px] border-[#6D7177]/30 pl-[8px]'>
+          {node.children.map((child, index) => (
+            <PathTreeComponent
+              key={child.id}
+              node={child}
+              onUpdate={updatedChild => updateChild(index, updatedChild)}
+              onFocus={onFocus}
+              onBlur={onBlur}
+            />
+          ))}
+        </div>
       )}
     </div>
   );
-};
+});
+
+PathTreeComponent.displayName = 'PathTreeComponent';
+EditStructured.displayName = 'EditStructured';
 
 export default EditStructured;

--- a/PuppyFlow/app/components/workflow/edgesNode/edgeNodesNew/EditText.tsx
+++ b/PuppyFlow/app/components/workflow/edgesNode/edgeNodesNew/EditText.tsx
@@ -1,6 +1,12 @@
 import { Handle, Position, NodeProps, Node, useReactFlow } from '@xyflow/react';
 import { useNodesPerFlowContext } from '@/app/components/states/NodesPerFlowContext';
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import React, {
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+  useMemo,
+} from 'react';
 import InputOutputDisplay from './components/InputOutputDisplay';
 import { PuppyDropdown } from '../../../misc/PuppyDropDown';
 import { UI_COLORS } from '@/app/utils/colors';
@@ -30,506 +36,537 @@ export type ModifyConfigNodeData = {
 
 type ModifyConfigNodeProps = NodeProps<Node<ModifyConfigNodeData>>;
 
-function EditText({ data, isConnectable, id }: ModifyConfigNodeProps) {
-  const {
-    isOnConnect,
-    activatedEdge,
-    isOnGeneratingNewNode,
-    clearEdgeActivation,
-    activateEdge,
-    clearAll,
-  } = useNodesPerFlowContext();
-  const [isTargetHandleTouched, setIsTargetHandleTouched] = useState(false);
-  const { getNode, getInternalNode, setNodes, setEdges } = useReactFlow();
-  const { getSourceNodeIdWithLabel, getTargetNodeIdWithLabel } =
-    useGetSourceTarget();
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const [isLoading, setIsLoading] = useState(false);
-  const menuRef = useRef<HTMLUListElement>(null);
-  const [isHovered, setIsHovered] = useState(false);
-  const [isRunButtonHovered, setIsRunButtonHovered] = useState(false);
-
-  // 获取所有需要的依赖
-  const { streamResult, reportError, resetLoadingUI } = useJsonConstructUtils();
-  const { getAuthHeaders } = useAppSettings();
-
-  // 常量定义
-  const RET_ALL = 'return all';
-  const RET_FN = 'return first n';
-  const RET_LN = 'return last n';
-  const EX_FN = 'exclude first n';
-  const EX_LN = 'exclude last n';
-
-  // 状态管理
-  const [textContent, setTextContent] = useState<string>(
-    (getNode(id)?.data as ModifyConfigNodeData)?.content || ''
-  );
-
-  // 加载配置值
-  const [retMode, setRetMode] = useState<string>(
-    typeof (getNode(id)?.data?.extra_configs as any)?.retMode === 'string'
-      ? (getNode(id)?.data?.extra_configs as any)?.retMode
-      : RET_ALL
-  );
-
-  const [configNum, setConfigNum] = useState<number>(
-    typeof (getNode(id)?.data?.extra_configs as any)?.configNum === 'number'
-      ? (getNode(id)?.data?.extra_configs as any)?.configNum
-      : 100
-  );
-
-  // 创建执行上下文
-  const createExecutionContext = useCallback(
-    (): RunSingleEdgeNodeContext => ({
-      getNode,
-      setNodes,
-      setEdges,
-      getSourceNodeIdWithLabel,
-      getTargetNodeIdWithLabel,
+const EditText: React.FC<ModifyConfigNodeProps> = React.memo(
+  ({ data, isConnectable, id }) => {
+    const {
+      isOnConnect,
+      activatedEdge,
+      isOnGeneratingNewNode,
+      clearEdgeActivation,
+      activateEdge,
       clearAll,
-      streamResult,
-      reportError,
-      resetLoadingUI,
-      getAuthHeaders,
-    }),
-    [
-      getNode,
-      setNodes,
-      setEdges,
-      getSourceNodeIdWithLabel,
-      getTargetNodeIdWithLabel,
-      clearAll,
-      streamResult,
-      reportError,
-      resetLoadingUI,
-      getAuthHeaders,
-    ]
-  );
+    } = useNodesPerFlowContext();
+    const [isTargetHandleTouched, setIsTargetHandleTouched] = useState(false);
+    const { getNode, getInternalNode, setNodes, setEdges } = useReactFlow();
+    const { getSourceNodeIdWithLabel, getTargetNodeIdWithLabel } =
+      useGetSourceTarget();
+    const [isMenuOpen, setIsMenuOpen] = useState(false);
+    const [isLoading, setIsLoading] = useState(false);
+    const menuRef = useRef<HTMLUListElement>(null);
+    const [isHovered, setIsHovered] = useState(false);
+    const [isRunButtonHovered, setIsRunButtonHovered] = useState(false);
 
-  // 使用执行函数的 handleDataSubmit
-  const handleDataSubmit = useCallback(async () => {
-    if (isLoading) return;
+    // 获取所有需要的依赖
+    const { streamResult, reportError, resetLoadingUI } =
+      useJsonConstructUtils();
+    const { getAuthHeaders } = useAppSettings();
 
-    setIsLoading(true);
-    try {
-      const context = createExecutionContext();
-      await runSingleEdgeNode({
-        parentId: id,
-        targetNodeType: 'text',
-        context,
-        // 可以选择不提供 constructJsonData，使用默认实现
-      });
-    } catch (error) {
-      console.error('执行失败:', error);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [id, isLoading, createExecutionContext]);
+    // 使用 useRef 跟踪是否已挂载
+    const hasMountedRef = useRef(false);
 
-  useEffect(() => {
-    console.log(getInternalNode(id));
+    // 常量定义 - 使用 useMemo 缓存
+    const modeConstants = useMemo(
+      () => ({
+        RET_ALL: 'return all',
+        RET_FN: 'return first n',
+        RET_LN: 'return last n',
+        EX_FN: 'exclude first n',
+        EX_LN: 'exclude last n',
+      }),
+      []
+    );
 
-    if (!isOnGeneratingNewNode) {
-      clearAll();
-      activateEdge(id);
-    }
+    const { RET_ALL, RET_FN, RET_LN, EX_FN, EX_LN } = modeConstants;
 
-    return () => {
+    // 优化状态初始化 - 使用函数形式避免重复计算
+    const [textContent, setTextContent] = useState(
+      () => (getNode(id)?.data as ModifyConfigNodeData)?.content || ''
+    );
+
+    const [retMode, setRetMode] = useState(() =>
+      typeof (getNode(id)?.data?.extra_configs as any)?.retMode === 'string'
+        ? (getNode(id)?.data?.extra_configs as any)?.retMode
+        : RET_ALL
+    );
+
+    const [configNum, setConfigNum] = useState<number>(() =>
+      typeof (getNode(id)?.data?.extra_configs as any)?.configNum === 'number'
+        ? (getNode(id)?.data?.extra_configs as any)?.configNum
+        : 100
+    );
+
+    // 创建执行上下文 - 使用 useCallback 缓存
+    const createExecutionContext = useCallback(
+      (): RunSingleEdgeNodeContext => ({
+        getNode,
+        setNodes,
+        setEdges,
+        getSourceNodeIdWithLabel,
+        getTargetNodeIdWithLabel,
+        clearAll,
+        streamResult,
+        reportError,
+        resetLoadingUI,
+        getAuthHeaders,
+      }),
+      [
+        getNode,
+        setNodes,
+        setEdges,
+        getSourceNodeIdWithLabel,
+        getTargetNodeIdWithLabel,
+        clearAll,
+        streamResult,
+        reportError,
+        resetLoadingUI,
+        getAuthHeaders,
+      ]
+    );
+
+    // 使用执行函数的 handleDataSubmit - 使用 useCallback 缓存
+    const handleDataSubmit = useCallback(async () => {
+      if (isLoading) return;
+
+      setIsLoading(true);
+      try {
+        const context = createExecutionContext();
+        await runSingleEdgeNode({
+          parentId: id,
+          targetNodeType: 'text',
+          context,
+        });
+      } catch (error) {
+        console.error('执行失败:', error);
+      } finally {
+        setIsLoading(false);
+      }
+    }, [id, isLoading, createExecutionContext]);
+
+    // 辅助函数 - 使用 useCallback 缓存
+    const onFocus = useCallback(() => {
+      const curRef = menuRef.current;
+      if (curRef && !curRef.classList.contains('nodrag')) {
+        curRef.classList.add('nodrag');
+      }
+    }, []);
+
+    const onBlur = useCallback(() => {
+      const curRef = menuRef.current;
+      if (curRef) {
+        curRef.classList.remove('nodrag');
+      }
+    }, []);
+
+    // 状态同步逻辑 - 使用 requestAnimationFrame 延迟执行，避免在节点创建时干扰
+    useEffect(() => {
+      if (!isOnGeneratingNewNode && hasMountedRef.current) {
+        requestAnimationFrame(() => {
+          const node = getNode(id);
+          if (node) {
+            setNodes(prevNodes =>
+              prevNodes.map(n => {
+                if (n.id === id) {
+                  // 确保 n.data 存在并且是对象类型
+                  const nodeData =
+                    typeof n.data === 'object' && n.data !== null ? n.data : {};
+
+                  // 确保 extra_configs 存在并且是对象类型
+                  const existingExtraConfigs =
+                    typeof nodeData.extra_configs === 'object' &&
+                    nodeData.extra_configs !== null
+                      ? nodeData.extra_configs
+                      : {};
+
+                  return {
+                    ...n,
+                    data: {
+                      ...nodeData,
+                      content: textContent,
+                      extra_configs: {
+                        ...existingExtraConfigs,
+                        retMode: retMode,
+                        configNum: configNum,
+                      },
+                    },
+                  };
+                }
+                return n;
+              })
+            );
+          }
+        });
+      }
+    }, [textContent, retMode, configNum, isOnGeneratingNewNode]);
+
+    // UI 交互函数 - 使用 useCallback 缓存
+    const onClickButton = useCallback(() => {
+      setIsMenuOpen(!isMenuOpen);
+
+      if (isOnGeneratingNewNode) return;
       if (activatedEdge === id) {
         clearEdgeActivation();
+      } else {
+        clearAll();
+        activateEdge(id);
       }
-    };
-  }, []);
+    }, [
+      isMenuOpen,
+      isOnGeneratingNewNode,
+      activatedEdge,
+      id,
+      clearEdgeActivation,
+      clearAll,
+      activateEdge,
+    ]);
 
-  // 辅助函数
-  const onFocus = () => {
-    const curRef = menuRef.current;
-    if (curRef && !curRef.classList.contains('nodrag')) {
-      curRef.classList.add('nodrag');
-    }
-  };
+    // 执行函数 - 使用 useCallback 缓存
+    const onDataSubmit = useCallback(() => {
+      handleDataSubmit();
+    }, [handleDataSubmit]);
 
-  const onBlur = () => {
-    const curRef = menuRef.current;
-    if (curRef) {
-      curRef.classList.remove('nodrag');
-    }
-  };
+    // 添加停止函数 - 使用 useCallback 缓存
+    const onStopExecution = useCallback(() => {
+      console.log('Stop execution');
+      setIsLoading(false);
+    }, []);
 
-  // 状态同步到 ReactFlow
-  useEffect(() => {
-    setNodes(prevNodes =>
-      prevNodes.map(node => {
-        if (node.id === id) {
-          // 确保 node.data 存在并且是对象类型
-          const nodeData =
-            typeof node.data === 'object' && node.data !== null
-              ? node.data
-              : {};
-
-          // 确保 extra_configs 存在并且是对象类型
-          const existingExtraConfigs =
-            typeof nodeData.extra_configs === 'object' &&
-            nodeData.extra_configs !== null
-              ? nodeData.extra_configs
-              : {};
-
-          return {
-            ...node,
-            data: {
-              ...nodeData,
-              content: textContent,
-              extra_configs: {
-                ...existingExtraConfigs,
-                retMode: retMode,
-                configNum: configNum,
-              },
-            },
-          };
-        }
-        return node;
-      })
+    // 在组件顶部定义共享样式 - 使用 useMemo 缓存
+    const handleStyle = useMemo(
+      () => ({
+        position: 'absolute' as const,
+        width: 'calc(100%)',
+        height: 'calc(100%)',
+        top: '0',
+        left: '0',
+        borderRadius: '0',
+        transform: 'translate(0px, 0px)',
+        background: 'transparent',
+        border: '3px solid transparent',
+        zIndex: !isOnConnect ? '-1' : '1',
+      }),
+      [isOnConnect]
     );
-  }, [id, setNodes, textContent, retMode, configNum]);
 
-  const onClickButton = () => {
-    setIsMenuOpen(!isMenuOpen);
+    // 缓存按钮样式 - 使用 useMemo 缓存
+    const runButtonStyle = useMemo(
+      () => ({
+        backgroundColor: isRunButtonHovered
+          ? isLoading
+            ? '#FFA73D'
+            : '#39BC66'
+          : '#181818',
+        borderColor: isRunButtonHovered
+          ? isLoading
+            ? '#FFA73D'
+            : '#39BC66'
+          : UI_COLORS.EDGENODE_BORDER_GREY,
+        color: isRunButtonHovered ? '#000' : UI_COLORS.EDGENODE_BORDER_GREY,
+      }),
+      [isRunButtonHovered, isLoading]
+    );
 
-    if (isOnGeneratingNewNode) return;
-    if (activatedEdge === id) {
-      clearEdgeActivation();
-    } else {
-      clearAll();
-      activateEdge(id);
-    }
-  };
-
-  // 执行函数
-  const onDataSubmit = () => {
-    handleDataSubmit();
-  };
-
-  // 在组件顶部定义共享样式
-  const handleStyle = {
-    position: 'absolute' as const,
-    width: 'calc(100%)',
-    height: 'calc(100%)',
-    top: '0',
-    left: '0',
-    borderRadius: '0',
-    transform: 'translate(0px, 0px)',
-    background: 'transparent',
-    border: '3px solid transparent',
-    zIndex: !isOnConnect ? '-1' : '1',
-  };
-
-  return (
-    <div className='p-[3px] w-[80px] h-[48px] relative'>
-      {/* Invisible hover area between node and run button */}
-      <div
-        className='absolute -top-[40px] left-0 w-full h-[40px]'
-        onMouseEnter={() => setIsHovered(true)}
-        onMouseLeave={() => setIsHovered(false)}
-      />
-
-      {/* Run button positioned above the node - show when node or run button is hovered */}
-      <button
-        className={`absolute -top-[40px] left-1/2 transform -translate-x-1/2 w-[57px] h-[24px] rounded-[6px] border-[1px] text-[10px] font-[600] font-plus-jakarta-sans flex flex-row items-center justify-center gap-[4px] transition-all duration-200 ${
-          isHovered || isRunButtonHovered ? 'opacity-100' : 'opacity-0'
-        }`}
-        style={{
-          backgroundColor: isRunButtonHovered ? '#39BC66' : '#181818',
-          borderColor: isRunButtonHovered
-            ? '#39BC66'
-            : UI_COLORS.EDGENODE_BORDER_GREY,
-          color: isRunButtonHovered ? '#000' : UI_COLORS.EDGENODE_BORDER_GREY,
-        }}
-        onClick={onDataSubmit}
-        disabled={isLoading}
-        onMouseEnter={() => setIsRunButtonHovered(true)}
-        onMouseLeave={() => setIsRunButtonHovered(false)}
-      >
-        <span>
-          {isLoading ? (
-            <svg className='animate-spin h-3 w-3' viewBox='0 0 24 24'>
-              <circle
-                className='opacity-25'
-                cx='12'
-                cy='12'
-                r='10'
-                stroke='currentColor'
-                strokeWidth='4'
-              ></circle>
-              <path
-                className='opacity-75'
-                fill='currentColor'
-                d='M4 12a8 8 0 818-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 714 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z'
-              ></path>
-            </svg>
-          ) : (
-            <svg
-              xmlns='http://www.w3.org/2000/svg'
-              width='6'
-              height='8'
-              viewBox='0 0 8 10'
-              fill='none'
-            >
-              <path d='M8 5L0 10V0L8 5Z' fill='currentColor' />
-            </svg>
-          )}
-        </span>
-        <span>{isLoading ? '' : 'Run'}</span>
-      </button>
-
-      <button
-        onClick={onClickButton}
-        onMouseEnter={() => setIsHovered(true)}
-        onMouseLeave={() => setIsHovered(false)}
-        className={`w-full h-full flex-shrink-0 rounded-[8px] border-[2px] bg-[#181818] flex items-center justify-center font-plus-jakarta-sans text-[10px] font-[700] edge-node transition-colors gap-[4px]`}
-        style={{
-          borderColor: isHovered
+    const mainButtonStyle = useMemo(
+      () => ({
+        borderColor: isLoading
+          ? '#FFA73D'
+          : isHovered
             ? UI_COLORS.LINE_ACTIVE
             : UI_COLORS.EDGENODE_BORDER_GREY,
-          color: isHovered
+        color: isLoading
+          ? '#FFA73D'
+          : isHovered
             ? UI_COLORS.LINE_ACTIVE
             : UI_COLORS.EDGENODE_BORDER_GREY,
-        }}
-      >
-        {/* Edit Text SVG icon */}
-        <svg
-          xmlns='http://www.w3.org/2000/svg'
-          width='10'
-          height='10'
-          viewBox='0 0 12 12'
-          fill='none'
+      }),
+      [isLoading, isHovered]
+    );
+
+    // 组件初始化
+    useEffect(() => {
+      hasMountedRef.current = true;
+    }, []);
+
+    useEffect(() => {
+      if (hasMountedRef.current && !isOnGeneratingNewNode) {
+        clearAll();
+        activateEdge(id);
+      }
+
+      return () => {
+        if (activatedEdge === id) {
+          clearEdgeActivation();
+        }
+      };
+    }, [isOnGeneratingNewNode]);
+
+    return (
+      <div className='p-[3px] w-[80px] h-[48px] relative'>
+        {/* Invisible hover area between node and run button */}
+        <div
+          className='absolute -top-[40px] left-0 w-full h-[40px]'
+          onMouseEnter={() => setIsHovered(true)}
+          onMouseLeave={() => setIsHovered(false)}
+        />
+
+        {/* Run button positioned above the node - show when node or run button is hovered */}
+        <button
+          className={`absolute -top-[40px] left-1/2 transform -translate-x-1/2 w-[57px] h-[24px] rounded-[6px] border-[1px] text-[10px] font-[600] font-plus-jakarta-sans flex flex-row items-center justify-center gap-[4px] transition-all duration-200 ${
+            isHovered || isRunButtonHovered ? 'opacity-100' : 'opacity-0'
+          }`}
+          style={runButtonStyle}
+          onClick={isLoading ? onStopExecution : handleDataSubmit}
+          disabled={false}
+          onMouseEnter={() => setIsRunButtonHovered(true)}
+          onMouseLeave={() => setIsRunButtonHovered(false)}
         >
-          <path d='M2 10H10' stroke='currentColor' strokeWidth='1.5' />
-          <path
-            d='M8.5 2L9.5 3L5 7.5L3 8L3.5 6L8 1.5L9 2.5'
-            stroke='currentColor'
-            strokeWidth='1.5'
+          <span>
+            {isLoading ? (
+              <svg width='6' height='6' viewBox='0 0 6 6' fill='none'>
+                <rect width='6' height='6' fill='currentColor' />
+              </svg>
+            ) : (
+              <svg width='6' height='8' viewBox='0 0 8 10' fill='none'>
+                <path d='M8 5L0 10V0L8 5Z' fill='currentColor' />
+              </svg>
+            )}
+          </span>
+          <span>{isLoading ? 'Stop' : 'Run'}</span>
+        </button>
+
+        {/* Main button */}
+        <button
+          onClick={onClickButton}
+          onMouseEnter={() => setIsHovered(true)}
+          onMouseLeave={() => setIsHovered(false)}
+          className={`w-full h-full flex-shrink-0 rounded-[8px] border-[2px] bg-[#181818] flex items-center justify-center font-plus-jakarta-sans text-[10px] font-[700] edge-node transition-colors gap-[4px]`}
+          style={mainButtonStyle}
+        >
+          {/* Edit Text SVG icon */}
+          <svg
+            xmlns='http://www.w3.org/2000/svg'
+            width='10'
+            height='10'
+            viewBox='0 0 12 12'
+            fill='none'
+          >
+            <path d='M2 10H10' stroke='currentColor' strokeWidth='1.5' />
+            <path
+              d='M8.5 2L9.5 3L5 7.5L3 8L3.5 6L8 1.5L9 2.5'
+              stroke='currentColor'
+              strokeWidth='1.5'
+            />
+          </svg>
+          <div className='flex flex-col items-center justify-center leading-tight text-[9px]'>
+            <span>Edit</span>
+            <span>Text</span>
+          </div>
+
+          {/* Source Handles */}
+          <Handle
+            id={`${id}-a`}
+            className='edgeSrcHandle handle-with-icon handle-top'
+            type='source'
+            position={Position.Top}
           />
-        </svg>
-        <div className='flex flex-col items-center justify-center leading-tight text-[9px]'>
-          <span>Edit</span>
-          <span>Text</span>
-        </div>
+          <Handle
+            id={`${id}-b`}
+            className='edgeSrcHandle handle-with-icon handle-right'
+            type='source'
+            position={Position.Right}
+          />
+          <Handle
+            id={`${id}-c`}
+            className='edgeSrcHandle handle-with-icon handle-bottom'
+            type='source'
+            position={Position.Bottom}
+          />
+          <Handle
+            id={`${id}-d`}
+            className='edgeSrcHandle handle-with-icon handle-left'
+            type='source'
+            position={Position.Left}
+          />
 
-        <Handle
-          id={`${id}-a`}
-          className='edgeSrcHandle handle-with-icon handle-top'
-          type='source'
-          position={Position.Top}
-        />
-        <Handle
-          id={`${id}-b`}
-          className='edgeSrcHandle handle-with-icon handle-right'
-          type='source'
-          position={Position.Right}
-        />
-        <Handle
-          id={`${id}-c`}
-          className='edgeSrcHandle handle-with-icon handle-bottom'
-          type='source'
-          position={Position.Bottom}
-        />
-        <Handle
-          id={`${id}-d`}
-          className='edgeSrcHandle handle-with-icon handle-left'
-          type='source'
-          position={Position.Left}
-        />
+          {/* Target Handles */}
+          <Handle
+            id={`${id}-a`}
+            type='target'
+            position={Position.Top}
+            style={handleStyle}
+            isConnectable={isConnectable}
+            onMouseEnter={() => setIsTargetHandleTouched(true)}
+            onMouseLeave={() => setIsTargetHandleTouched(false)}
+          />
+          <Handle
+            id={`${id}-b`}
+            type='target'
+            position={Position.Right}
+            style={handleStyle}
+            isConnectable={isConnectable}
+            onMouseEnter={() => setIsTargetHandleTouched(true)}
+            onMouseLeave={() => setIsTargetHandleTouched(false)}
+          />
+          <Handle
+            id={`${id}-c`}
+            type='target'
+            position={Position.Bottom}
+            style={handleStyle}
+            isConnectable={isConnectable}
+            onMouseEnter={() => setIsTargetHandleTouched(true)}
+            onMouseLeave={() => setIsTargetHandleTouched(false)}
+          />
+          <Handle
+            id={`${id}-d`}
+            type='target'
+            position={Position.Left}
+            style={handleStyle}
+            isConnectable={isConnectable}
+            onMouseEnter={() => setIsTargetHandleTouched(true)}
+            onMouseLeave={() => setIsTargetHandleTouched(false)}
+          />
+        </button>
 
-        <Handle
-          id={`${id}-a`}
-          type='target'
-          position={Position.Top}
-          style={handleStyle}
-          isConnectable={isConnectable}
-          onMouseEnter={() => setIsTargetHandleTouched(true)}
-          onMouseLeave={() => setIsTargetHandleTouched(false)}
-        />
-        <Handle
-          id={`${id}-b`}
-          type='target'
-          position={Position.Right}
-          style={handleStyle}
-          isConnectable={isConnectable}
-          onMouseEnter={() => setIsTargetHandleTouched(true)}
-          onMouseLeave={() => setIsTargetHandleTouched(false)}
-        />
-        <Handle
-          id={`${id}-c`}
-          type='target'
-          position={Position.Bottom}
-          style={handleStyle}
-          isConnectable={isConnectable}
-          onMouseEnter={() => setIsTargetHandleTouched(true)}
-          onMouseLeave={() => setIsTargetHandleTouched(false)}
-        />
-        <Handle
-          id={`${id}-d`}
-          type='target'
-          position={Position.Left}
-          style={handleStyle}
-          isConnectable={isConnectable}
-          onMouseEnter={() => setIsTargetHandleTouched(true)}
-          onMouseLeave={() => setIsTargetHandleTouched(false)}
-        />
-      </button>
-
-      {/* Configuration Menu */}
-      {isMenuOpen && (
-        <ul
-          ref={menuRef}
-          className='absolute top-[64px] text-white w-[448px] rounded-[16px] border-[1px] bg-[#1A1A1A] p-[12px] font-plus-jakarta-sans flex flex-col gap-[16px] shadow-lg'
-          style={{
-            borderColor: UI_COLORS.EDGENODE_BORDER_GREY,
-          }}
-        >
-          <li className='flex h-[28px] gap-1 items-center justify-between font-plus-jakarta-sans'>
-            <div className='flex flex-row gap-[8px] justify-center items-center'>
-              <div className='w-[24px] h-[24px] border-[1px] border-main-grey bg-main-black-theme rounded-[8px] flex items-center justify-center'>
-                <svg
-                  xmlns='http://www.w3.org/2000/svg'
-                  width='12'
-                  height='12'
-                  viewBox='0 0 12 12'
-                  fill='none'
-                >
-                  <path d='M2 10H10' stroke='#CDCDCD' strokeWidth='1.5' />
-                  <path
-                    d='M8.5 2L9.5 3L5 7.5L3 8L3.5 6L8 1.5L9 2.5'
-                    stroke='#CDCDCD'
-                    strokeWidth='1.5'
-                  />
-                </svg>
-              </div>
-              <div className='flex items-center justify-center text-[14px] font-[600] text-main-grey font-plus-jakarta-sans leading-normal'>
-                Edit Text
-              </div>
-            </div>
-            <div className='flex flex-row gap-[8px] items-center justify-center'>
-              <button
-                className='w-[57px] h-[24px] rounded-[8px] bg-[#39BC66] text-[#000] text-[12px] font-[600] font-plus-jakarta-sans flex flex-row items-center justify-center gap-[7px]'
-                onClick={onDataSubmit}
-                disabled={isLoading}
-              >
-                <span>
-                  {isLoading ? (
-                    <svg className='animate-spin h-4 w-4' viewBox='0 0 24 24'>
-                      <circle
-                        className='opacity-25'
-                        cx='12'
-                        cy='12'
-                        r='10'
-                        stroke='currentColor'
-                        strokeWidth='4'
-                      ></circle>
-                      <path
-                        className='opacity-75'
-                        fill='currentColor'
-                        d='M4 12a8 8 0 718-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 714 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z'
-                      ></path>
-                    </svg>
-                  ) : (
+        {/* Configuration Menu */}
+        {isMenuOpen && (
+          <ul
+            ref={menuRef}
+            className='absolute top-[64px] text-white w-[448px] rounded-[16px] border-[1px] bg-[#1A1A1A] p-[12px] font-plus-jakarta-sans flex flex-col gap-[16px] shadow-lg'
+            style={{
+              borderColor: UI_COLORS.EDGENODE_BORDER_GREY,
+            }}
+          >
+            <li className='flex h-[28px] gap-1 items-center justify-between font-plus-jakarta-sans'>
+              <div className='flex flex-row gap-[12px]'>
+                <div className='flex flex-row gap-[8px] justify-center items-center'>
+                  <div className='w-[24px] h-[24px] border-[1px] border-main-grey bg-main-black-theme rounded-[8px] flex items-center justify-center'>
                     <svg
                       xmlns='http://www.w3.org/2000/svg'
-                      width='8'
-                      height='10'
-                      viewBox='0 0 8 10'
+                      width='12'
+                      height='12'
+                      viewBox='0 0 12 12'
                       fill='none'
                     >
-                      <path d='M8 5L0 10V0L8 5Z' fill='black' />
+                      <path d='M2 10H10' stroke='#CDCDCD' strokeWidth='1.5' />
+                      <path
+                        d='M8.5 2L9.5 3L5 7.5L3 8L3.5 6L8 1.5L9 2.5'
+                        stroke='#CDCDCD'
+                        strokeWidth='1.5'
+                      />
                     </svg>
-                  )}
-                </span>
-                <span>{isLoading ? '' : 'Run'}</span>
-              </button>
-            </div>
-          </li>
+                  </div>
+                  <div className='flex items-center justify-center text-[14px] font-semibold text-main-grey font-plus-jakarta-sans leading-normal'>
+                    Edit Text
+                  </div>
+                </div>
+              </div>
+              <div className='w-[57px] h-[26px]'>
+                <button
+                  className='w-full h-full rounded-[8px] text-[#000] text-[12px] font-semibold font-plus-jakarta-sans flex flex-row items-center justify-center gap-[7px]'
+                  style={{
+                    backgroundColor: isLoading ? '#FFA73D' : '#39BC66',
+                  }}
+                  onClick={isLoading ? onStopExecution : onDataSubmit}
+                  disabled={false}
+                >
+                  <span>
+                    {isLoading ? (
+                      <svg width='8' height='8' viewBox='0 0 8 8' fill='none'>
+                        <rect width='8' height='8' fill='currentColor' />
+                      </svg>
+                    ) : (
+                      <svg width='8' height='10' viewBox='0 0 8 10' fill='none'>
+                        <path d='M8 5L0 10V0L8 5Z' fill='black' />
+                      </svg>
+                    )}
+                  </span>
+                  <span>{isLoading ? 'Stop' : 'Run'}</span>
+                </button>
+              </div>
+            </li>
 
-          <li>
-            <InputOutputDisplay
-              parentId={id}
-              getNode={getNode}
-              getSourceNodeIdWithLabel={getSourceNodeIdWithLabel}
-              getTargetNodeIdWithLabel={getTargetNodeIdWithLabel}
-              supportedInputTypes={['text']}
-              supportedOutputTypes={['text']}
-              inputNodeCategory='blocknode'
-              outputNodeCategory='blocknode'
-            />
-          </li>
+            <li>
+              <InputOutputDisplay
+                parentId={id}
+                getNode={getNode}
+                getSourceNodeIdWithLabel={getSourceNodeIdWithLabel}
+                getTargetNodeIdWithLabel={getTargetNodeIdWithLabel}
+                supportedInputTypes={['text']}
+                supportedOutputTypes={['text']}
+                inputNodeCategory='blocknode'
+                outputNodeCategory='blocknode'
+              />
+            </li>
 
-          <li className='flex flex-col gap-2'>
-            <div className='flex items-center gap-2'>
-              <label className='text-[13px] font-semibold text-[#6D7177]'>
-                Return Text
-              </label>
-              <div className='w-[5px] h-[5px] rounded-full bg-[#FF4D4D]'></div>
-            </div>
-            <div className='bg-[#252525] rounded-[8px] p-3 border-[1px] border-[#6D7177]/30 hover:border-[#6D7177]/50 transition-colors'>
-              <textarea
-                value={textContent}
-                onChange={e => {
-                  setTextContent(e.target.value);
-                }}
-                onFocus={onFocus}
-                onBlur={onBlur}
-                placeholder={`use {{}} and id to reference input content 
+            <li className='flex flex-col gap-2'>
+              <div className='flex items-center gap-2'>
+                <label className='text-[13px] font-semibold text-[#6D7177]'>
+                  Return Text
+                </label>
+                <div className='w-[5px] h-[5px] rounded-full bg-[#FF4D4D]'></div>
+              </div>
+              <div className='bg-[#252525] rounded-[8px] p-3 border-[1px] border-[#6D7177]/30 hover:border-[#6D7177]/50 transition-colors'>
+                <textarea
+                  value={textContent}
+                  onChange={e => {
+                    setTextContent(e.target.value);
+                  }}
+                  onFocus={onFocus}
+                  onBlur={onBlur}
+                  placeholder={`use {{}} and id to reference input content 
 example: hello, {{parent_nodeid}}`}
-                className='w-full h-[140px] bg-transparent text-[#CDCDCD] text-[12px] resize-none outline-none p-1'
-              />
-            </div>
-          </li>
+                  className='w-full h-[140px] bg-transparent text-[#CDCDCD] text-[12px] resize-none outline-none p-1'
+                />
+              </div>
+            </li>
 
-          <li className='flex flex-col gap-2'>
-            <div className='flex items-center gap-2'>
-              <label className='text-[13px] font-semibold text-[#6D7177]'>
-                Return Mode
-              </label>
-              <div className='w-[5px] h-[5px] rounded-full bg-[#FF4D4D]'></div>
-            </div>
-            <div className='flex items-center gap-2 h-[32px] p-0 bg-[#252525] rounded-[6px] border-[1px] border-[#6D7177]/30 hover:border-[#6D7177]/50 transition-colors'>
-              <PuppyDropdown
-                options={[RET_ALL, RET_FN, RET_LN, EX_FN, EX_LN]}
-                onSelect={(option: string) => {
-                  setRetMode(option);
-                }}
-                selectedValue={retMode}
-                listWidth={'200px'}
-                containerClassnames='w-full'
-              />
+            <li className='flex flex-col gap-2'>
+              <div className='flex items-center gap-2'>
+                <label className='text-[13px] font-semibold text-[#6D7177]'>
+                  Return Mode
+                </label>
+                <div className='w-[5px] h-[5px] rounded-full bg-[#FF4D4D]'></div>
+              </div>
+              <div className='flex items-center gap-2 h-[32px] p-0 bg-[#252525] rounded-[6px] border-[1px] border-[#6D7177]/30 hover:border-[#6D7177]/50 transition-colors'>
+                <PuppyDropdown
+                  options={[RET_ALL, RET_FN, RET_LN, EX_FN, EX_LN]}
+                  onSelect={(option: string) => {
+                    setRetMode(option);
+                  }}
+                  selectedValue={retMode}
+                  listWidth={'200px'}
+                  containerClassnames='w-full'
+                />
 
-              {retMode !== RET_ALL && (
-                <div className='flex items-center gap-2'>
-                  <input
-                    value={configNum}
-                    onChange={e => {
-                      setConfigNum(parseInt(e.target.value));
-                    }}
-                    className='w-[80px] h-[32px] px-3 bg-[#252525] rounded-[6px] 
+                {retMode !== RET_ALL && (
+                  <div className='flex items-center gap-2'>
+                    <input
+                      value={configNum}
+                      onChange={e => {
+                        setConfigNum(parseInt(e.target.value));
+                      }}
+                      className='w-[80px] h-[32px] px-3 bg-[#252525] rounded-[6px] 
                                                     border-[1px] border-[#6D7177]/30 
                                                     text-[12px] text-[#CDCDCD] 
                                                     hover:border-[#6D7177]/50 transition-colors'
-                    type='number'
-                    onMouseDownCapture={onFocus}
-                    onBlur={onBlur}
-                  />
-                  <span className='text-[12px] text-[#CDCDCD]'>
-                    {retMode.includes('first') || retMode.includes('last')
-                      ? 'items'
-                      : 'characters'}
-                  </span>
-                </div>
-              )}
-            </div>
-          </li>
-        </ul>
-      )}
-    </div>
-  );
-}
+                      type='number'
+                      onMouseDownCapture={onFocus}
+                      onBlur={onBlur}
+                    />
+                    <span className='text-[12px] text-[#CDCDCD]'>
+                      {retMode.includes('first') || retMode.includes('last')
+                        ? 'items'
+                        : 'characters'}
+                    </span>
+                  </div>
+                )}
+              </div>
+            </li>
+          </ul>
+        )}
+      </div>
+    );
+  }
+);
 
+EditText.displayName = 'EditText';
 export default EditText;

--- a/PuppyFlow/app/components/workflow/edgesNode/edgeNodesNew/Generate.tsx
+++ b/PuppyFlow/app/components/workflow/edgesNode/edgeNodesNew/Generate.tsx
@@ -6,6 +6,7 @@ import React, {
   useRef,
   useMemo,
   useCallback,
+  memo,
 } from 'react';
 import InputOutputDisplay from './components/InputOutputDisplay';
 import { PuppyDropdown } from '../../../misc/PuppyDropDown';
@@ -92,691 +93,731 @@ const PROMPT_TEMPLATES: Record<PromptTemplateType, string> = {
 
 type GenerateNodeProps = NodeProps<Node<GenerateConfigNodeData>>;
 
-function Generate({ data, isConnectable, id }: GenerateNodeProps) {
-  const {
-    isOnConnect,
-    activatedEdge,
-    isOnGeneratingNewNode,
-    clearEdgeActivation,
-    activateEdge,
-    clearAll,
-  } = useNodesPerFlowContext();
-  const [isTargetHandleTouched, setIsTargetHandleTouched] = useState(false);
-  const { getNode, setNodes, setEdges } = useReactFlow();
-  const { getSourceNodeIdWithLabel, getTargetNodeIdWithLabel } =
-    useGetSourceTarget();
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const [isHovered, setIsHovered] = useState(false);
-  const [isRunButtonHovered, setIsRunButtonHovered] = useState(false);
-  const [isLoading, setIsLoading] = useState(false);
-  const menuRef = useRef<HTMLUListElement>(null);
+const Generate: React.FC<GenerateNodeProps> = memo(
+  ({ data, isConnectable, id }: GenerateNodeProps) => {
+    const {
+      isOnConnect,
+      activatedEdge,
+      isOnGeneratingNewNode,
+      clearEdgeActivation,
+      activateEdge,
+      clearAll,
+    } = useNodesPerFlowContext();
+    const [isTargetHandleTouched, setIsTargetHandleTouched] = useState(false);
+    const { getNode, setNodes, setEdges } = useReactFlow();
+    const { getSourceNodeIdWithLabel, getTargetNodeIdWithLabel } =
+      useGetSourceTarget();
+    const [isMenuOpen, setIsMenuOpen] = useState(false);
+    const [isHovered, setIsHovered] = useState(false);
+    const [isRunButtonHovered, setIsRunButtonHovered] = useState(false);
+    const [isLoading, setIsLoading] = useState(false);
+    const menuRef = useRef<HTMLUListElement>(null);
 
-  // 获取所有需要的依赖
-  const { streamResult, reportError, resetLoadingUI } = useJsonConstructUtils();
-  const { getAuthHeaders } = useAppSettings();
+    // 获取所有需要的依赖
+    const { streamResult, reportError, resetLoadingUI } =
+      useJsonConstructUtils();
+    const { getAuthHeaders } = useAppSettings();
 
-  // 使用 AppSettingsContext
-  const { availableModels, isLocalDeployment } = useAppSettings();
+    // 使用 AppSettingsContext
+    const { availableModels, isLocalDeployment } = useAppSettings();
 
-  // 获取可用的激活模型列表 - 只显示 LLM 类型的模型
-  const activeModels = useMemo(() => {
-    return availableModels.filter(m => m.active && m.type === 'llm');
-  }, [availableModels]);
+    // 使用 useRef 跟踪是否已挂载，防止首次渲染时执行状态更新
+    const hasMountedRef = useRef(false);
 
-  // 状态管理 - 使用第一个可用的激活 LLM 模型作为默认值
-  const [model, setModel] = useState<string>(() => {
-    // 首先尝试获取节点已有的模型值
-    const nodeModel = getNode(id)?.data?.model as string;
-    if (nodeModel) return nodeModel;
+    // 获取可用的激活模型列表 - 只显示 LLM 类型的模型
+    const activeModels = useMemo(() => {
+      return availableModels.filter(m => m.active && m.type === 'llm');
+    }, [availableModels]);
 
-    // 如果节点没有模型值，则使用第一个可用的激活 LLM 模型
-    return activeModels.length > 0 ? activeModels[0].id : '';
-  });
+    // 状态管理 - 使用函数形式初始化，避免重复计算
+    const [model, setModel] = useState<string>(() => {
+      const nodeModel = getNode(id)?.data?.model as string;
+      if (nodeModel) return nodeModel;
+      return activeModels.length > 0 ? activeModels[0].id : '';
+    });
 
-  // 当可用模型变化且当前模型不在可用列表中时，更新为第一个可用 LLM 模型
-  useEffect(() => {
-    if (activeModels.length > 0 && !activeModels.some(m => m.id === model)) {
-      setModel(activeModels[0].id);
-    }
-  }, [activeModels, model]);
+    // 当可用模型变化且当前模型不在可用列表中时，更新为第一个可用 LLM 模型
+    useEffect(() => {
+      if (
+        hasMountedRef.current &&
+        activeModels.length > 0 &&
+        !activeModels.some(m => m.id === model)
+      ) {
+        setModel(activeModels[0].id);
+      }
+    }, [activeModels, model]);
 
-  // 自定义渲染模型选项的函数
-  const renderModelOption = (modelObj: Model) => {
-    return (
-      <div className='flex items-center justify-between w-full'>
-        <span className='truncate mr-2'>{modelObj.name || modelObj.id}</span>
-        {modelObj.isLocal ? (
-          <span className='ml-auto px-1.5 py-0.5 text-[10px] rounded bg-[#2A4365] text-[#90CDF4] flex-shrink-0'>
-            Local
-          </span>
-        ) : (
-          <span className='ml-auto px-1.5 py-0.5 text-[10px] rounded bg-[#4A4A4A] text-[#CDCDCD] flex-shrink-0'>
-            Cloud
-          </span>
-        )}
-      </div>
+    const [structuredOutput, setStructuredOutput] = useState<boolean>(
+      () =>
+        (getNode(id)?.data as GenerateConfigNodeData)?.structured_output ??
+        false
     );
-  };
 
-  // 自定义显示选择的模型的函数
-  const mapModelToDisplay = (modelId: string) => {
-    const selectedModel = activeModels.find(m => m.id === modelId);
-    if (!selectedModel) return modelId;
-    return selectedModel.name || selectedModel.id;
-  };
+    const [selectedTemplate, setSelectedTemplate] =
+      useState<PromptTemplateType>(
+        () =>
+          ((getNode(id)?.data as GenerateConfigNodeData)
+            ?.promptTemplate as PromptTemplateType) || 'default'
+      );
 
-  const [structuredOutput, setStructuredOutput] = useState<boolean>(
-    (getNode(id)?.data as GenerateConfigNodeData)?.structured_output ?? false
-  );
+    // 基础URL(可选)
+    const [baseUrl, setBaseUrl] = useState<string>(
+      () => (getNode(id)?.data as GenerateConfigNodeData)?.base_url ?? ''
+    );
 
-  const [selectedTemplate, setSelectedTemplate] = useState<PromptTemplateType>(
-    ((getNode(id)?.data as GenerateConfigNodeData)
-      ?.promptTemplate as PromptTemplateType) || 'default'
-  );
+    // 显示高级设置
+    const [showSettings, setShowSettings] = useState(false);
 
-  // 基础URL(可选)
-  const [baseUrl, setBaseUrl] = useState<string>(
-    (getNode(id)?.data as GenerateConfigNodeData)?.base_url ?? ''
-  );
+    // 复制功能状态
+    const [copiedLabel, setCopiedLabel] = useState<string | null>(null);
 
-  // 显示高级设置
-  const [showSettings, setShowSettings] = useState(false);
+    // 创建执行上下文 - 使用 useCallback 缓存
+    const createExecutionContext = useCallback(
+      (): RunSingleEdgeNodeContext => ({
+        getNode,
+        setNodes,
+        setEdges,
+        getSourceNodeIdWithLabel,
+        getTargetNodeIdWithLabel,
+        clearAll,
+        streamResult,
+        reportError,
+        resetLoadingUI,
+        getAuthHeaders,
+      }),
+      [
+        getNode,
+        setNodes,
+        setEdges,
+        getSourceNodeIdWithLabel,
+        getTargetNodeIdWithLabel,
+        clearAll,
+        streamResult,
+        reportError,
+        resetLoadingUI,
+        getAuthHeaders,
+      ]
+    );
 
-  // 复制功能状态
-  const [copiedLabel, setCopiedLabel] = useState<string | null>(null);
+    // 使用执行函数的 handleDataSubmit - 使用 useCallback 缓存
+    const handleDataSubmit = useCallback(async () => {
+      if (isLoading) return;
 
-  // 创建执行上下文
-  const createExecutionContext = useCallback(
-    (): RunSingleEdgeNodeContext => ({
-      getNode,
+      setIsLoading(true);
+      try {
+        const context = createExecutionContext();
+        await runSingleEdgeNode({
+          parentId: id,
+          targetNodeType: 'text',
+          context,
+        });
+      } catch (error) {
+        console.error('执行失败:', error);
+      } finally {
+        setIsLoading(false);
+      }
+    }, [id, isLoading, createExecutionContext]);
+
+    // 组件初始化
+    useEffect(() => {
+      hasMountedRef.current = true;
+    }, []);
+
+    useEffect(() => {
+      if (hasMountedRef.current && !isOnGeneratingNewNode) {
+        clearAll();
+        activateEdge(id);
+      }
+
+      return () => {
+        if (activatedEdge === id) {
+          clearEdgeActivation();
+        }
+      };
+    }, [isOnGeneratingNewNode]);
+
+    // 同步状态到 ReactFlow - 使用 requestAnimationFrame 延迟执行，避免在节点创建时干扰
+    useEffect(() => {
+      if (!isOnGeneratingNewNode && hasMountedRef.current) {
+        requestAnimationFrame(() => {
+          setNodes(prevNodes =>
+            prevNodes.map(node => {
+              if (node.id === id) {
+                return {
+                  ...node,
+                  data: {
+                    ...node.data,
+                    model,
+                    promptTemplate: selectedTemplate,
+                    structured_output: structuredOutput,
+                    base_url: baseUrl,
+                  },
+                };
+              }
+              return node;
+            })
+          );
+        });
+      }
+    }, [
+      model,
+      selectedTemplate,
+      structuredOutput,
+      baseUrl,
+      id,
       setNodes,
-      setEdges,
-      getSourceNodeIdWithLabel,
-      getTargetNodeIdWithLabel,
-      clearAll,
-      streamResult,
-      reportError,
-      resetLoadingUI,
-      getAuthHeaders,
-    }),
-    [
-      getNode,
-      setNodes,
-      setEdges,
-      getSourceNodeIdWithLabel,
-      getTargetNodeIdWithLabel,
-      clearAll,
-      streamResult,
-      reportError,
-      resetLoadingUI,
-      getAuthHeaders,
-    ]
-  );
+      isOnGeneratingNewNode,
+    ]);
 
-  // 使用执行函数的 handleDataSubmit
-  const handleDataSubmit = useCallback(async () => {
-    if (isLoading) return;
+    // 辅助函数 - 使用 useCallback 缓存
+    const onFocus = useCallback(() => {
+      const curRef = menuRef.current;
+      if (curRef && !curRef.classList.contains('nodrag')) {
+        curRef.classList.add('nodrag');
+      }
+    }, []);
 
-    setIsLoading(true);
-    try {
-      const context = createExecutionContext();
-      await runSingleEdgeNode({
-        parentId: id,
-        targetNodeType: 'text',
-        context,
-        // 可以选择不提供 constructJsonData，使用默认实现
-      });
-    } catch (error) {
-      console.error('执行失败:', error);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [id, isLoading, createExecutionContext]);
+    const onBlur = useCallback(() => {
+      const curRef = menuRef.current;
+      if (curRef) {
+        curRef.classList.remove('nodrag');
+      }
+    }, []);
 
-  useEffect(() => {
-    if (!isOnGeneratingNewNode) {
-      clearAll();
-      activateEdge(id);
-    }
+    const copyToClipboard = useCallback((text: string) => {
+      navigator.clipboard
+        .writeText(`{{${text}}}`)
+        .then(() => {
+          setCopiedLabel(text);
+          setTimeout(() => setCopiedLabel(null), 1000);
+        })
+        .catch(err => {
+          console.warn('Failed to copy:', err);
+        });
+    }, []);
 
-    return () => {
+    // UI 交互函数 - 使用 useCallback 缓存
+    const onClickButton = useCallback(() => {
+      setIsMenuOpen(prev => !prev);
+
+      if (isOnGeneratingNewNode) return;
       if (activatedEdge === id) {
         clearEdgeActivation();
+      } else {
+        clearAll();
+        activateEdge(id);
       }
-    };
-  }, []);
+    }, [
+      isOnGeneratingNewNode,
+      activatedEdge,
+      id,
+      clearEdgeActivation,
+      clearAll,
+      activateEdge,
+    ]);
 
-  // 辅助函数
-  const onFocus = () => {
-    const curRef = menuRef.current;
-    if (curRef && !curRef.classList.contains('nodrag')) {
-      curRef.classList.add('nodrag');
-    }
-  };
-
-  const onBlur = () => {
-    const curRef = menuRef.current;
-    if (curRef) {
-      curRef.classList.remove('nodrag');
-    }
-  };
-
-  const copyToClipboard = (text: string) => {
-    navigator.clipboard
-      .writeText(`{{${text}}}`)
-      .then(() => {
-        setCopiedLabel(text);
-        setTimeout(() => setCopiedLabel(null), 1000);
-      })
-      .catch(err => {
-        console.warn('Failed to copy:', err);
-      });
-  };
-
-  // 同步状态到ReactFlow
-  useEffect(() => {
-    setNodes(prevNodes =>
-      prevNodes.map(node => {
-        if (node.id === id) {
-          return {
-            ...node,
-            data: {
-              ...node.data,
-              model,
-              promptTemplate: selectedTemplate,
-              structured_output: structuredOutput,
-              base_url: baseUrl,
-            },
-          };
-        }
-        return node;
-      })
+    // 在组件顶部定义共享样式 - 使用 useMemo 缓存
+    const handleStyle = useMemo(
+      () => ({
+        position: 'absolute' as const,
+        width: 'calc(100%)',
+        height: 'calc(100%)',
+        top: '0',
+        left: '0',
+        borderRadius: '0',
+        transform: 'translate(0px, 0px)',
+        background: 'transparent',
+        border: '3px solid transparent',
+        zIndex: !isOnConnect ? '-1' : '1',
+      }),
+      [isOnConnect]
     );
-  }, [id, setNodes, model, selectedTemplate, structuredOutput, baseUrl]);
 
-  const onClickButton = () => {
-    setIsMenuOpen(!isMenuOpen);
+    // 缓存按钮样式 - 使用 useMemo 缓存
+    const runButtonStyle = useMemo(
+      () => ({
+        backgroundColor: isRunButtonHovered ? '#39BC66' : '#181818',
+        borderColor: isRunButtonHovered
+          ? '#39BC66'
+          : UI_COLORS.EDGENODE_BORDER_GREY,
+        color: isRunButtonHovered ? '#000' : UI_COLORS.EDGENODE_BORDER_GREY,
+      }),
+      [isRunButtonHovered]
+    );
 
-    if (isOnGeneratingNewNode) return;
-    if (activatedEdge === id) {
-      clearEdgeActivation();
-    } else {
-      clearAll();
-      activateEdge(id);
-    }
-  };
+    const mainButtonStyle = useMemo(
+      () => ({
+        borderColor: isHovered
+          ? UI_COLORS.LINE_ACTIVE
+          : UI_COLORS.EDGENODE_BORDER_GREY,
+        color: isHovered
+          ? UI_COLORS.LINE_ACTIVE
+          : UI_COLORS.EDGENODE_BORDER_GREY,
+      }),
+      [isHovered]
+    );
 
-  // 在组件顶部定义共享样式
-  const handleStyle = {
-    position: 'absolute' as const,
-    width: 'calc(100%)',
-    height: 'calc(100%)',
-    top: '0',
-    left: '0',
-    borderRadius: '0',
-    transform: 'translate(0px, 0px)',
-    background: 'transparent',
-    border: '3px solid transparent',
-    zIndex: !isOnConnect ? '-1' : '1',
-  };
-
-  return (
-    <div className='p-[3px] w-[80px] h-[48px] relative'>
-      {/* Invisible hover area between node and run button */}
-      <div
-        className='absolute -top-[40px] left-0 w-full h-[40px]'
-        onMouseEnter={() => setIsHovered(true)}
-        onMouseLeave={() => setIsHovered(false)}
-      />
-
-      {/* Run button positioned above the node - show when node or run button is hovered */}
-      <button
-        className={`absolute -top-[40px] left-1/2 transform -translate-x-1/2 w-[57px] h-[24px] rounded-[6px] border-[1px] text-[10px] font-[600] font-plus-jakarta-sans flex flex-row items-center justify-center gap-[4px] transition-all duration-200 ${
-          isHovered || isRunButtonHovered ? 'opacity-100' : 'opacity-0'
-        }`}
-        style={{
-          backgroundColor: isRunButtonHovered ? '#39BC66' : '#181818',
-          borderColor: isRunButtonHovered
-            ? '#39BC66'
-            : UI_COLORS.EDGENODE_BORDER_GREY,
-          color: isRunButtonHovered ? '#000' : UI_COLORS.EDGENODE_BORDER_GREY,
-        }}
-        onClick={handleDataSubmit}
-        disabled={isLoading}
-        onMouseEnter={() => setIsRunButtonHovered(true)}
-        onMouseLeave={() => setIsRunButtonHovered(false)}
-      >
-        <span>
-          {isLoading ? (
-            <svg className='animate-spin h-3 w-3' viewBox='0 0 24 24'>
-              <circle
-                className='opacity-25'
-                cx='12'
-                cy='12'
-                r='10'
-                stroke='currentColor'
-                strokeWidth='4'
-              ></circle>
-              <path
-                className='opacity-75'
-                fill='currentColor'
-                d='M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 714 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z'
-              ></path>
-            </svg>
+    // 自定义渲染模型选项的函数 - 使用 useCallback 缓存
+    const renderModelOption = useCallback((modelObj: Model) => {
+      return (
+        <div className='flex items-center justify-between w-full'>
+          <span className='truncate mr-2'>{modelObj.name || modelObj.id}</span>
+          {modelObj.isLocal ? (
+            <span className='ml-auto px-1.5 py-0.5 text-[10px] rounded bg-[#2A4365] text-[#90CDF4] flex-shrink-0'>
+              Local
+            </span>
           ) : (
-            <svg
-              xmlns='http://www.w3.org/2000/svg'
-              width='6'
-              height='8'
-              viewBox='0 0 8 10'
-              fill='none'
-            >
-              <path d='M8 5L0 10V0L8 5Z' fill='currentColor' />
-            </svg>
+            <span className='ml-auto px-1.5 py-0.5 text-[10px] rounded bg-[#4A4A4A] text-[#CDCDCD] flex-shrink-0'>
+              Cloud
+            </span>
           )}
-        </span>
-        <span>{isLoading ? '' : 'Run'}</span>
-      </button>
-
-      <button
-        onClick={onClickButton}
-        onMouseEnter={() => setIsHovered(true)}
-        onMouseLeave={() => setIsHovered(false)}
-        className={`w-full h-full flex-shrink-0 rounded-[8px] border-[2px] bg-[#181818] flex items-center justify-center font-plus-jakarta-sans text-[10px] font-[700] edge-node transition-colors gap-[4px]`}
-        style={{
-          borderColor: isHovered
-            ? UI_COLORS.LINE_ACTIVE
-            : UI_COLORS.EDGENODE_BORDER_GREY,
-          color: isHovered
-            ? UI_COLORS.LINE_ACTIVE
-            : UI_COLORS.EDGENODE_BORDER_GREY,
-        }}
-      >
-        {/* Generate SVG icon */}
-        <svg
-          width='10'
-          height='10'
-          viewBox='0 0 24 24'
-          fill='none'
-          stroke='currentColor'
-          strokeWidth='1.5'
-        >
-          <path d='M12 3v18M3 12h18M5 5l14 14M19 5L5 19' />
-        </svg>
-        <div className='flex flex-col items-center justify-center leading-tight text-[9px]'>
-          <span>Generate</span>
         </div>
+      );
+    }, []);
 
-        <Handle
-          id={`${id}-a`}
-          className='edgeSrcHandle handle-with-icon handle-top'
-          type='source'
-          position={Position.Top}
-        />
-        <Handle
-          id={`${id}-b`}
-          className='edgeSrcHandle handle-with-icon handle-right'
-          type='source'
-          position={Position.Right}
-        />
-        <Handle
-          id={`${id}-c`}
-          className='edgeSrcHandle handle-with-icon handle-bottom'
-          type='source'
-          position={Position.Bottom}
-        />
-        <Handle
-          id={`${id}-d`}
-          className='edgeSrcHandle handle-with-icon handle-left'
-          type='source'
-          position={Position.Left}
+    // 自定义显示选择的模型的函数 - 使用 useCallback 缓存
+    const mapModelToDisplay = useCallback(
+      (modelId: string) => {
+        const selectedModel = activeModels.find(m => m.id === modelId);
+        if (!selectedModel) return modelId;
+        return selectedModel.name || selectedModel.id;
+      },
+      [activeModels]
+    );
+
+    return (
+      <div className='p-[3px] w-[80px] h-[48px] relative'>
+        {/* Invisible hover area between node and run button */}
+        <div
+          className='absolute -top-[40px] left-0 w-full h-[40px]'
+          onMouseEnter={() => setIsHovered(true)}
+          onMouseLeave={() => setIsHovered(false)}
         />
 
-        <Handle
-          id={`${id}-a`}
-          type='target'
-          position={Position.Top}
-          style={handleStyle}
-          isConnectable={isConnectable}
-          onMouseEnter={() => setIsTargetHandleTouched(true)}
-          onMouseLeave={() => setIsTargetHandleTouched(false)}
-        />
-        <Handle
-          id={`${id}-b`}
-          type='target'
-          position={Position.Right}
-          style={handleStyle}
-          isConnectable={isConnectable}
-          onMouseEnter={() => setIsTargetHandleTouched(true)}
-          onMouseLeave={() => setIsTargetHandleTouched(false)}
-        />
-        <Handle
-          id={`${id}-c`}
-          type='target'
-          position={Position.Bottom}
-          style={handleStyle}
-          isConnectable={isConnectable}
-          onMouseEnter={() => setIsTargetHandleTouched(true)}
-          onMouseLeave={() => setIsTargetHandleTouched(false)}
-        />
-        <Handle
-          id={`${id}-d`}
-          type='target'
-          position={Position.Left}
-          style={handleStyle}
-          isConnectable={isConnectable}
-          onMouseEnter={() => setIsTargetHandleTouched(true)}
-          onMouseLeave={() => setIsTargetHandleTouched(false)}
-        />
-      </button>
-
-      {/* Configuration Menu */}
-      {isMenuOpen && (
-        <ul
-          ref={menuRef}
-          className='absolute top-[64px] text-white w-[320px] rounded-[16px] border-[1px] bg-[#1A1A1A] p-[12px] font-plus-jakarta-sans flex flex-col gap-[16px] shadow-lg'
-          style={{
-            borderColor: UI_COLORS.EDGENODE_BORDER_GREY,
-          }}
+        {/* Run button positioned above the node - show when node or run button is hovered */}
+        <button
+          className={`absolute -top-[40px] left-1/2 transform -translate-x-1/2 w-[57px] h-[24px] rounded-[6px] border-[1px] text-[10px] font-[600] font-plus-jakarta-sans flex flex-row items-center justify-center gap-[4px] transition-all duration-200 ${
+            isHovered || isRunButtonHovered ? 'opacity-100' : 'opacity-0'
+          }`}
+          style={runButtonStyle}
+          onClick={handleDataSubmit}
+          disabled={isLoading}
+          onMouseEnter={() => setIsRunButtonHovered(true)}
+          onMouseLeave={() => setIsRunButtonHovered(false)}
         >
-          <li className='flex h-[28px] gap-1 items-center justify-between font-plus-jakarta-sans'>
-            <div className='flex flex-row gap-[12px]'>
-              <div className='flex flex-row gap-[8px] justify-center items-center'>
-                <div className='w-[24px] h-[24px] border-[1px] border-main-grey bg-main-black-theme rounded-[8px] flex items-center justify-center'>
-                  <svg
-                    width='16'
-                    height='16'
-                    viewBox='0 0 24 24'
-                    fill='none'
-                    stroke='#CDCDCD'
-                    strokeWidth='1.5'
-                  >
-                    <path d='M12 3v18M3 12h18M5 5l14 14M19 5L5 19' />
-                  </svg>
-                </div>
-                <div className='flex items-center justify-center text-[14px] font-semibold text-main-grey font-plus-jakarta-sans leading-normal'>
-                  Generate
+          <span>
+            {isLoading ? (
+              <svg className='animate-spin h-3 w-3' viewBox='0 0 24 24'>
+                <circle
+                  className='opacity-25'
+                  cx='12'
+                  cy='12'
+                  r='10'
+                  stroke='currentColor'
+                  strokeWidth='4'
+                ></circle>
+                <path
+                  className='opacity-75'
+                  fill='currentColor'
+                  d='M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 714 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z'
+                ></path>
+              </svg>
+            ) : (
+              <svg
+                xmlns='http://www.w3.org/2000/svg'
+                width='6'
+                height='8'
+                viewBox='0 0 8 10'
+                fill='none'
+              >
+                <path d='M8 5L0 10V0L8 5Z' fill='currentColor' />
+              </svg>
+            )}
+          </span>
+          <span>{isLoading ? '' : 'Run'}</span>
+        </button>
+
+        <button
+          onClick={onClickButton}
+          onMouseEnter={() => setIsHovered(true)}
+          onMouseLeave={() => setIsHovered(false)}
+          className={`w-full h-full flex-shrink-0 rounded-[8px] border-[2px] bg-[#181818] flex items-center justify-center font-plus-jakarta-sans text-[10px] font-[700] edge-node transition-colors gap-[4px]`}
+          style={mainButtonStyle}
+        >
+          {/* Generate SVG icon */}
+          <svg
+            width='10'
+            height='10'
+            viewBox='0 0 24 24'
+            fill='none'
+            stroke='currentColor'
+            strokeWidth='1.5'
+          >
+            <path d='M12 3v18M3 12h18M5 5l14 14M19 5L5 19' />
+          </svg>
+          <div className='flex flex-col items-center justify-center leading-tight text-[9px]'>
+            <span>Generate</span>
+          </div>
+
+          <Handle
+            id={`${id}-a`}
+            className='edgeSrcHandle handle-with-icon handle-top'
+            type='source'
+            position={Position.Top}
+          />
+          <Handle
+            id={`${id}-b`}
+            className='edgeSrcHandle handle-with-icon handle-right'
+            type='source'
+            position={Position.Right}
+          />
+          <Handle
+            id={`${id}-c`}
+            className='edgeSrcHandle handle-with-icon handle-bottom'
+            type='source'
+            position={Position.Bottom}
+          />
+          <Handle
+            id={`${id}-d`}
+            className='edgeSrcHandle handle-with-icon handle-left'
+            type='source'
+            position={Position.Left}
+          />
+
+          <Handle
+            id={`${id}-a`}
+            type='target'
+            position={Position.Top}
+            style={handleStyle}
+            isConnectable={isConnectable}
+            onMouseEnter={() => setIsTargetHandleTouched(true)}
+            onMouseLeave={() => setIsTargetHandleTouched(false)}
+          />
+          <Handle
+            id={`${id}-b`}
+            type='target'
+            position={Position.Right}
+            style={handleStyle}
+            isConnectable={isConnectable}
+            onMouseEnter={() => setIsTargetHandleTouched(true)}
+            onMouseLeave={() => setIsTargetHandleTouched(false)}
+          />
+          <Handle
+            id={`${id}-c`}
+            type='target'
+            position={Position.Bottom}
+            style={handleStyle}
+            isConnectable={isConnectable}
+            onMouseEnter={() => setIsTargetHandleTouched(true)}
+            onMouseLeave={() => setIsTargetHandleTouched(false)}
+          />
+          <Handle
+            id={`${id}-d`}
+            type='target'
+            position={Position.Left}
+            style={handleStyle}
+            isConnectable={isConnectable}
+            onMouseEnter={() => setIsTargetHandleTouched(true)}
+            onMouseLeave={() => setIsTargetHandleTouched(false)}
+          />
+        </button>
+
+        {isMenuOpen && (
+          <ul
+            ref={menuRef}
+            className='absolute top-[64px] text-white w-[448px] rounded-[16px] border-[1px] bg-[#1A1A1A] p-[12px] font-plus-jakarta-sans flex flex-col gap-[16px] shadow-lg'
+            style={{
+              borderColor: UI_COLORS.EDGENODE_BORDER_GREY,
+            }}
+          >
+            {/* Header */}
+            <li className='flex h-[28px] gap-1 items-center justify-between font-plus-jakarta-sans'>
+              <div className='flex flex-row gap-[12px]'>
+                <div className='flex flex-row gap-[8px] justify-center items-center'>
+                  <div className='w-[24px] h-[24px] border-[1px] border-main-grey bg-main-black-theme rounded-[8px] flex items-center justify-center'>
+                    <svg
+                      width='14'
+                      height='14'
+                      viewBox='0 0 24 24'
+                      fill='none'
+                      stroke='#CDCDCD'
+                      strokeWidth='1.5'
+                    >
+                      <path d='M12 3v18M3 12h18M5 5l14 14M19 5L5 19' />
+                    </svg>
+                  </div>
+                  <div className='flex items-center justify-center text-[14px] font-semibold text-main-grey font-plus-jakarta-sans leading-normal'>
+                    Generate
+                  </div>
                 </div>
               </div>
-            </div>
-            <div className='w-[57px] h-[26px]'>
-              <button
-                className='w-full h-full rounded-[8px] bg-[#39BC66] text-[#000] text-[12px] font-semibold font-plus-jakarta-sans flex flex-row items-center justify-center gap-[7px]'
-                onClick={handleDataSubmit}
-                disabled={isLoading}
-              >
-                <span>
-                  {isLoading ? (
-                    <svg className='animate-spin h-4 w-4' viewBox='0 0 24 24'>
-                      <circle
-                        className='opacity-25'
-                        cx='12'
-                        cy='12'
-                        r='10'
-                        stroke='currentColor'
-                        strokeWidth='4'
-                      ></circle>
-                      <path
-                        className='opacity-75'
-                        fill='currentColor'
-                        d='M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 714 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z'
-                      ></path>
-                    </svg>
-                  ) : (
-                    <svg
-                      xmlns='http://www.w3.org/2000/svg'
-                      width='8'
-                      height='10'
-                      viewBox='0 0 8 10'
-                      fill='none'
-                    >
-                      <path d='M8 5L0 10V0L8 5Z' fill='black' />
-                    </svg>
-                  )}
-                </span>
-                <span>{isLoading ? '' : 'Run'}</span>
-              </button>
-            </div>
-          </li>
+              <div className='w-[57px] h-[26px]'>
+                <button
+                  className='w-full h-full rounded-[8px] text-[#000] text-[12px] font-semibold font-plus-jakarta-sans flex flex-row items-center justify-center gap-[7px]'
+                  style={{
+                    backgroundColor: isLoading ? '#FFA73D' : '#39BC66',
+                  }}
+                  onClick={handleDataSubmit}
+                  disabled={isLoading}
+                >
+                  <span>
+                    {isLoading ? (
+                      <svg
+                        className='animate-spin h-3 w-3 text-black'
+                        xmlns='http://www.w3.org/2000/svg'
+                        fill='none'
+                        viewBox='0 0 24 24'
+                      >
+                        <circle
+                          className='opacity-25'
+                          cx='12'
+                          cy='12'
+                          r='10'
+                          stroke='currentColor'
+                          strokeWidth='4'
+                        ></circle>
+                        <path
+                          className='opacity-75'
+                          fill='currentColor'
+                          d='M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z'
+                        ></path>
+                      </svg>
+                    ) : (
+                      <svg width='8' height='10' viewBox='0 0 8 10' fill='none'>
+                        <path d='M8 5L0 10V0L8 5Z' fill='black' />
+                      </svg>
+                    )}
+                  </span>
+                  <span>{isLoading ? 'Stop' : 'Run'}</span>
+                </button>
+              </div>
+            </li>
 
-          <li>
-            <InputOutputDisplay
-              parentId={id}
-              getNode={getNode}
-              getSourceNodeIdWithLabel={getSourceNodeIdWithLabel}
-              getTargetNodeIdWithLabel={getTargetNodeIdWithLabel}
-              supportedInputTypes={['text', 'structured']}
-              supportedOutputTypes={['text', 'structured']}
-              inputNodeCategory='blocknode'
-              outputNodeCategory='blocknode'
-            />
-          </li>
-
-          {/* Queries 下拉选项 */}
-          <li className='flex flex-col gap-2'>
-            <div className='flex items-center gap-2'>
-              <label className='text-[13px] font-semibold text-[#6D7177]'>
-                Queries
-              </label>
-              <div className='w-[5px] h-[5px] rounded-full bg-[#FF4D4D]'></div>
-            </div>
-            <div className='relative h-[32px] p-0 bg-[#252525] rounded-[6px] border-[1px] border-[#6D7177]/30 hover:border-[#6D7177]/50 transition-colors'>
-              <PuppyDropdown
-                options={getSourceNodeIdWithLabel(id).map(node => node.label)}
-                selectedValue={
-                  (getNode(id)?.data as GenerateConfigNodeData)?.query_ids
-                    ?.label
-                }
-                onSelect={(value: string) => {
-                  const selectedNode = getSourceNodeIdWithLabel(id).find(
-                    node => node.label === value
-                  );
-                  setNodes(prevNodes =>
-                    prevNodes.map(node => {
-                      if (node.id === id) {
-                        return {
-                          ...node,
-                          data: {
-                            ...node.data,
-                            query_ids: selectedNode,
-                          },
-                        };
-                      }
-                      return node;
-                    })
-                  );
-                }}
-                buttonHeight='32px'
-                buttonBgColor='transparent'
-                menuBgColor='#1A1A1A'
-                listWidth='100%'
-                containerClassnames='w-full'
+            {/* Input/Output display */}
+            <li>
+              <InputOutputDisplay
+                parentId={id}
+                getNode={getNode}
+                getSourceNodeIdWithLabel={getSourceNodeIdWithLabel}
+                getTargetNodeIdWithLabel={getTargetNodeIdWithLabel}
+                supportedInputTypes={['text', 'structured']}
+                supportedOutputTypes={['text']}
+                inputNodeCategory='blocknode'
+                outputNodeCategory='blocknode'
               />
-            </div>
-          </li>
+            </li>
 
-          {/* Documents 下拉选项 */}
-          <li className='flex flex-col gap-2'>
-            <div className='flex items-center gap-2'>
-              <label className='text-[13px] font-semibold text-[#6D7177]'>
-                Documents
-              </label>
-              <div className='w-[5px] h-[5px] rounded-full bg-[#FF4D4D]'></div>
-            </div>
-            <div className='relative h-[32px] p-0 bg-[#252525] rounded-[6px] border-[1px] border-[#6D7177]/30 hover:border-[#6D7177]/50 transition-colors'>
-              <PuppyDropdown
-                options={getSourceNodeIdWithLabel(id).map(node => node.label)}
-                selectedValue={
-                  (getNode(id)?.data as GenerateConfigNodeData)?.document_ids
-                    ?.label || 'Choose Document'
-                }
-                onSelect={(value: string) => {
-                  const selectedNode = getSourceNodeIdWithLabel(id).find(
-                    node => node.label === value
-                  );
-                  setNodes(prevNodes =>
-                    prevNodes.map(node => {
-                      if (node.id === id) {
-                        return {
-                          ...node,
-                          data: {
-                            ...node.data,
-                            document_ids: selectedNode,
-                          },
-                        };
-                      }
-                      return node;
-                    })
-                  );
-                }}
-                buttonHeight='32px'
-                buttonBgColor='transparent'
-                menuBgColor='#1A1A1A'
-                listWidth='100%'
-                containerClassnames='w-full'
-              />
-            </div>
-          </li>
-
-          {/* Prompt Template 下拉选择 */}
-          <li className='flex flex-col gap-2'>
-            <div className='flex items-center gap-2'>
-              <label className='text-[13px] font-semibold text-[#6D7177]'>
-                Prompt Template
-              </label>
-              <div className='w-[5px] h-[5px] rounded-full bg-[#FF4D4D]'></div>
-            </div>
-            <div className='relative h-[32px] p-0 bg-[#252525] rounded-[6px] border-[1px] border-[#6D7177]/30 hover:border-[#6D7177]/50 transition-colors'>
-              <PuppyDropdown
-                options={Object.keys(PROMPT_TEMPLATES) as PromptTemplateType[]}
-                selectedValue={selectedTemplate}
-                onSelect={(value: string) => {
-                  setSelectedTemplate(value as PromptTemplateType);
-                }}
-                buttonHeight='32px'
-                buttonBgColor='transparent'
-                menuBgColor='#1A1A1A'
-                listWidth='100%'
-                containerClassnames='w-full'
-                mapValueTodisplay={(v: string) => v.replace(/_/g, ' ')}
-              />
-            </div>
-          </li>
-
-          {/* Prompt Template 预览区域 */}
-          <li className='flex flex-col gap-2'>
-            <div className=' text-[10px] text-[#6D7177]'>
-              {PROMPT_TEMPLATES[selectedTemplate]}
-            </div>
-          </li>
-
-          {/* Output Type */}
-          <li className='flex flex-col gap-2'>
-            <div className='flex items-center gap-2'>
-              <label className='text-[13px] font-semibold text-[#6D7177]'>
-                Output type
-              </label>
-              <div className='w-[5px] h-[5px] rounded-full bg-[#FF4D4D]'></div>
-            </div>
-            <div className='flex items-center gap-2 h-[32px] p-0 bg-[#252525] rounded-[6px] border-[1px] border-[#6D7177]/30 hover:border-[#6D7177]/50 transition-colors'>
-              <PuppyDropdown
-                options={['text', 'structured text']}
-                selectedValue={structuredOutput ? 'structured text' : 'text'}
-                onSelect={(value: string) => {
-                  setStructuredOutput(value === 'structured text');
-                  onBlur && onBlur();
-                }}
-                buttonHeight='32px'
-                buttonBgColor='transparent'
-                menuBgColor='#1A1A1A'
-                listWidth='100%'
-                containerClassnames='w-full'
-                onFocus={onFocus}
-              />
-            </div>
-          </li>
-
-          {/* Settings 设置选项 */}
-          <li className='flex flex-col gap-2'>
-            <div className='flex items-center justify-between'>
+            {/* Queries 下拉选项 */}
+            <li className='flex flex-col gap-2'>
               <div className='flex items-center gap-2'>
                 <label className='text-[13px] font-semibold text-[#6D7177]'>
-                  Settings
+                  Queries
                 </label>
-                <div className='w-[5px] h-[5px] rounded-full bg-[#6D7177]'></div>
+                <div className='w-[5px] h-[5px] rounded-full bg-[#FF4D4D]'></div>
               </div>
-              <button
-                onClick={() => setShowSettings(!showSettings)}
-                className='text-[12px] text-[#6D7177] hover:text-[#39BC66] transition-colors flex items-center gap-1'
-              >
-                {showSettings ? 'Hide' : 'Show'}
-                <svg
-                  className={`w-4 h-4 transition-transform ${showSettings ? 'rotate-180' : ''}`}
-                  fill='none'
-                  viewBox='0 0 24 24'
-                  stroke='currentColor'
+              <div className='relative h-[32px] p-0 bg-[#252525] rounded-[6px] border-[1px] border-[#6D7177]/30 hover:border-[#6D7177]/50 transition-colors'>
+                <PuppyDropdown
+                  options={getSourceNodeIdWithLabel(id).map(node => node.label)}
+                  selectedValue={
+                    (getNode(id)?.data as GenerateConfigNodeData)?.query_ids
+                      ?.label
+                  }
+                  onSelect={(value: string) => {
+                    const selectedNode = getSourceNodeIdWithLabel(id).find(
+                      node => node.label === value
+                    );
+                    setNodes(prevNodes =>
+                      prevNodes.map(node => {
+                        if (node.id === id) {
+                          return {
+                            ...node,
+                            data: {
+                              ...node.data,
+                              query_ids: selectedNode,
+                            },
+                          };
+                        }
+                        return node;
+                      })
+                    );
+                  }}
+                  buttonHeight='32px'
+                  buttonBgColor='transparent'
+                  menuBgColor='#1A1A1A'
+                  listWidth='100%'
+                  containerClassnames='w-full'
+                />
+              </div>
+            </li>
+
+            {/* Documents 下拉选项 */}
+            <li className='flex flex-col gap-2'>
+              <div className='flex items-center gap-2'>
+                <label className='text-[13px] font-semibold text-[#6D7177]'>
+                  Documents
+                </label>
+                <div className='w-[5px] h-[5px] rounded-full bg-[#FF4D4D]'></div>
+              </div>
+              <div className='relative h-[32px] p-0 bg-[#252525] rounded-[6px] border-[1px] border-[#6D7177]/30 hover:border-[#6D7177]/50 transition-colors'>
+                <PuppyDropdown
+                  options={getSourceNodeIdWithLabel(id).map(node => node.label)}
+                  selectedValue={
+                    (getNode(id)?.data as GenerateConfigNodeData)?.document_ids
+                      ?.label || 'Choose Document'
+                  }
+                  onSelect={(value: string) => {
+                    const selectedNode = getSourceNodeIdWithLabel(id).find(
+                      node => node.label === value
+                    );
+                    setNodes(prevNodes =>
+                      prevNodes.map(node => {
+                        if (node.id === id) {
+                          return {
+                            ...node,
+                            data: {
+                              ...node.data,
+                              document_ids: selectedNode,
+                            },
+                          };
+                        }
+                        return node;
+                      })
+                    );
+                  }}
+                  buttonHeight='32px'
+                  buttonBgColor='transparent'
+                  menuBgColor='#1A1A1A'
+                  listWidth='100%'
+                  containerClassnames='w-full'
+                />
+              </div>
+            </li>
+
+            {/* Prompt Template 下拉选择 */}
+            <li className='flex flex-col gap-2'>
+              <div className='flex items-center gap-2'>
+                <label className='text-[13px] font-semibold text-[#6D7177]'>
+                  Prompt Template
+                </label>
+                <div className='w-[5px] h-[5px] rounded-full bg-[#FF4D4D]'></div>
+              </div>
+              <div className='relative h-[32px] p-0 bg-[#252525] rounded-[6px] border-[1px] border-[#6D7177]/30 hover:border-[#6D7177]/50 transition-colors'>
+                <PuppyDropdown
+                  options={
+                    Object.keys(PROMPT_TEMPLATES) as PromptTemplateType[]
+                  }
+                  selectedValue={selectedTemplate}
+                  onSelect={(value: string) => {
+                    setSelectedTemplate(value as PromptTemplateType);
+                  }}
+                  buttonHeight='32px'
+                  buttonBgColor='transparent'
+                  menuBgColor='#1A1A1A'
+                  listWidth='100%'
+                  containerClassnames='w-full'
+                  mapValueTodisplay={(v: string) =>
+                    v
+                      .replace(/_/g, ' ')
+                      .replace(/\b\w/g, (l: string) => l.toUpperCase())
+                  }
+                />
+              </div>
+            </li>
+
+            {/* Prompt Template 预览区域 */}
+            <li className='flex flex-col gap-2'>
+              <div className=' text-[10px] text-[#6D7177]'>
+                {PROMPT_TEMPLATES[selectedTemplate]}
+              </div>
+            </li>
+
+            {/* Model Selection */}
+            <li className='flex flex-col gap-2'>
+              <div className='flex items-center gap-2'>
+                <label className='text-[13px] font-semibold text-[#6D7177]'>
+                  Model & Provider
+                </label>
+              </div>
+              <div className='relative h-[32px] bg-[#252525] rounded-[6px] border-[1px] border-[#6D7177]/30 hover:border-[#6D7177]/50 transition-colors'>
+                <PuppyDropdown
+                  options={activeModels}
+                  selectedValue={model}
+                  onSelect={(selectedModel: Model) =>
+                    setModel(selectedModel.id)
+                  }
+                  valueKey='id'
+                  listWidth='100%'
+                  containerClassnames='w-full'
+                  mapValueTodisplay={mapModelToDisplay}
+                  renderOption={renderModelOption}
+                />
+              </div>
+            </li>
+
+            {/* Settings section */}
+            <li className='flex flex-col gap-2'>
+              <div className='flex items-center justify-between'>
+                <div className='flex items-center gap-2'>
+                  <label className='text-[13px] font-semibold text-[#6D7177]'>
+                    Advanced Settings
+                  </label>
+                </div>
+                <button
+                  onClick={() => setShowSettings(!showSettings)}
+                  className='text-[11px] text-[#6D7177] hover:text-white transition-colors'
                 >
-                  <path
-                    strokeLinecap='round'
-                    strokeLinejoin='round'
-                    strokeWidth={2}
-                    d='M19 9l-7 7-7-7'
-                  />
-                </svg>
-              </button>
-            </div>
+                  {showSettings ? 'Hide' : 'Show'}
+                </button>
+              </div>
 
-            {showSettings && (
-              <div className='flex flex-col gap-2 p-2 bg-[#1E1E1E] rounded-[8px] border-[1px] border-[#6D7177]/30'>
-                <div className='flex flex-col gap-2'>
-                  <div className='flex items-center gap-2'>
-                    <label className='text-[12px] font-medium text-[#6D7177]'>
-                      Model
-                    </label>
-                  </div>
-                  <div className='relative h-[32px] bg-[#252525] rounded-[6px] border-[1px] border-[#6D7177]/30 hover:border-[#6D7177]/50 transition-colors'>
-                    <PuppyDropdown
-                      options={activeModels}
-                      selectedValue={model}
-                      onSelect={(selectedModel: Model) =>
-                        setModel(selectedModel.id)
-                      }
-                      buttonHeight='32px'
-                      buttonBgColor='transparent'
-                      menuBgColor='#1A1A1A'
-                      listWidth='100%'
-                      containerClassnames='w-full'
-                      onFocus={onFocus}
-                      onBlur={onBlur}
-                      mapValueTodisplay={mapModelToDisplay}
-                      renderOption={renderModelOption}
-                    />
-                  </div>
-
-                  <div className='flex flex-col gap-1 mt-2'>
-                    <label className='text-[12px] font-medium text-[#6D7177]'>
-                      Base URL (Optional)
+              {showSettings && (
+                <div className='flex flex-col gap-3 p-2 bg-[#252525] rounded-md'>
+                  {/* Base URL */}
+                  <div className='flex flex-col gap-1'>
+                    <label className='text-[11px] text-[#6D7177]'>
+                      Base URL (optional)
                     </label>
                     <input
                       type='text'
                       value={baseUrl}
                       onChange={e => setBaseUrl(e.target.value)}
-                      placeholder='Enter base URL if needed'
-                      className='w-full h-[32px] px-3 bg-[#252525] rounded-[6px] border-[1px] border-[#6D7177]/30 
-                                                        text-[#CDCDCD] text-[12px] font-medium appearance-none
-                                                        hover:border-[#6D7177]/50 transition-colors'
-                      onMouseDownCapture={onFocus}
+                      placeholder='https://api.example.com/v1'
+                      className='h-[28px] px-2 bg-[#1E1E1E] border-[1px] border-[#6D7177]/30 rounded-[4px] text-[12px] text-white placeholder-[#6D7177] focus:border-[#6D7177]/50 focus:outline-none'
+                      onFocus={onFocus}
                       onBlur={onBlur}
                     />
                   </div>
+                  {/* Structured Output */}
+                  <div className='flex items-center justify-between'>
+                    <label className='text-[11px] text-[#6D7177]'>
+                      Structured Output (JSON)
+                    </label>
+                    <button
+                      onClick={() => setStructuredOutput(!structuredOutput)}
+                      className={`w-[40px] h-[20px] rounded-full border transition-colors ${
+                        structuredOutput
+                          ? 'bg-[#39BC66] border-[#39BC66]'
+                          : 'bg-[#1E1E1E] border-[#6D7177]/30'
+                      }`}
+                    >
+                      <div
+                        className={`w-[16px] h-[16px] bg-white rounded-full transition-transform ${
+                          structuredOutput
+                            ? 'translate-x-[22px]'
+                            : 'translate-x-[2px]'
+                        }`}
+                      />
+                    </button>
+                  </div>
                 </div>
-              </div>
-            )}
-          </li>
-        </ul>
-      )}
-    </div>
-  );
-}
+              )}
+            </li>
+          </ul>
+        )}
+      </div>
+    );
+  }
+);
 
+Generate.displayName = 'Generate';
 export default Generate;

--- a/PuppyFlow/app/components/workflow/edgesNode/edgeNodesNew/Retrieving.tsx
+++ b/PuppyFlow/app/components/workflow/edgesNode/edgeNodesNew/Retrieving.tsx
@@ -1,6 +1,13 @@
 import { Handle, Position, NodeProps, Node, useReactFlow } from '@xyflow/react';
 import { useNodesPerFlowContext } from '@/app/components/states/NodesPerFlowContext';
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import React, {
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+  useMemo,
+  memo,
+} from 'react';
 import InputOutputDisplay from './components/InputOutputDisplay';
 import { PuppyDropdown } from '@/app/components/misc/PuppyDropDown';
 import { UI_COLORS } from '@/app/utils/colors';
@@ -56,842 +63,888 @@ export type RetrievingConfigNodeData = {
 
 type RetrievingConfigNodeProps = NodeProps<Node<RetrievingConfigNodeData>>;
 
-function Retrieving({ isConnectable, id }: RetrievingConfigNodeProps) {
-  const {
-    isOnConnect,
-    activatedEdge,
-    isOnGeneratingNewNode,
-    clearEdgeActivation,
-    activateEdge,
-    clearAll,
-  } = useNodesPerFlowContext();
-  const [isTargetHandleTouched, setIsTargetHandleTouched] = useState(false);
-  const { getNode, setNodes, setEdges } = useReactFlow();
-  const { getSourceNodeIdWithLabel, getTargetNodeIdWithLabel } =
-    useGetSourceTarget();
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const [isLoading, setIsLoading] = useState(false);
-  const menuRef = useRef<HTMLUListElement>(null);
-  const [isHovered, setIsHovered] = useState(false);
-  const [isRunButtonHovered, setIsRunButtonHovered] = useState(false);
+const Retrieving: React.FC<RetrievingConfigNodeProps> = memo(
+  ({ isConnectable, id }: RetrievingConfigNodeProps) => {
+    const {
+      isOnConnect,
+      activatedEdge,
+      isOnGeneratingNewNode,
+      clearEdgeActivation,
+      activateEdge,
+      clearAll,
+    } = useNodesPerFlowContext();
+    const [isTargetHandleTouched, setIsTargetHandleTouched] = useState(false);
+    const { getNode, setNodes, setEdges } = useReactFlow();
+    const { getSourceNodeIdWithLabel, getTargetNodeIdWithLabel } =
+      useGetSourceTarget();
+    const [isMenuOpen, setIsMenuOpen] = useState(false);
+    const [isLoading, setIsLoading] = useState(false);
+    const menuRef = useRef<HTMLUListElement>(null);
+    const [isHovered, setIsHovered] = useState(false);
+    const [isRunButtonHovered, setIsRunButtonHovered] = useState(false);
 
-  // 获取所有需要的依赖
-  const { streamResult, reportError, resetLoadingUI } = useJsonConstructUtils();
-  const { getAuthHeaders } = useAppSettings();
+    // 获取所有需要的依赖
+    const { streamResult, reportError, resetLoadingUI } =
+      useJsonConstructUtils();
+    const { getAuthHeaders } = useAppSettings();
 
-  // 状态管理 - 保留在主组件中
-  const [query, setQuery] = useState<{ id: string; label: string }>(
-    (getNode(id)?.data as RetrievingConfigNodeData)?.query_id ?? {
-      id: '',
-      label: '',
-    }
-  );
-  const [top_k, setTop_k] = useState<number | undefined>(
-    (getNode(id)?.data as RetrievingConfigNodeData)?.top_k ?? 5
-  );
-  const [threshold, setThreshold] = useState<number | undefined>(
-    (getNode(id)?.data as RetrievingConfigNodeData)?.extra_configs?.threshold ??
-      0.7
-  );
-  const [showSettings, setShowSettings] = useState(false);
-  const [dataSource, setDataSource] = useState<
-    { label: string; id: string; index_item?: SimplifiedIndexItem }[]
-  >((getNode(id)?.data as RetrievingConfigNodeData)?.dataSource ?? []);
-  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+    // 使用 useRef 跟踪是否已挂载
+    const hasMountedRef = useRef(false);
 
-  // Refs
-  const queryRef = useRef<HTMLSelectElement>(null);
-  const thresholdRef = useRef<HTMLInputElement>(null);
-  const topkRef = useRef<HTMLInputElement>(null);
+    // 优化状态初始化 - 使用函数形式避免重复计算
+    const [query, setQuery] = useState<{ id: string; label: string }>(
+      () =>
+        (getNode(id)?.data as RetrievingConfigNodeData)?.query_id ?? {
+          id: '',
+          label: '',
+        }
+    );
 
-  // 接着定义一个新的 ref 用于存储扁平化的索引项列表
-  const flattenedIndexItems = useRef<
-    {
-      nodeId: string;
-      nodeLabel: string;
-      indexItem: IndexingItem;
-    }[]
-  >([]);
+    const [top_k, setTop_k] = useState<number | undefined>(
+      () => (getNode(id)?.data as RetrievingConfigNodeData)?.top_k ?? 5
+    );
 
-  // 更新扁平化的索引项列表
-  useEffect(() => {
-    const items: {
-      nodeId: string;
-      nodeLabel: string;
-      indexItem: IndexingItem;
-    }[] = [];
+    const [threshold, setThreshold] = useState<number | undefined>(
+      () =>
+        (getNode(id)?.data as RetrievingConfigNodeData)?.extra_configs
+          ?.threshold ?? 0.7
+    );
 
-    getSourceNodeIdWithLabel(id).forEach(node => {
-      const nodeInfo = getNode(node.id);
-      if (nodeInfo?.type === 'structured') {
-        const indexingList = nodeInfo?.data?.indexingList as
-          | IndexingItem[]
-          | undefined;
+    const [showSettings, setShowSettings] = useState(false);
 
-        if (Array.isArray(indexingList)) {
-          indexingList.forEach(item => {
-            if (item.type === 'vector' && item.status === 'done') {
-              items.push({
-                nodeId: node.id,
-                nodeLabel: node.label,
-                indexItem: item,
-              });
-            }
+    const [dataSource, setDataSource] = useState<
+      { label: string; id: string; index_item?: SimplifiedIndexItem }[]
+    >(() => (getNode(id)?.data as RetrievingConfigNodeData)?.dataSource ?? []);
+
+    const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+
+    // Refs
+    const queryRef = useRef<HTMLSelectElement>(null);
+    const thresholdRef = useRef<HTMLInputElement>(null);
+    const topkRef = useRef<HTMLInputElement>(null);
+
+    // 接着定义一个新的 ref 用于存储扁平化的索引项列表 - 使用 useMemo 缓存
+    const flattenedIndexItems = useMemo(() => {
+      const items: {
+        nodeId: string;
+        nodeLabel: string;
+        indexItem: IndexingItem;
+      }[] = [];
+
+      getSourceNodeIdWithLabel(id).forEach(node => {
+        const nodeInfo = getNode(node.id);
+        if (nodeInfo?.type === 'structured') {
+          const indexingList = nodeInfo?.data?.indexingList as
+            | IndexingItem[]
+            | undefined;
+
+          if (Array.isArray(indexingList)) {
+            indexingList.forEach(item => {
+              if (item.type === 'vector' && item.status === 'done') {
+                items.push({
+                  nodeId: node.id,
+                  nodeLabel: node.label,
+                  indexItem: item,
+                });
+              }
+            });
+          }
+        }
+      });
+
+      return items;
+    }, [getSourceNodeIdWithLabel(id), getNode]);
+
+    // 创建执行上下文 - 使用 useCallback 缓存
+    const createExecutionContext = useCallback(
+      (): RunSingleEdgeNodeContext => ({
+        getNode,
+        setNodes,
+        setEdges,
+        getSourceNodeIdWithLabel,
+        getTargetNodeIdWithLabel,
+        clearAll,
+        streamResult,
+        reportError,
+        resetLoadingUI,
+        getAuthHeaders,
+      }),
+      [
+        getNode,
+        setNodes,
+        setEdges,
+        getSourceNodeIdWithLabel,
+        getTargetNodeIdWithLabel,
+        clearAll,
+        streamResult,
+        reportError,
+        resetLoadingUI,
+        getAuthHeaders,
+      ]
+    );
+
+    // 使用执行函数的 handleDataSubmit - 使用 useCallback 缓存
+    const handleDataSubmit = useCallback(async () => {
+      if (isLoading) return;
+
+      setIsLoading(true);
+      try {
+        const context = createExecutionContext();
+        await runSingleEdgeNode({
+          parentId: id,
+          targetNodeType: 'structured',
+          context,
+          // 可以选择不提供 constructJsonData，使用默认实现
+        });
+      } catch (error) {
+        console.error('执行失败:', error);
+      } finally {
+        setIsLoading(false);
+      }
+    }, [id, isLoading, createExecutionContext]);
+
+    // 辅助函数 - 使用 useCallback 缓存
+    const onFocus = useCallback(() => {
+      const curRef = menuRef.current;
+      if (curRef && !curRef.classList.contains('nodrag')) {
+        curRef.classList.add('nodrag');
+      }
+    }, []);
+
+    const onBlur = useCallback(() => {
+      const curRef = menuRef.current;
+      if (curRef) {
+        curRef.classList.remove('nodrag');
+      }
+    }, []);
+
+    // 数据同步函数 - 使用 useCallback 缓存
+    const onQueryChange = useCallback(
+      (newQuery: { id: string; label: string }) => {
+        if (!isOnGeneratingNewNode && hasMountedRef.current) {
+          requestAnimationFrame(() => {
+            setNodes(prevNodes =>
+              prevNodes.map(node => {
+                if (node.id === id) {
+                  return {
+                    ...node,
+                    data: { ...node.data, query_id: newQuery },
+                  };
+                }
+                return node;
+              })
+            );
           });
         }
+      },
+      [id, setNodes, isOnGeneratingNewNode]
+    );
+
+    const onTopKChange = useCallback(
+      (newTopK: number | undefined) => {
+        if (!isOnGeneratingNewNode && hasMountedRef.current) {
+          requestAnimationFrame(() => {
+            setNodes(prevNodes =>
+              prevNodes.map(node => {
+                if (node.id === id) {
+                  return { ...node, data: { ...node.data, top_k: newTopK } };
+                }
+                return node;
+              })
+            );
+          });
+        }
+      },
+      [id, setNodes, isOnGeneratingNewNode]
+    );
+
+    const onThresholdChange = useCallback(
+      (newThreshold: number | undefined) => {
+        if (!isOnGeneratingNewNode && hasMountedRef.current) {
+          requestAnimationFrame(() => {
+            setNodes(prevNodes =>
+              prevNodes.map(node => {
+                if (node.id === id) {
+                  return {
+                    ...node,
+                    data: {
+                      ...node.data,
+                      extra_configs: {
+                        ...(node.data as RetrievingConfigNodeData)
+                          .extra_configs,
+                        threshold: newThreshold,
+                      },
+                    },
+                  };
+                }
+                return node;
+              })
+            );
+          });
+        }
+      },
+      [id, setNodes, isOnGeneratingNewNode]
+    );
+
+    // Node标签管理 - 使用 useCallback 缓存
+    const updateDataSourceInParent = useCallback(
+      (
+        dataSource: {
+          label: string;
+          id: string;
+          index_item?: SimplifiedIndexItem;
+        }[]
+      ) => {
+        if (!isOnGeneratingNewNode && hasMountedRef.current) {
+          requestAnimationFrame(() => {
+            setNodes(prevNodes =>
+              prevNodes.map(node => {
+                if (node.id === id) {
+                  return {
+                    ...node,
+                    data: { ...node.data, dataSource: dataSource },
+                  };
+                }
+                return node;
+              })
+            );
+          });
+        }
+      },
+      [id, setNodes, isOnGeneratingNewNode]
+    );
+
+    // 修改 addNodeLabel 函数 - 使用 useCallback 缓存
+    const addNodeLabel = useCallback(
+      (option: {
+        nodeId: string;
+        nodeLabel: string;
+        indexItem: IndexingItem;
+      }) => {
+        // 使用连入的 JSON Block 的 nodeId 作为 id
+        const nodeId = option.nodeId;
+
+        // 检查是否已经添加了相同 nodeId 的数据源
+        if (!dataSource.some(item => item.id === nodeId)) {
+          const simplifiedIndexItem: SimplifiedIndexItem = {
+            index_name: option.indexItem.index_name,
+            collection_configs: option.indexItem.collection_configs,
+          };
+
+          const newItem = {
+            id: nodeId, // 使用原始的 nodeId
+            label: option.nodeLabel,
+            index_item: simplifiedIndexItem, // 改为index_item
+          };
+
+          const newDataSource = [...dataSource, newItem];
+          setDataSource(newDataSource);
+          updateDataSourceInParent(newDataSource);
+        }
+      },
+      [dataSource, updateDataSourceInParent]
+    );
+
+    const removeNodeLabel = useCallback(
+      (index: number) => {
+        const newDataSource = [...dataSource];
+        newDataSource.splice(index, 1);
+        setDataSource(newDataSource);
+        updateDataSourceInParent(newDataSource);
+      },
+      [dataSource, updateDataSourceInParent]
+    );
+
+    // UI助手函数 - 使用 useCallback 和 useMemo 缓存
+    const queryOptions = useMemo(() => {
+      return getSourceNodeIdWithLabel(id)
+        .filter(node => {
+          const nodeInfo = getNode(node.id);
+          return nodeInfo?.type === 'text';
+        })
+        .map(q => ({
+          id: q.id,
+          label: q.label,
+        }));
+    }, [getSourceNodeIdWithLabel(id), getNode]);
+
+    // 状态同步逻辑 - 使用 requestAnimationFrame 延迟执行，避免在节点创建时干扰
+    useEffect(() => {
+      if (!isOnGeneratingNewNode && hasMountedRef.current) {
+        onQueryChange(query);
       }
-    });
+    }, [query, onQueryChange, isOnGeneratingNewNode]);
 
-    flattenedIndexItems.current = items;
-  }, [getSourceNodeIdWithLabel(id)]);
+    useEffect(() => {
+      if (!isOnGeneratingNewNode && hasMountedRef.current) {
+        onTopKChange(top_k);
+      }
+    }, [top_k, onTopKChange, isOnGeneratingNewNode]);
 
-  // 创建执行上下文
-  const createExecutionContext = useCallback(
-    (): RunSingleEdgeNodeContext => ({
-      getNode,
-      setNodes,
-      setEdges,
-      getSourceNodeIdWithLabel,
-      getTargetNodeIdWithLabel,
-      clearAll,
-      streamResult,
-      reportError,
-      resetLoadingUI,
-      getAuthHeaders,
-    }),
-    [
-      getNode,
-      setNodes,
-      setEdges,
-      getSourceNodeIdWithLabel,
-      getTargetNodeIdWithLabel,
-      clearAll,
-      streamResult,
-      reportError,
-      resetLoadingUI,
-      getAuthHeaders,
-    ]
-  );
+    useEffect(() => {
+      if (!isOnGeneratingNewNode && hasMountedRef.current) {
+        onThresholdChange(threshold);
+      }
+    }, [threshold, onThresholdChange, isOnGeneratingNewNode]);
 
-  // 使用执行函数的 handleDataSubmit
-  const handleDataSubmit = useCallback(async () => {
-    if (isLoading) return;
+    // 组件初始化
+    useEffect(() => {
+      hasMountedRef.current = true;
+    }, []);
 
-    setIsLoading(true);
-    try {
-      const context = createExecutionContext();
-      await runSingleEdgeNode({
-        parentId: id,
-        targetNodeType: 'structured',
-        context,
-        // 可以选择不提供 constructJsonData，使用默认实现
-      });
-    } catch (error) {
-      console.error('执行失败:', error);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [id, isLoading, createExecutionContext]);
+    useEffect(() => {
+      if (hasMountedRef.current && !isOnGeneratingNewNode) {
+        clearAll();
+        activateEdge(id);
+      }
 
-  // 状态同步逻辑 - 保留在主组件中
-  useEffect(() => {
-    onQueryChange(query);
-  }, [query]);
+      return () => {
+        if (activatedEdge === id) {
+          clearEdgeActivation();
+        }
+      };
+    }, [isOnGeneratingNewNode]);
 
-  useEffect(() => {
-    onTopKChange(top_k);
-  }, [top_k]);
+    // UI 交互函数 - 使用 useCallback 缓存
+    const onClickButton = useCallback(() => {
+      setIsMenuOpen(!isMenuOpen);
 
-  useEffect(() => {
-    onThresholdChange(threshold);
-  }, [threshold]);
-
-  // 组件初始化
-  useEffect(() => {
-    if (!isOnGeneratingNewNode) {
-      clearAll();
-      activateEdge(id);
-    }
-
-    return () => {
+      if (isOnGeneratingNewNode) return;
       if (activatedEdge === id) {
         clearEdgeActivation();
+      } else {
+        clearAll();
+        activateEdge(id);
       }
-    };
-  }, []);
+    }, [
+      isMenuOpen,
+      isOnGeneratingNewNode,
+      activatedEdge,
+      id,
+      clearEdgeActivation,
+      clearAll,
+      activateEdge,
+    ]);
 
-  // UI 交互函数
-  const onClickButton = () => {
-    setIsMenuOpen(!isMenuOpen);
+    // 修改 onDataSubmit 函数 - 使用 useCallback 缓存
+    const onDataSubmit = useCallback(() => {
+      handleDataSubmit();
+    }, [handleDataSubmit]);
 
-    if (isOnGeneratingNewNode) return;
-    if (activatedEdge === id) {
-      clearEdgeActivation();
-    } else {
-      clearAll();
-      activateEdge(id);
-    }
-  };
+    // 添加停止函数 - 使用 useCallback 缓存
+    const onStopExecution = useCallback(() => {
+      console.log('Stop execution');
+      setIsLoading(false);
+    }, []);
 
-  const onFocus = () => {
-    const curRef = menuRef.current;
-    if (curRef && !curRef.classList.contains('nodrag')) {
-      curRef.classList.add('nodrag');
-    }
-  };
-
-  const onBlur = () => {
-    const curRef = menuRef.current;
-    if (curRef) {
-      curRef.classList.remove('nodrag');
-    }
-  };
-
-  // 数据同步函数
-  const onQueryChange = (newQuery: { id: string; label: string }) => {
-    setNodes(prevNodes =>
-      prevNodes.map(node => {
-        if (node.id === id) {
-          return { ...node, data: { ...node.data, query_id: newQuery } };
-        }
-        return node;
-      })
+    // 在组件顶部定义共享样式 - 使用 useMemo 缓存
+    const handleStyle = useMemo(
+      () => ({
+        position: 'absolute' as const,
+        width: 'calc(100%)',
+        height: 'calc(100%)',
+        top: '0',
+        left: '0',
+        borderRadius: '0',
+        transform: 'translate(0px, 0px)',
+        background: 'transparent',
+        border: '3px solid transparent',
+        zIndex: !isOnConnect ? '-1' : '1',
+      }),
+      [isOnConnect]
     );
-  };
 
-  const onTopKChange = (newTopK: number | undefined) => {
-    setNodes(prevNodes =>
-      prevNodes.map(node => {
-        if (node.id === id) {
-          return { ...node, data: { ...node.data, top_k: newTopK } };
-        }
-        return node;
-      })
+    // 缓存按钮样式 - 使用 useMemo 缓存
+    const runButtonStyle = useMemo(
+      () => ({
+        backgroundColor: isRunButtonHovered
+          ? isLoading
+            ? '#FFA73D'
+            : '#39BC66'
+          : '#181818',
+        borderColor: isRunButtonHovered
+          ? isLoading
+            ? '#FFA73D'
+            : '#39BC66'
+          : UI_COLORS.EDGENODE_BORDER_GREY,
+        color: isRunButtonHovered ? '#000' : UI_COLORS.EDGENODE_BORDER_GREY,
+      }),
+      [isRunButtonHovered, isLoading]
     );
-  };
 
-  const onThresholdChange = (newThreshold: number | undefined) => {
-    setNodes(prevNodes =>
-      prevNodes.map(node => {
-        if (node.id === id) {
-          return {
-            ...node,
-            data: {
-              ...node.data,
-              extra_configs: {
-                ...(node.data as RetrievingConfigNodeData).extra_configs,
-                threshold: newThreshold,
-              },
-            },
-          };
-        }
-        return node;
-      })
-    );
-  };
-
-  // Node标签管理
-  const updateDataSourceInParent = (
-    dataSource: {
-      label: string;
-      id: string;
-      index_item?: SimplifiedIndexItem;
-    }[]
-  ) => {
-    setNodes(prevNodes =>
-      prevNodes.map(node => {
-        if (node.id === id) {
-          return { ...node, data: { ...node.data, dataSource: dataSource } };
-        }
-        return node;
-      })
-    );
-  };
-
-  // 修改 addNodeLabel 函数
-  const addNodeLabel = (option: {
-    nodeId: string;
-    nodeLabel: string;
-    indexItem: IndexingItem;
-  }) => {
-    // 使用连入的 JSON Block 的 nodeId 作为 id
-    const nodeId = option.nodeId;
-
-    // 检查是否已经添加了相同 nodeId 的数据源
-    if (!dataSource.some(item => item.id === nodeId)) {
-      const simplifiedIndexItem: SimplifiedIndexItem = {
-        index_name: option.indexItem.index_name,
-        collection_configs: option.indexItem.collection_configs,
-      };
-
-      const newItem = {
-        id: nodeId, // 使用原始的 nodeId
-        label: option.nodeLabel,
-        index_item: simplifiedIndexItem, // 改为index_item
-      };
-
-      const newDataSource = [...dataSource, newItem];
-      setDataSource(newDataSource);
-      updateDataSourceInParent(newDataSource);
-    }
-  };
-
-  const removeNodeLabel = (index: number) => {
-    const newDataSource = [...dataSource];
-    newDataSource.splice(index, 1);
-    setDataSource(newDataSource);
-    updateDataSourceInParent(newDataSource);
-  };
-
-  // UI助手函数
-  const displayQueryLabels = () => {
-    const queryList = getSourceNodeIdWithLabel(id).filter(node => {
-      const nodeInfo = getNode(node.id);
-      if (nodeInfo?.type === 'text') {
-        return true;
-      }
-      return false;
-    });
-    if (queryList.length > 0 && !query.id) {
-      setQuery({ id: queryList[0].id, label: queryList[0].label });
-    } else if (queryList.length > 0 && query.id) {
-      if (!queryList.map(node => node.id).includes(query.id)) {
-        setQuery({ id: queryList[0].id, label: queryList[0].label });
-      }
-    } else if (queryList.length === 0 && query.id) {
-      setQuery({ id: '', label: '' });
-    }
-
-    return queryList.map((q: { id: string; label: string }) => (
-      <option key={`${q.id}-${id}`} value={q.id} className='text-[#3B9BFF]'>
-        {`{{${q.label}}}`}
-      </option>
-    ));
-  };
-
-  // 修改 onDataSubmit 函数
-  const onDataSubmit = () => {
-    handleDataSubmit();
-  };
-
-  // 在组件顶部定义共享样式
-  const handleStyle = {
-    position: 'absolute' as const,
-    width: 'calc(100%)',
-    height: 'calc(100%)',
-    top: '0',
-    left: '0',
-    borderRadius: '0',
-    transform: 'translate(0px, 0px)',
-    background: 'transparent',
-    border: '3px solid transparent',
-    zIndex: !isOnConnect ? '-1' : '1',
-  };
-
-  return (
-    <div className='p-[3px] w-[80px] h-[48px] relative'>
-      {/* Invisible hover area between node and run button */}
-      <div
-        className='absolute -top-[40px] left-0 w-full h-[40px]'
-        onMouseEnter={() => setIsHovered(true)}
-        onMouseLeave={() => setIsHovered(false)}
-      />
-
-      {/* Run button positioned above the node - show when node or run button is hovered */}
-      <button
-        className={`absolute -top-[40px] left-1/2 transform -translate-x-1/2 w-[57px] h-[24px] rounded-[6px] border-[1px] text-[10px] font-[600] font-plus-jakarta-sans flex flex-row items-center justify-center gap-[4px] transition-all duration-200 ${
-          isHovered || isRunButtonHovered ? 'opacity-100' : 'opacity-0'
-        }`}
-        style={{
-          backgroundColor: isRunButtonHovered ? '#39BC66' : '#181818',
-          borderColor: isRunButtonHovered
-            ? '#39BC66'
-            : UI_COLORS.EDGENODE_BORDER_GREY,
-          color: isRunButtonHovered ? '#000' : UI_COLORS.EDGENODE_BORDER_GREY,
-        }}
-        onClick={onDataSubmit}
-        disabled={isLoading}
-        onMouseEnter={() => setIsRunButtonHovered(true)}
-        onMouseLeave={() => setIsRunButtonHovered(false)}
-      >
-        <span>
-          {isLoading ? (
-            <svg className='animate-spin h-3 w-3' viewBox='0 0 24 24'>
-              <circle
-                className='opacity-25'
-                cx='12'
-                cy='12'
-                r='10'
-                stroke='currentColor'
-                strokeWidth='4'
-              ></circle>
-              <path
-                className='opacity-75'
-                fill='currentColor'
-                d='M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 714 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z'
-              ></path>
-            </svg>
-          ) : (
-            <svg
-              xmlns='http://www.w3.org/2000/svg'
-              width='6'
-              height='8'
-              viewBox='0 0 8 10'
-              fill='none'
-            >
-              <path d='M8 5L0 10V0L8 5Z' fill='currentColor' />
-            </svg>
-          )}
-        </span>
-        <span>{isLoading ? '' : 'Run'}</span>
-      </button>
-
-      <button
-        onClick={onClickButton}
-        onMouseEnter={() => setIsHovered(true)}
-        onMouseLeave={() => setIsHovered(false)}
-        className={`w-full h-full flex-shrink-0 rounded-[8px] border-[2px] bg-[#181818] flex items-center justify-center font-plus-jakarta-sans text-[10px] font-[700] edge-node transition-colors gap-[4px]`}
-        style={{
-          borderColor: isHovered
+    const mainButtonStyle = useMemo(
+      () => ({
+        borderColor: isLoading
+          ? '#FFA73D'
+          : isHovered
             ? UI_COLORS.LINE_ACTIVE
             : UI_COLORS.EDGENODE_BORDER_GREY,
-          color: isHovered
+        color: isLoading
+          ? '#FFA73D'
+          : isHovered
             ? UI_COLORS.LINE_ACTIVE
             : UI_COLORS.EDGENODE_BORDER_GREY,
-        }}
-      >
-        {/* Retrieve SVG icon */}
-        <svg
-          xmlns='http://www.w3.org/2000/svg'
-          width='10'
-          height='10'
-          fill='none'
-          viewBox='0 0 14 14'
+      }),
+      [isLoading, isHovered]
+    );
+
+    return (
+      <div className='p-[3px] w-[80px] h-[48px] relative'>
+        {/* Invisible hover area between node and run button */}
+        <div
+          className='absolute -top-[40px] left-0 w-full h-[40px]'
+          onMouseEnter={() => setIsHovered(true)}
+          onMouseLeave={() => setIsHovered(false)}
+        />
+
+        {/* Run button positioned above the node - show when node or run button is hovered */}
+        <button
+          className={`absolute -top-[40px] left-1/2 transform -translate-x-1/2 w-[57px] h-[24px] rounded-[6px] border-[1px] text-[10px] font-[600] font-plus-jakarta-sans flex flex-row items-center justify-center gap-[4px] transition-all duration-200 ${
+            isHovered || isRunButtonHovered ? 'opacity-100' : 'opacity-0'
+          }`}
+          style={runButtonStyle}
+          onClick={isLoading ? onStopExecution : onDataSubmit}
+          disabled={false}
+          onMouseEnter={() => setIsRunButtonHovered(true)}
+          onMouseLeave={() => setIsRunButtonHovered(false)}
         >
-          <path
-            fill='currentColor'
-            d='m0 14 4.597-.446-2.684-3.758L0 14Zm6.768-5.325-4.071 2.907.465.651 4.07-2.908-.465-.65Z'
-          />
-          <path stroke='currentColor' strokeWidth='1.5' d='M7 9V2' />
-          <path fill='currentColor' d='M7 0 4.69 4h4.62L7 0Z' />
-          <path stroke='currentColor' strokeWidth='1.5' d='m7 9-5 3.5' />
-          <path
-            fill='currentColor'
-            d='m14 14-4.597-.446 2.684-3.758L14 14ZM7.232 8.675l4.071 2.907-.465.651-4.07-2.908.465-.65Z'
-          />
-          <path stroke='currentColor' strokeWidth='1.5' d='m7 9 5 3.5' />
-        </svg>
-        <div className='flex flex-col items-center justify-center leading-tight text-[9px]'>
-          <span>Retrieve</span>
-        </div>
-
-        {/* ... existing handles remain the same ... */}
-        <Handle
-          id={`${id}-a`}
-          className='edgeSrcHandle handle-with-icon handle-top'
-          type='source'
-          position={Position.Top}
-        />
-        <Handle
-          id={`${id}-b`}
-          className='edgeSrcHandle handle-with-icon handle-right'
-          type='source'
-          position={Position.Right}
-        />
-        <Handle
-          id={`${id}-c`}
-          className='edgeSrcHandle handle-with-icon handle-bottom'
-          type='source'
-          position={Position.Bottom}
-        />
-        <Handle
-          id={`${id}-d`}
-          className='edgeSrcHandle handle-with-icon handle-left'
-          type='source'
-          position={Position.Left}
-        />
-
-        <Handle
-          id={`${id}-a`}
-          type='target'
-          position={Position.Top}
-          style={handleStyle}
-          isConnectable={isConnectable}
-          onMouseEnter={() => setIsTargetHandleTouched(true)}
-          onMouseLeave={() => setIsTargetHandleTouched(false)}
-        />
-        <Handle
-          id={`${id}-b`}
-          type='target'
-          position={Position.Right}
-          style={handleStyle}
-          isConnectable={isConnectable}
-          onMouseEnter={() => setIsTargetHandleTouched(true)}
-          onMouseLeave={() => setIsTargetHandleTouched(false)}
-        />
-        <Handle
-          id={`${id}-c`}
-          type='target'
-          position={Position.Bottom}
-          style={handleStyle}
-          isConnectable={isConnectable}
-          onMouseEnter={() => setIsTargetHandleTouched(true)}
-          onMouseLeave={() => setIsTargetHandleTouched(false)}
-        />
-        <Handle
-          id={`${id}-d`}
-          type='target'
-          position={Position.Left}
-          style={handleStyle}
-          isConnectable={isConnectable}
-          onMouseEnter={() => setIsTargetHandleTouched(true)}
-          onMouseLeave={() => setIsTargetHandleTouched(false)}
-        />
-      </button>
-
-      {/* Configuration Menu (integrated directly) */}
-      {isMenuOpen && (
-        <ul
-          ref={menuRef}
-          className='absolute top-[64px] text-white w-[320px] rounded-[16px] border-[1px] bg-[#1A1A1A] p-[12px] font-plus-jakarta-sans flex flex-col gap-[16px] shadow-lg'
-          style={{
-            borderColor: UI_COLORS.EDGENODE_BORDER_GREY,
-          }}
-        >
-          <li className='flex h-[28px] gap-1 items-center justify-between font-plus-jakarta-sans'>
-            <div className='flex flex-row gap-[12px]'>
-              <div className='flex flex-row gap-[8px] justify-center items-center'>
-                <div className='w-[24px] h-[24px] border-[1px] border-main-grey bg-main-black-theme rounded-[8px] flex items-center justify-center'>
-                  <svg
-                    xmlns='http://www.w3.org/2000/svg'
-                    width='14'
-                    height='14'
-                    fill='none'
-                    viewBox='0 0 14 14'
-                  >
-                    <path
-                      fill='#CDCDCD'
-                      d='m0 14 4.597-.446-2.684-3.758L0 14Zm6.768-5.325-4.071 2.907.465.651 4.07-2.908-.465-.65Z'
-                    />
-                    <path stroke='#CDCDCD' strokeWidth='1.5' d='M7 9V2' />
-                    <path fill='#CDCDCD' d='M7 0 4.69 4h4.62L7 0Z' />
-                    <path stroke='#CDCDCD' strokeWidth='1.5' d='m7 9-5 3.5' />
-                    <path
-                      fill='#CDCDCD'
-                      d='m14 14-4.597-.446 2.684-3.758L14 14ZM7.232 8.675l4.071 2.907-.465.651-4.07-2.908.465-.65Z'
-                    />
-                    <path stroke='#CDCDCD' strokeWidth='1.5' d='m7 9 5 3.5' />
-                  </svg>
-                </div>
-                <div className='flex items-center justify-center text-[14px] font-semibold text-main-grey font-plus-jakarta-sans leading-normal'>
-                  Retrieve by Vector
-                </div>
-              </div>
-            </div>
-            <div className='w-[57px] h-[26px]'>
-              <button
-                className='w-full h-full rounded-[8px] bg-[#39BC66] text-[#000] text-[12px] font-semibold font-plus-jakarta-sans flex flex-row items-center justify-center gap-[7px]'
-                onClick={onDataSubmit}
-                disabled={isLoading}
+          <span>
+            {isLoading ? (
+              <svg width='6' height='6' viewBox='0 0 6 6' fill='none'>
+                <rect width='6' height='6' fill='currentColor' />
+              </svg>
+            ) : (
+              <svg
+                xmlns='http://www.w3.org/2000/svg'
+                width='6'
+                height='8'
+                viewBox='0 0 8 10'
+                fill='none'
               >
-                <span>
-                  {isLoading ? (
-                    <svg className='animate-spin h-4 w-4' viewBox='0 0 24 24'>
-                      <circle
-                        className='opacity-25'
-                        cx='12'
-                        cy='12'
-                        r='10'
-                        stroke='currentColor'
-                        strokeWidth='4'
-                      ></circle>
-                      <path
-                        className='opacity-75'
-                        fill='currentColor'
-                        d='M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 714 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z'
-                      ></path>
-                    </svg>
-                  ) : (
+                <path d='M8 5L0 10V0L8 5Z' fill='currentColor' />
+              </svg>
+            )}
+          </span>
+          <span>{isLoading ? 'Stop' : 'Run'}</span>
+        </button>
+
+        <button
+          onClick={onClickButton}
+          onMouseEnter={() => setIsHovered(true)}
+          onMouseLeave={() => setIsHovered(false)}
+          className={`w-full h-full flex-shrink-0 rounded-[8px] border-[2px] bg-[#181818] flex items-center justify-center font-plus-jakarta-sans text-[10px] font-[700] edge-node transition-colors gap-[4px]`}
+          style={mainButtonStyle}
+        >
+          {/* Retrieve SVG icon */}
+          <svg
+            xmlns='http://www.w3.org/2000/svg'
+            width='10'
+            height='10'
+            fill='none'
+            viewBox='0 0 14 14'
+          >
+            <path
+              fill='currentColor'
+              d='m0 14 4.597-.446-2.684-3.758L0 14Zm6.768-5.325-4.071 2.907.465.651 4.07-2.908-.465-.65Z'
+            />
+            <path stroke='currentColor' strokeWidth='1.5' d='M7 9V2' />
+            <path fill='currentColor' d='M7 0 4.69 4h4.62L7 0Z' />
+            <path stroke='currentColor' strokeWidth='1.5' d='m7 9-5 3.5' />
+            <path
+              fill='currentColor'
+              d='m14 14-4.597-.446 2.684-3.758L14 14ZM7.232 8.675l4.071 2.907-.465.651-4.07-2.908.465-.65Z'
+            />
+            <path stroke='currentColor' strokeWidth='1.5' d='m7 9 5 3.5' />
+          </svg>
+          <div className='flex flex-col items-center justify-center leading-tight text-[9px]'>
+            <span>Retrieve</span>
+          </div>
+
+          {/* ... existing handles remain the same ... */}
+          <Handle
+            id={`${id}-a`}
+            className='edgeSrcHandle handle-with-icon handle-top'
+            type='source'
+            position={Position.Top}
+          />
+          <Handle
+            id={`${id}-b`}
+            className='edgeSrcHandle handle-with-icon handle-right'
+            type='source'
+            position={Position.Right}
+          />
+          <Handle
+            id={`${id}-c`}
+            className='edgeSrcHandle handle-with-icon handle-bottom'
+            type='source'
+            position={Position.Bottom}
+          />
+          <Handle
+            id={`${id}-d`}
+            className='edgeSrcHandle handle-with-icon handle-left'
+            type='source'
+            position={Position.Left}
+          />
+
+          <Handle
+            id={`${id}-a`}
+            type='target'
+            position={Position.Top}
+            style={handleStyle}
+            isConnectable={isConnectable}
+            onMouseEnter={() => setIsTargetHandleTouched(true)}
+            onMouseLeave={() => setIsTargetHandleTouched(false)}
+          />
+          <Handle
+            id={`${id}-b`}
+            type='target'
+            position={Position.Right}
+            style={handleStyle}
+            isConnectable={isConnectable}
+            onMouseEnter={() => setIsTargetHandleTouched(true)}
+            onMouseLeave={() => setIsTargetHandleTouched(false)}
+          />
+          <Handle
+            id={`${id}-c`}
+            type='target'
+            position={Position.Bottom}
+            style={handleStyle}
+            isConnectable={isConnectable}
+            onMouseEnter={() => setIsTargetHandleTouched(true)}
+            onMouseLeave={() => setIsTargetHandleTouched(false)}
+          />
+          <Handle
+            id={`${id}-d`}
+            type='target'
+            position={Position.Left}
+            style={handleStyle}
+            isConnectable={isConnectable}
+            onMouseEnter={() => setIsTargetHandleTouched(true)}
+            onMouseLeave={() => setIsTargetHandleTouched(false)}
+          />
+        </button>
+
+        {/* Configuration Menu (integrated directly) */}
+        {isMenuOpen && (
+          <ul
+            ref={menuRef}
+            className='absolute top-[64px] text-white w-[320px] rounded-[16px] border-[1px] bg-[#1A1A1A] p-[12px] font-plus-jakarta-sans flex flex-col gap-[16px] shadow-lg'
+            style={{
+              borderColor: UI_COLORS.EDGENODE_BORDER_GREY,
+            }}
+          >
+            <li className='flex h-[28px] gap-1 items-center justify-between font-plus-jakarta-sans'>
+              <div className='flex flex-row gap-[12px]'>
+                <div className='flex flex-row gap-[8px] justify-center items-center'>
+                  <div className='w-[24px] h-[24px] border-[1px] border-main-grey bg-main-black-theme rounded-[8px] flex items-center justify-center'>
                     <svg
                       xmlns='http://www.w3.org/2000/svg'
-                      width='8'
-                      height='10'
-                      viewBox='0 0 8 10'
+                      width='14'
+                      height='14'
                       fill='none'
+                      viewBox='0 0 14 14'
                     >
-                      <path d='M8 5L0 10V0L8 5Z' fill='black' />
+                      <path
+                        fill='#CDCDCD'
+                        d='m0 14 4.597-.446-2.684-3.758L0 14Zm6.768-5.325-4.071 2.907.465.651 4.07-2.908-.465-.65Z'
+                      />
+                      <path stroke='#CDCDCD' strokeWidth='1.5' d='M7 9V2' />
+                      <path fill='#CDCDCD' d='M7 0 4.69 4h4.62L7 0Z' />
+                      <path stroke='#CDCDCD' strokeWidth='1.5' d='m7 9-5 3.5' />
+                      <path
+                        fill='#CDCDCD'
+                        d='m14 14-4.597-.446 2.684-3.758L14 14ZM7.232 8.675l4.071 2.907-.465.651-4.07-2.908.465-.65Z'
+                      />
+                      <path stroke='#CDCDCD' strokeWidth='1.5' d='m7 9 5 3.5' />
                     </svg>
-                  )}
-                </span>
-                <span>{isLoading ? '' : 'Run'}</span>
-              </button>
-            </div>
-          </li>
-
-          {/* Input/Output display */}
-          <li>
-            <InputOutputDisplay
-              parentId={id}
-              getNode={getNode}
-              getSourceNodeIdWithLabel={getSourceNodeIdWithLabel}
-              getTargetNodeIdWithLabel={getTargetNodeIdWithLabel}
-              supportedInputTypes={['text', 'structured']}
-              supportedOutputTypes={['structured']}
-              inputNodeCategory='blocknode'
-              outputNodeCategory='blocknode'
-            />
-          </li>
-
-          <li className='flex flex-col gap-2'>
-            <div className='flex items-center gap-2'>
-              <label className='text-[13px] font-semibold text-[#6D7177]'>
-                Query
-              </label>
-              <div className='w-[5px] h-[5px] rounded-full bg-[#FF4D4D]'></div>
-            </div>
-            <div className='flex items-center gap-2 h-[32px] p-0 bg-[#252525] rounded-[6px] border-[1px] border-[#6D7177]/30 hover:border-[#6D7177]/50 transition-colors'>
-              <PuppyDropdown
-                options={getSourceNodeIdWithLabel(id)
-                  .filter(node => getNode(node.id)?.type === 'text')
-                  .map(q => ({
-                    id: q.id,
-                    label: q.label,
-                  }))}
-                selectedValue={
-                  query.id ? { id: query.id, label: query.label } : null
-                }
-                onSelect={(value: { id: string; label: string }) => {
-                  setQuery({ id: value.id, label: value.label });
-                }}
-                buttonHeight='32px'
-                buttonBgColor='transparent'
-                menuBgColor='#1A1A1A'
-                listWidth='100%'
-                containerClassnames='w-full'
-                mapValueTodisplay={(value: any) =>
-                  value && value.label ? (
-                    <span className='text-[#3B9BFF] text-[12px] font-medium'>{`{{${value.label}}}`}</span>
-                  ) : (
-                    <span className='text-[#6D7177] text-[12px]'>
-                      Select a query
-                    </span>
-                  )
-                }
-                renderOption={(option: { id: string; label: string }) => (
-                  <div className='text-[#3B9BFF] text-[12px] font-medium'>{`{{${option.label}}}`}</div>
-                )}
-              />
-            </div>
-          </li>
-
-          <li className='flex flex-col gap-2'>
-            <div className='flex items-center gap-2'>
-              <label className='text-[13px] font-semibold text-[#6D7177]'>
-                Indexed Structured Data
-              </label>
-              <div className='w-[5px] h-[5px] rounded-full bg-[#FF4D4D]'></div>
-            </div>
-
-            {/* start of node labels */}
-            <div className='bg-[#1E1E1E] rounded-[8px] p-[8px] border-[1px] border-[#6D7177]/30 hover:border-[#6D7177]/50 transition-colors'>
-              <div className='flex flex-wrap gap-2 items-center min-h-[12px]'>
-                {dataSource.map((item, index) => (
-                  <div
-                    key={index}
-                    className='flex items-center bg-[#252525] rounded-[4px] h-[26px] p-[6px]
-                                                    border border-[#9B7EDB]/30 hover:border-[#9B7EDB]/50 
-                                                    transition-colors group'
-                  >
-                    <span className='text-[10px] px-1'>
-                      <span className='text-[#9B7EDB]'>{`{{${item.label}}}`}</span>
-                      <span className='text-[#CDCDCD]'>
-                        -{item.index_item?.index_name}
-                      </span>
-                    </span>
-                    <button
-                      onClick={() => removeNodeLabel(index)}
-                      className='text-[#6D7177] hover:text-[#ff6b6b] transition-colors 
-                                                        px-1 opacity-0 group-hover:opacity-100'
-                    >
+                  </div>
+                  <div className='flex items-center justify-center text-[14px] font-semibold text-main-grey font-plus-jakarta-sans leading-normal'>
+                    Retrieve by Vector
+                  </div>
+                </div>
+              </div>
+              <div className='w-[57px] h-[26px]'>
+                <button
+                  className='w-full h-full rounded-[8px] text-[#000] text-[12px] font-semibold font-plus-jakarta-sans flex flex-row items-center justify-center gap-[7px]'
+                  style={{
+                    backgroundColor: isLoading ? '#FFA73D' : '#39BC66',
+                  }}
+                  onClick={isLoading ? onStopExecution : onDataSubmit}
+                  disabled={false}
+                >
+                  <span>
+                    {isLoading ? (
+                      <svg width='8' height='8' viewBox='0 0 8 8' fill='none'>
+                        <rect width='8' height='8' fill='currentColor' />
+                      </svg>
+                    ) : (
                       <svg
                         xmlns='http://www.w3.org/2000/svg'
-                        width='10'
+                        width='8'
                         height='10'
-                        viewBox='0 0 24 24'
+                        viewBox='0 0 8 10'
                         fill='none'
-                        stroke='currentColor'
-                        strokeWidth='2'
-                        strokeLinecap='round'
-                        strokeLinejoin='round'
                       >
-                        <line x1='18' y1='6' x2='6' y2='18'></line>
-                        <line x1='6' y1='6' x2='18' y2='18'></line>
+                        <path d='M8 5L0 10V0L8 5Z' fill='black' />
                       </svg>
-                    </button>
-                  </div>
-                ))}
-                <div className='relative w-[26px] h-[26px] bg-[#252525] rounded-[6px] border-[1px] border-[#6D7177]/30'>
-                  <PuppyDropdown
-                    options={flattenedIndexItems.current.map(item => ({
-                      nodeId: item.nodeId,
-                      nodeLabel: item.nodeLabel,
-                      indexItem: item.indexItem,
-                      displayText: item.nodeLabel,
-                    }))}
-                    onSelect={(option: {
-                      nodeId: string;
-                      nodeLabel: string;
-                      indexItem: IndexingItem;
-                    }) => addNodeLabel(option)}
-                    selectedValue={null}
-                    optionBadge={false}
-                    listWidth='250px'
-                    buttonHeight='26px'
-                    buttonBgColor='transparent'
-                    menuBgColor='#1A1A1A'
-                    containerClassnames='w-[26px]'
-                    showDropdownIcon={false}
-                    mapValueTodisplay={(
-                      value:
-                        | null
-                        | undefined
-                        | string
-                        | {
-                            nodeId: string;
-                            nodeLabel: string;
-                            indexItem: IndexingItem;
-                          }
-                        | any
-                    ) => {
-                      if (value === null || value === undefined)
-                        return (
-                          <span className='flex items-center justify-center w-full h-full'>
-                            <svg width='10' height='10' viewBox='0 0 14 14'>
-                              <path
-                                d='M7 0v14M0 7h14'
-                                stroke='#6D7177'
-                                strokeWidth='2'
-                              />
-                            </svg>
-                          </span>
-                        );
-
-                      return (
-                        <span className='flex items-center justify-center w-full h-full'>
-                          <svg width='10' height='10' viewBox='0 0 14 14'>
-                            <path
-                              d='M7 0v14M0 7h14'
-                              stroke='#6D7177'
-                              strokeWidth='2'
-                            />
-                          </svg>
-                        </span>
-                      );
-                    }}
-                    renderOption={(option: {
-                      nodeId: string;
-                      nodeLabel: string;
-                      indexItem: IndexingItem;
-                      displayText: string;
-                    }) => (
-                      <div className='px-2 py-1 rounded cursor-pointer'>
-                        <div className='text-[11px] text-[#9B7EDB]'>{`{{${option.nodeLabel}}}`}</div>
-                        <div className='text-[9px] text-[#6D7177] truncate'>
-                          {option.indexItem.index_name}
-                        </div>
-                      </div>
                     )}
-                  />
-                </div>
+                  </span>
+                  <span>{isLoading ? 'Stop' : 'Run'}</span>
+                </button>
               </div>
-            </div>
-          </li>
+            </li>
 
-          <li className='flex flex-col gap-2'>
-            <div className='flex items-center justify-between'>
+            {/* Input/Output display */}
+            <li>
+              <InputOutputDisplay
+                parentId={id}
+                getNode={getNode}
+                getSourceNodeIdWithLabel={getSourceNodeIdWithLabel}
+                getTargetNodeIdWithLabel={getTargetNodeIdWithLabel}
+                supportedInputTypes={['text', 'structured']}
+                supportedOutputTypes={['structured']}
+                inputNodeCategory='blocknode'
+                outputNodeCategory='blocknode'
+              />
+            </li>
+
+            <li className='flex flex-col gap-2'>
               <div className='flex items-center gap-2'>
                 <label className='text-[13px] font-semibold text-[#6D7177]'>
-                  Settings
+                  Query
                 </label>
-                <div className='w-[5px] h-[5px] rounded-full bg-[#6D7177]'></div>
+                <div className='w-[5px] h-[5px] rounded-full bg-[#FF4D4D]'></div>
               </div>
+              <div className='flex items-center gap-2 h-[32px] p-0 bg-[#252525] rounded-[6px] border-[1px] border-[#6D7177]/30 hover:border-[#6D7177]/50 transition-colors'>
+                <PuppyDropdown
+                  options={queryOptions}
+                  selectedValue={
+                    query.id ? { id: query.id, label: query.label } : null
+                  }
+                  onSelect={(value: { id: string; label: string }) => {
+                    setQuery({ id: value.id, label: value.label });
+                  }}
+                  buttonHeight='32px'
+                  buttonBgColor='transparent'
+                  menuBgColor='#1A1A1A'
+                  listWidth='100%'
+                  containerClassnames='w-full'
+                  mapValueTodisplay={(value: any) =>
+                    value && value.label ? (
+                      <span className='text-[#3B9BFF] text-[12px] font-medium'>{`{{${value.label}}}`}</span>
+                    ) : (
+                      <span className='text-[#6D7177] text-[12px]'>
+                        Select a query
+                      </span>
+                    )
+                  }
+                  renderOption={(option: { id: string; label: string }) => (
+                    <div className='text-[#3B9BFF] text-[12px] font-medium'>{`{{${option.label}}}`}</div>
+                  )}
+                />
+              </div>
+            </li>
+
+            <li className='flex flex-col gap-2'>
+              <div className='flex items-center gap-2'>
+                <label className='text-[13px] font-semibold text-[#6D7177]'>
+                  Indexed Structured Data
+                </label>
+                <div className='w-[5px] h-[5px] rounded-full bg-[#FF4D4D]'></div>
+              </div>
+
+              {/* start of node labels */}
+              <div className='bg-[#1E1E1E] rounded-[8px] p-[8px] border-[1px] border-[#6D7177]/30 hover:border-[#6D7177]/50 transition-colors'>
+                <div className='flex flex-wrap gap-2 items-center min-h-[12px]'>
+                  {dataSource.map((item, index) => (
+                    <div
+                      key={index}
+                      className='flex items-center bg-[#252525] rounded-[4px] h-[26px] p-[6px]
+                                                                                                       border border-[#9B7EDB]/30 hover:border-[#9B7EDB]/50 
+                                                    transition-colors group'
+                    >
+                      <span className='text-[10px] text-[#9B7EDB] font-medium'>
+                        {item.label}
+                      </span>
+                      <button
+                        onClick={() => removeNodeLabel(index)}
+                        className='ml-2 text-[#6D7177] hover:text-[#ff6b6b] transition-colors 
+                                                        opacity-0 group-hover:opacity-100'
+                      >
+                        <svg
+                          xmlns='http://www.w3.org/2000/svg'
+                          width='10'
+                          height='10'
+                          viewBox='0 0 24 24'
+                          fill='none'
+                          stroke='currentColor'
+                          strokeWidth='2'
+                          strokeLinecap='round'
+                          strokeLinejoin='round'
+                        >
+                          <line x1='18' y1='6' x2='6' y2='18'></line>
+                          <line x1='6' y1='6' x2='18' y2='18'></line>
+                        </svg>
+                      </button>
+                    </div>
+                  ))}
+
+                  {flattenedIndexItems.length > 0 && (
+                    <div className='relative'>
+                      <button
+                        onClick={() => setIsDropdownOpen(!isDropdownOpen)}
+                        className='w-[24px] h-[24px] flex items-center justify-center rounded-md
+                                                        bg-[#252525] border border-[#6D7177]/30 
+                                                        text-[#6D7177] 
+                                                        hover:border-[#6D7177]/50 hover:bg-[#252525]/80 
+                                                        transition-colors'
+                      >
+                        <svg
+                          width='12'
+                          height='12'
+                          viewBox='0 0 24 24'
+                          fill='none'
+                          stroke='currentColor'
+                        >
+                          <path
+                            d='M12 5v14M5 12h14'
+                            strokeWidth='2'
+                            strokeLinecap='round'
+                          />
+                        </svg>
+                      </button>
+
+                      {isDropdownOpen && (
+                        <div
+                          className='absolute top-full left-0 mt-1 w-[240px] bg-[#1A1A1A] 
+                                                        border border-[#6D7177]/30 rounded-[8px] shadow-lg z-10 max-h-[200px] overflow-y-auto'
+                        >
+                          {flattenedIndexItems.map((item, index) => (
+                            <button
+                              key={index}
+                              onClick={() => {
+                                addNodeLabel(item);
+                                setIsDropdownOpen(false);
+                              }}
+                              className='w-full text-left px-3 py-2 text-[11px] text-[#CDCDCD] 
+                                                            hover:bg-[#252525] transition-colors border-b border-[#6D7177]/20 last:border-b-0'
+                            >
+                              <div className='font-medium text-[#9B7EDB]'>
+                                {item.nodeLabel}
+                              </div>
+                              <div className='text-[#6D7177] text-[10px] mt-1'>
+                                Index: {item.indexItem.index_name}
+                              </div>
+                            </button>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </li>
+
+            <li className='flex flex-col gap-2'>
+              <div className='flex items-center gap-2'>
+                <label className='text-[13px] font-semibold text-[#6D7177]'>
+                  Top K
+                </label>
+                <div className='w-[5px] h-[5px] rounded-full bg-[#FF4D4D]'></div>
+              </div>
+              <input
+                ref={topkRef}
+                value={top_k || ''}
+                onChange={e => setTop_k(Number(e.target.value) || undefined)}
+                type='number'
+                min='1'
+                max='100'
+                className='w-full h-[32px] px-3 bg-[#252525] rounded-[6px] border-[1px] border-[#6D7177]/30 
+                                        text-[#CDCDCD] text-[12px] font-medium appearance-none 
+                                        hover:border-[#6D7177]/50 transition-colors'
+                autoComplete='off'
+                onMouseDownCapture={onFocus}
+                onBlur={onBlur}
+              />
+            </li>
+
+            <li className='flex flex-col gap-2'>
+              <div className='flex items-center gap-2'>
+                <label className='text-[13px] font-semibold text-[#6D7177]'>
+                  Threshold
+                </label>
+                <div className='w-[5px] h-[5px] rounded-full bg-[#FF4D4D]'></div>
+              </div>
+              <input
+                ref={thresholdRef}
+                value={threshold || ''}
+                onChange={e =>
+                  setThreshold(Number(e.target.value) || undefined)
+                }
+                type='number'
+                min='0'
+                max='1'
+                step='0.1'
+                className='w-full h-[32px] px-3 bg-[#252525] rounded-[6px] border-[1px] border-[#6D7177]/30 
+                                        text-[#CDCDCD] text-[12px] font-medium appearance-none 
+                                        hover:border-[#6D7177]/50 transition-colors'
+                autoComplete='off'
+                onMouseDownCapture={onFocus}
+                onBlur={onBlur}
+              />
+            </li>
+
+            {/* Settings toggle */}
+            <li className='flex items-center justify-between'>
+              <label className='text-[13px] font-semibold text-[#6D7177]'>
+                Advanced Settings
+              </label>
               <button
                 onClick={() => setShowSettings(!showSettings)}
-                className='text-[12px] text-[#6D7177] hover:text-[#39BC66] transition-colors flex items-center gap-1'
+                className={`w-[40px] h-[20px] rounded-full border transition-colors ${
+                  showSettings
+                    ? 'bg-[#39BC66] border-[#39BC66]'
+                    : 'bg-[#252525] border-[#6D7177]/30'
+                }`}
               >
-                {showSettings ? 'Hide' : 'Show'}
-                <svg
-                  className={`w-4 h-4 transition-transform ${showSettings ? 'rotate-180' : ''}`}
-                  fill='none'
-                  viewBox='0 0 24 24'
-                  stroke='currentColor'
-                >
-                  <path
-                    strokeLinecap='round'
-                    strokeLinejoin='round'
-                    strokeWidth={2}
-                    d='M19 9l-7 7-7-7'
-                  />
-                </svg>
+                <div
+                  className={`w-[16px] h-[16px] bg-white rounded-full transition-transform ${
+                    showSettings ? 'translate-x-[22px]' : 'translate-x-[2px]'
+                  }`}
+                />
               </button>
-            </div>
+            </li>
 
             {showSettings && (
-              <div className='flex flex-col p-[8px] gap-2 bg-[#1E1E1E] rounded-[8px] border-[1px] border-[#6D7177]/30'>
-                <div className='flex flex-col gap-1'>
-                  <label className='text-[12px] text-[#6D7177]'>
-                    Result Number
+              <li className='flex flex-col gap-2'>
+                <div className='flex items-center gap-2'>
+                  <label className='text-[13px] font-semibold text-[#6D7177]'>
+                    Model
                   </label>
-                  <input
-                    ref={topkRef}
-                    value={top_k}
-                    onChange={() => {
-                      if (topkRef.current) {
-                        setTop_k(
-                          topkRef.current.value === ''
-                            ? undefined
-                            : Number(topkRef.current.value)
-                        );
-                      }
+                </div>
+                <div className='flex gap-2 bg-[#252525] rounded-[8px] border-[1px] border-[#6D7177]/30 hover:border-[#6D7177]/50 transition-colors'>
+                  <PuppyDropdown
+                    options={[
+                      'llama-3.1-sonar-small-128k-online',
+                      'llama-3.1-sonar-large-128k-online',
+                      'llama-3.1-sonar-huge-128k-online',
+                    ]}
+                    onSelect={(option: string) => {
+                      // Handle model selection if needed
+                      console.log('Selected model:', option);
                     }}
-                    type='number'
-                    className='w-full h-[32px] px-3 bg-[#252525] rounded-[6px] border-[1px] border-[#6D7177]/30 text-[12px] text-[#CDCDCD] hover:border-[#6D7177]/50 transition-colors'
-                    onMouseDownCapture={onFocus}
-                    onBlur={onBlur}
+                    selectedValue={'llama-3.1-sonar-small-128k-online'}
+                    listWidth={'200px'}
                   />
                 </div>
-                <div className='flex flex-col gap-1'>
-                  <label className='text-[12px] text-[#6D7177]'>
-                    Threshold
-                  </label>
-                  <input
-                    ref={thresholdRef}
-                    value={threshold}
-                    onChange={() => {
-                      if (thresholdRef.current) {
-                        setThreshold(
-                          thresholdRef.current.value === ''
-                            ? undefined
-                            : Number(thresholdRef.current.value)
-                        );
-                      }
-                    }}
-                    type='number'
-                    max={1}
-                    min={0}
-                    step={0.001}
-                    className='w-full h-[32px] px-3 bg-[#252525] rounded-[6px] border-[1px] border-[#6D7177]/30 text-[12px] text-[#CDCDCD] hover:border-[#6D7177]/50 transition-colors'
-                    onMouseDownCapture={onFocus}
-                    onBlur={onBlur}
-                  />
-                </div>
-              </div>
+              </li>
             )}
-          </li>
-        </ul>
-      )}
-    </div>
-  );
-}
+          </ul>
+        )}
+      </div>
+    );
+  }
+);
 
+Retrieving.displayName = 'Retrieving';
 export default Retrieving;

--- a/PuppyFlow/app/components/workflow/edgesNode/edgeNodesNew/SearchGoogle.tsx
+++ b/PuppyFlow/app/components/workflow/edgesNode/edgeNodesNew/SearchGoogle.tsx
@@ -1,6 +1,12 @@
 import { Handle, Position, NodeProps, Node, useReactFlow } from '@xyflow/react';
 import { useNodesPerFlowContext } from '@/app/components/states/NodesPerFlowContext';
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import React, {
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+  useMemo,
+} from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faGoogle } from '@fortawesome/free-brands-svg-icons';
 import InputOutputDisplay from './components/InputOutputDisplay';
@@ -33,449 +39,484 @@ export type SearchConfigNodeData = {
 
 type SearchConfigNodeProps = NodeProps<Node<SearchConfigNodeData>>;
 
-function SearchGoogle({ data, isConnectable, id }: SearchConfigNodeProps) {
-  const {
-    isOnConnect,
-    activatedEdge,
-    isOnGeneratingNewNode,
-    clearEdgeActivation,
-    activateEdge,
-    clearAll,
-  } = useNodesPerFlowContext();
-  const [isTargetHandleTouched, setIsTargetHandleTouched] = useState(false);
-  const { getNode, setNodes, setEdges } = useReactFlow();
-  const { getSourceNodeIdWithLabel, getTargetNodeIdWithLabel } =
-    useGetSourceTarget();
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const [isLoading, setIsLoading] = useState(false);
-  const menuRef = useRef<HTMLUListElement>(null);
-  const [isHovered, setIsHovered] = useState(false);
-  const [isRunButtonHovered, setIsRunButtonHovered] = useState(false);
-
-  // 获取所有需要的依赖
-  const { streamResult, reportError, resetLoadingUI } = useJsonConstructUtils();
-  const { getAuthHeaders } = useAppSettings();
-
-  // 状态管理
-  const [showSettings, setShowSettings] = useState(false);
-
-  // 加载配置值
-  const [top_k, setTop_k] = useState<number | undefined>(
-    (getNode(id)?.data as SearchConfigNodeData)?.top_k ?? 5
-  );
-  const topkRef = useRef<HTMLInputElement>(null);
-
-  // 创建执行上下文
-  const createExecutionContext = useCallback(
-    (): RunSingleEdgeNodeContext => ({
-      getNode,
-      setNodes,
-      setEdges,
-      getSourceNodeIdWithLabel,
-      getTargetNodeIdWithLabel,
+const SearchGoogle: React.FC<SearchConfigNodeProps> = React.memo(
+  ({ data, isConnectable, id }) => {
+    const {
+      isOnConnect,
+      activatedEdge,
+      isOnGeneratingNewNode,
+      clearEdgeActivation,
+      activateEdge,
       clearAll,
-      streamResult,
-      reportError,
-      resetLoadingUI,
-      getAuthHeaders,
-    }),
-    [
-      getNode,
-      setNodes,
-      setEdges,
-      getSourceNodeIdWithLabel,
-      getTargetNodeIdWithLabel,
-      clearAll,
-      streamResult,
-      reportError,
-      resetLoadingUI,
-      getAuthHeaders,
-    ]
-  );
+    } = useNodesPerFlowContext();
+    const [isTargetHandleTouched, setIsTargetHandleTouched] = useState(false);
+    const { getNode, setNodes, setEdges } = useReactFlow();
+    const { getSourceNodeIdWithLabel, getTargetNodeIdWithLabel } =
+      useGetSourceTarget();
+    const [isMenuOpen, setIsMenuOpen] = useState(false);
+    const [isLoading, setIsLoading] = useState(false);
+    const menuRef = useRef<HTMLUListElement>(null);
+    const [isHovered, setIsHovered] = useState(false);
+    const [isRunButtonHovered, setIsRunButtonHovered] = useState(false);
 
-  // 使用执行函数的 handleDataSubmit
-  const handleDataSubmit = useCallback(async () => {
-    if (isLoading) return;
+    // 获取所有需要的依赖
+    const { streamResult, reportError, resetLoadingUI } =
+      useJsonConstructUtils();
+    const { getAuthHeaders } = useAppSettings();
 
-    setIsLoading(true);
-    try {
-      const context = createExecutionContext();
-      await runSingleEdgeNode({
-        parentId: id,
-        targetNodeType: 'structured',
-        context,
-        // 可以选择不提供 constructJsonData，使用默认实现
-      });
-    } catch (error) {
-      console.error('执行失败:', error);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [id, isLoading, createExecutionContext]);
+    // 使用 useRef 跟踪是否已挂载
+    const hasMountedRef = useRef(false);
 
-  useEffect(() => {
-    if (!isOnGeneratingNewNode) {
-      clearAll();
-      activateEdge(id);
-    }
+    // 状态管理
+    const [showSettings, setShowSettings] = useState(false);
 
-    return () => {
+    // 优化状态初始化 - 使用函数形式避免重复计算
+    const [top_k, setTop_k] = useState<number | undefined>(
+      () => (getNode(id)?.data as SearchConfigNodeData)?.top_k ?? 5
+    );
+    const topkRef = useRef<HTMLInputElement>(null);
+
+    // 创建执行上下文 - 使用 useCallback 缓存
+    const createExecutionContext = useCallback(
+      (): RunSingleEdgeNodeContext => ({
+        getNode,
+        setNodes,
+        setEdges,
+        getSourceNodeIdWithLabel,
+        getTargetNodeIdWithLabel,
+        clearAll,
+        streamResult,
+        reportError,
+        resetLoadingUI,
+        getAuthHeaders,
+      }),
+      [
+        getNode,
+        setNodes,
+        setEdges,
+        getSourceNodeIdWithLabel,
+        getTargetNodeIdWithLabel,
+        clearAll,
+        streamResult,
+        reportError,
+        resetLoadingUI,
+        getAuthHeaders,
+      ]
+    );
+
+    // 使用执行函数的 handleDataSubmit - 使用 useCallback 缓存
+    const handleDataSubmit = useCallback(async () => {
+      if (isLoading) return;
+
+      setIsLoading(true);
+      try {
+        const context = createExecutionContext();
+        await runSingleEdgeNode({
+          parentId: id,
+          targetNodeType: 'structured',
+          context,
+          // 可以选择不提供 constructJsonData，使用默认实现
+        });
+      } catch (error) {
+        console.error('执行失败:', error);
+      } finally {
+        setIsLoading(false);
+      }
+    }, [id, isLoading, createExecutionContext]);
+
+    // 组件初始化
+    useEffect(() => {
+      hasMountedRef.current = true;
+    }, []);
+
+    useEffect(() => {
+      if (hasMountedRef.current && !isOnGeneratingNewNode) {
+        clearAll();
+        activateEdge(id);
+      }
+
+      return () => {
+        if (activatedEdge === id) {
+          clearEdgeActivation();
+        }
+      };
+    }, [isOnGeneratingNewNode]);
+
+    // 辅助函数 - 使用 useCallback 缓存
+    const onFocus = useCallback(() => {
+      const curRef = menuRef.current;
+      if (curRef && !curRef.classList.contains('nodrag')) {
+        curRef.classList.add('nodrag');
+      }
+    }, []);
+
+    const onBlur = useCallback(() => {
+      const curRef = menuRef.current;
+      if (curRef) {
+        curRef.classList.remove('nodrag');
+      }
+    }, []);
+
+    // 状态同步到 ReactFlow - 使用 requestAnimationFrame 延迟执行，避免在节点创建时干扰
+    useEffect(() => {
+      if (!isOnGeneratingNewNode && hasMountedRef.current) {
+        requestAnimationFrame(() => {
+          const node = getNode(id);
+          if (node) {
+            setNodes(prevNodes =>
+              prevNodes.map(n => {
+                if (n.id === id) {
+                  // 确保 node.data 存在并且是对象类型
+                  const nodeData =
+                    typeof n.data === 'object' && n.data !== null ? n.data : {};
+
+                  return {
+                    ...n,
+                    data: {
+                      ...nodeData,
+                      top_k: top_k,
+                    },
+                  };
+                }
+                return n;
+              })
+            );
+          }
+        });
+      }
+    }, [id, setNodes, top_k, isOnGeneratingNewNode]);
+
+    // UI 交互函数 - 使用 useCallback 缓存
+    const onClickButton = useCallback(() => {
+      setIsMenuOpen(!isMenuOpen);
+
+      if (isOnGeneratingNewNode) return;
       if (activatedEdge === id) {
         clearEdgeActivation();
+      } else {
+        clearAll();
+        activateEdge(id);
       }
-    };
-  }, []);
+    }, [
+      isMenuOpen,
+      isOnGeneratingNewNode,
+      activatedEdge,
+      id,
+      clearEdgeActivation,
+      clearAll,
+      activateEdge,
+    ]);
 
-  // 辅助函数
-  const onFocus = () => {
-    const curRef = menuRef.current;
-    if (curRef && !curRef.classList.contains('nodrag')) {
-      curRef.classList.add('nodrag');
-    }
-  };
-
-  const onBlur = () => {
-    const curRef = menuRef.current;
-    if (curRef) {
-      curRef.classList.remove('nodrag');
-    }
-  };
-
-  // 状态同步到 ReactFlow
-  useEffect(() => {
-    setNodes(prevNodes =>
-      prevNodes.map(node => {
-        if (node.id === id) {
-          // 确保 node.data 存在并且是对象类型
-          const nodeData =
-            typeof node.data === 'object' && node.data !== null
-              ? node.data
-              : {};
-
-          return {
-            ...node,
-            data: {
-              ...nodeData,
-              top_k: top_k,
-            },
-          };
-        }
-        return node;
-      })
+    // 在组件顶部定义共享样式 - 使用 useMemo 缓存
+    const handleStyle = useMemo(
+      () => ({
+        position: 'absolute' as const,
+        width: 'calc(100%)',
+        height: 'calc(100%)',
+        top: '0',
+        left: '0',
+        borderRadius: '0',
+        transform: 'translate(0px, 0px)',
+        background: 'transparent',
+        border: '3px solid transparent',
+        zIndex: !isOnConnect ? '-1' : '1',
+      }),
+      [isOnConnect]
     );
-  }, [id, setNodes, top_k]);
 
-  const onClickButton = () => {
-    setIsMenuOpen(!isMenuOpen);
+    // 执行函数 - 使用 useCallback 缓存
+    const onDataSubmit = useCallback(() => {
+      handleDataSubmit();
+    }, [handleDataSubmit]);
 
-    if (isOnGeneratingNewNode) return;
-    if (activatedEdge === id) {
-      clearEdgeActivation();
-    } else {
-      clearAll();
-      activateEdge(id);
-    }
-  };
+    // 添加停止函数 - 使用 useCallback 缓存
+    const onStopExecution = useCallback(() => {
+      console.log('Stop execution');
+      setIsLoading(false);
+    }, []);
 
-  // 在组件顶部定义共享样式
-  const handleStyle = {
-    position: 'absolute' as const,
-    width: 'calc(100%)',
-    height: 'calc(100%)',
-    top: '0',
-    left: '0',
-    borderRadius: '0',
-    transform: 'translate(0px, 0px)',
-    background: 'transparent',
-    border: '3px solid transparent',
-    zIndex: !isOnConnect ? '-1' : '1',
-  };
+    // 缓存按钮样式 - 使用 useMemo 缓存
+    const runButtonStyle = useMemo(
+      () => ({
+        backgroundColor: isRunButtonHovered
+          ? isLoading
+            ? '#FFA73D'
+            : '#39BC66'
+          : '#181818',
+        borderColor: isRunButtonHovered
+          ? isLoading
+            ? '#FFA73D'
+            : '#39BC66'
+          : UI_COLORS.EDGENODE_BORDER_GREY,
+        color: isRunButtonHovered ? '#000' : UI_COLORS.EDGENODE_BORDER_GREY,
+      }),
+      [isRunButtonHovered, isLoading]
+    );
 
-  // 修改 onDataSubmit 函数（如果存在的话）
-  const onDataSubmit = () => {
-    handleDataSubmit();
-  };
-
-  return (
-    <div className='p-[3px] w-[80px] h-[48px] relative'>
-      {/* Invisible hover area between node and run button */}
-      <div
-        className='absolute -top-[40px] left-0 w-full h-[40px]'
-        onMouseEnter={() => setIsHovered(true)}
-        onMouseLeave={() => setIsHovered(false)}
-      />
-
-      {/* Run button positioned above the node - show when node or run button is hovered */}
-      <button
-        className={`absolute -top-[40px] left-1/2 transform -translate-x-1/2 w-[57px] h-[24px] rounded-[6px] border-[1px] text-[10px] font-[600] font-plus-jakarta-sans flex flex-row items-center justify-center gap-[4px] transition-all duration-200 ${
-          isHovered || isRunButtonHovered ? 'opacity-100' : 'opacity-0'
-        }`}
-        style={{
-          backgroundColor: isRunButtonHovered ? '#39BC66' : '#181818',
-          borderColor: isRunButtonHovered
-            ? '#39BC66'
-            : UI_COLORS.EDGENODE_BORDER_GREY,
-          color: isRunButtonHovered ? '#000' : UI_COLORS.EDGENODE_BORDER_GREY,
-        }}
-        onClick={onDataSubmit}
-        disabled={isLoading}
-        onMouseEnter={() => setIsRunButtonHovered(true)}
-        onMouseLeave={() => setIsRunButtonHovered(false)}
-      >
-        <span>
-          {isLoading ? (
-            <svg className='animate-spin h-3 w-3' viewBox='0 0 24 24'>
-              <circle
-                className='opacity-25'
-                cx='12'
-                cy='12'
-                r='10'
-                stroke='currentColor'
-                strokeWidth='4'
-              ></circle>
-              <path
-                className='opacity-75'
-                fill='currentColor'
-                d='M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 714 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z'
-              ></path>
-            </svg>
-          ) : (
-            <svg
-              xmlns='http://www.w3.org/2000/svg'
-              width='6'
-              height='8'
-              viewBox='0 0 8 10'
-              fill='none'
-            >
-              <path d='M8 5L0 10V0L8 5Z' fill='currentColor' />
-            </svg>
-          )}
-        </span>
-        <span>{isLoading ? '' : 'Run'}</span>
-      </button>
-
-      <button
-        onClick={onClickButton}
-        onMouseEnter={() => setIsHovered(true)}
-        onMouseLeave={() => setIsHovered(false)}
-        className={`w-full h-full flex-shrink-0 rounded-[8px] border-[2px] bg-[#181818] flex items-center justify-center font-plus-jakarta-sans text-[10px] font-[700] edge-node transition-colors gap-[4px]`}
-        style={{
-          borderColor: isHovered
+    const mainButtonStyle = useMemo(
+      () => ({
+        borderColor: isLoading
+          ? '#FFA73D'
+          : isHovered
             ? UI_COLORS.LINE_ACTIVE
             : UI_COLORS.EDGENODE_BORDER_GREY,
-          color: isHovered
+        color: isLoading
+          ? '#FFA73D'
+          : isHovered
             ? UI_COLORS.LINE_ACTIVE
             : UI_COLORS.EDGENODE_BORDER_GREY,
-        }}
-      >
-        {/* Google icon */}
-        <FontAwesomeIcon icon={faGoogle} className='w-[10px] h-[10px]' />
-        <div className='flex flex-col items-center justify-center leading-tight text-[9px]'>
-          <span>Google</span>
-        </div>
+      }),
+      [isLoading, isHovered]
+    );
 
-        <Handle
-          id={`${id}-a`}
-          className='edgeSrcHandle handle-with-icon handle-top'
-          type='source'
-          position={Position.Top}
-        />
-        <Handle
-          id={`${id}-b`}
-          className='edgeSrcHandle handle-with-icon handle-right'
-          type='source'
-          position={Position.Right}
-        />
-        <Handle
-          id={`${id}-c`}
-          className='edgeSrcHandle handle-with-icon handle-bottom'
-          type='source'
-          position={Position.Bottom}
-        />
-        <Handle
-          id={`${id}-d`}
-          className='edgeSrcHandle handle-with-icon handle-left'
-          type='source'
-          position={Position.Left}
+    return (
+      <div className='p-[3px] w-[80px] h-[48px] relative'>
+        {/* Invisible hover area between node and run button */}
+        <div
+          className='absolute -top-[40px] left-0 w-full h-[40px]'
+          onMouseEnter={() => setIsHovered(true)}
+          onMouseLeave={() => setIsHovered(false)}
         />
 
-        <Handle
-          id={`${id}-a`}
-          type='target'
-          position={Position.Top}
-          style={handleStyle}
-          isConnectable={isConnectable}
-          onMouseEnter={() => setIsTargetHandleTouched(true)}
-          onMouseLeave={() => setIsTargetHandleTouched(false)}
-        />
-        <Handle
-          id={`${id}-b`}
-          type='target'
-          position={Position.Right}
-          style={handleStyle}
-          isConnectable={isConnectable}
-          onMouseEnter={() => setIsTargetHandleTouched(true)}
-          onMouseLeave={() => setIsTargetHandleTouched(false)}
-        />
-        <Handle
-          id={`${id}-c`}
-          type='target'
-          position={Position.Bottom}
-          style={handleStyle}
-          isConnectable={isConnectable}
-          onMouseEnter={() => setIsTargetHandleTouched(true)}
-          onMouseLeave={() => setIsTargetHandleTouched(false)}
-        />
-        <Handle
-          id={`${id}-d`}
-          type='target'
-          position={Position.Left}
-          style={handleStyle}
-          isConnectable={isConnectable}
-          onMouseEnter={() => setIsTargetHandleTouched(true)}
-          onMouseLeave={() => setIsTargetHandleTouched(false)}
-        />
-      </button>
-
-      {/* Configuration Menu */}
-      {isMenuOpen && (
-        <ul
-          ref={menuRef}
-          className={`absolute top-[64px] text-white w-[320px] rounded-[16px] border-[1px] bg-[#1A1A1A] p-[12px] font-plus-jakarta-sans flex flex-col gap-[16px] shadow-lg`}
-          style={{
-            borderColor: UI_COLORS.EDGENODE_BORDER_GREY,
-          }}
+        {/* Run button positioned above the node - show when node or run button is hovered */}
+        <button
+          className={`absolute -top-[40px] left-1/2 transform -translate-x-1/2 w-[57px] h-[24px] rounded-[6px] border-[1px] text-[10px] font-[600] font-plus-jakarta-sans flex flex-row items-center justify-center gap-[4px] transition-all duration-200 ${
+            isHovered || isRunButtonHovered ? 'opacity-100' : 'opacity-0'
+          }`}
+          style={runButtonStyle}
+          onClick={isLoading ? onStopExecution : handleDataSubmit}
+          disabled={false}
+          onMouseEnter={() => setIsRunButtonHovered(true)}
+          onMouseLeave={() => setIsRunButtonHovered(false)}
         >
-          <li className='flex h-[28px] gap-1 items-center justify-between font-plus-jakarta-sans'>
-            <div className='flex flex-row gap-[12px]'>
-              <div className='flex flex-row gap-[8px] justify-center items-center'>
-                <div className='w-[24px] h-[24px] border-[1px] border-main-grey bg-main-black-theme rounded-[8px] flex items-center justify-center'>
-                  <FontAwesomeIcon
-                    icon={faGoogle}
-                    className='text-main-grey w-[14px] h-[14px]'
-                  />
-                </div>
-                <div className='flex items-center justify-center text-[14px] font-semibold text-main-grey font-plus-jakarta-sans leading-normal'>
-                  Google
+          <span>
+            {isLoading ? (
+              <svg width='6' height='6' viewBox='0 0 6 6' fill='none'>
+                <rect width='6' height='6' fill='currentColor' />
+              </svg>
+            ) : (
+              <svg
+                xmlns='http://www.w3.org/2000/svg'
+                width='6'
+                height='8'
+                viewBox='0 0 8 10'
+                fill='none'
+              >
+                <path d='M8 5L0 10V0L8 5Z' fill='currentColor' />
+              </svg>
+            )}
+          </span>
+          <span>{isLoading ? 'Stop' : 'Run'}</span>
+        </button>
+
+        <button
+          onClick={onClickButton}
+          onMouseEnter={() => setIsHovered(true)}
+          onMouseLeave={() => setIsHovered(false)}
+          className={`w-full h-full flex-shrink-0 rounded-[8px] border-[2px] bg-[#181818] flex items-center justify-center font-plus-jakarta-sans text-[10px] font-[700] edge-node transition-colors gap-[4px]`}
+          style={mainButtonStyle}
+        >
+          {/* Google icon */}
+          <FontAwesomeIcon icon={faGoogle} className='w-[10px] h-[10px]' />
+          <div className='flex flex-col items-center justify-center leading-tight text-[9px]'>
+            <span>Google</span>
+          </div>
+
+          <Handle
+            id={`${id}-a`}
+            className='edgeSrcHandle handle-with-icon handle-top'
+            type='source'
+            position={Position.Top}
+          />
+          <Handle
+            id={`${id}-b`}
+            className='edgeSrcHandle handle-with-icon handle-right'
+            type='source'
+            position={Position.Right}
+          />
+          <Handle
+            id={`${id}-c`}
+            className='edgeSrcHandle handle-with-icon handle-bottom'
+            type='source'
+            position={Position.Bottom}
+          />
+          <Handle
+            id={`${id}-d`}
+            className='edgeSrcHandle handle-with-icon handle-left'
+            type='source'
+            position={Position.Left}
+          />
+
+          <Handle
+            id={`${id}-a`}
+            type='target'
+            position={Position.Top}
+            style={handleStyle}
+            isConnectable={isConnectable}
+            onMouseEnter={() => setIsTargetHandleTouched(true)}
+            onMouseLeave={() => setIsTargetHandleTouched(false)}
+          />
+          <Handle
+            id={`${id}-b`}
+            type='target'
+            position={Position.Right}
+            style={handleStyle}
+            isConnectable={isConnectable}
+            onMouseEnter={() => setIsTargetHandleTouched(true)}
+            onMouseLeave={() => setIsTargetHandleTouched(false)}
+          />
+          <Handle
+            id={`${id}-c`}
+            type='target'
+            position={Position.Bottom}
+            style={handleStyle}
+            isConnectable={isConnectable}
+            onMouseEnter={() => setIsTargetHandleTouched(true)}
+            onMouseLeave={() => setIsTargetHandleTouched(false)}
+          />
+          <Handle
+            id={`${id}-d`}
+            type='target'
+            position={Position.Left}
+            style={handleStyle}
+            isConnectable={isConnectable}
+            onMouseEnter={() => setIsTargetHandleTouched(true)}
+            onMouseLeave={() => setIsTargetHandleTouched(false)}
+          />
+        </button>
+
+        {/* Configuration Menu */}
+        {isMenuOpen && (
+          <ul
+            ref={menuRef}
+            className={`absolute top-[64px] text-white w-[320px] rounded-[16px] border-[1px] bg-[#1A1A1A] p-[12px] font-plus-jakarta-sans flex flex-col gap-[16px] shadow-lg`}
+            style={{
+              borderColor: UI_COLORS.EDGENODE_BORDER_GREY,
+            }}
+          >
+            <li className='flex h-[28px] gap-1 items-center justify-between font-plus-jakarta-sans'>
+              <div className='flex flex-row gap-[12px]'>
+                <div className='flex flex-row gap-[8px] justify-center items-center'>
+                  <div className='w-[24px] h-[24px] border-[1px] border-main-grey bg-main-black-theme rounded-[8px] flex items-center justify-center'>
+                    <FontAwesomeIcon
+                      icon={faGoogle}
+                      className='text-main-grey w-[14px] h-[14px]'
+                    />
+                  </div>
+                  <div className='flex items-center justify-center text-[14px] font-semibold text-main-grey font-plus-jakarta-sans leading-normal'>
+                    Google
+                  </div>
                 </div>
               </div>
-            </div>
-            <div className='w-[57px] h-[26px]'>
-              <button
-                className='w-full h-full rounded-[8px] bg-[#39BC66] text-[#000] text-[12px] font-semibold font-plus-jakarta-sans flex flex-row items-center justify-center gap-[7px]'
-                onClick={onDataSubmit}
-                disabled={isLoading}
-              >
-                <span>
-                  {isLoading ? (
-                    <svg className='animate-spin h-4 w-4' viewBox='0 0 24 24'>
-                      <circle
-                        className='opacity-25'
-                        cx='12'
-                        cy='12'
-                        r='10'
-                        stroke='currentColor'
-                        strokeWidth='4'
-                      ></circle>
-                      <path
-                        className='opacity-75'
-                        fill='currentColor'
-                        d='M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 714 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z'
-                      ></path>
-                    </svg>
-                  ) : (
-                    <svg
-                      xmlns='http://www.w3.org/2000/svg'
-                      width='8'
-                      height='10'
-                      viewBox='0 0 8 10'
-                      fill='none'
-                    >
-                      <path d='M8 5L0 10V0L8 5Z' fill='black' />
-                    </svg>
-                  )}
-                </span>
-                <span>{isLoading ? '' : 'Run'}</span>
-              </button>
-            </div>
-          </li>
-
-          <li>
-            <InputOutputDisplay
-              parentId={id}
-              getNode={getNode}
-              getSourceNodeIdWithLabel={getSourceNodeIdWithLabel}
-              getTargetNodeIdWithLabel={getTargetNodeIdWithLabel}
-              supportedInputTypes={['text']}
-              supportedOutputTypes={['structured']}
-              inputNodeCategory='blocknode'
-              outputNodeCategory='blocknode'
-            />
-          </li>
-
-          <li className='flex flex-col gap-2'>
-            <div className='flex items-center gap-2'>
-              <label className='text-[13px] font-semibold text-[#6D7177]'>
-                Settings
-              </label>
-              <div className='w-2 h-2 rounded-full bg-[#6D7177]'></div>
-              <button
-                onClick={() => setShowSettings(!showSettings)}
-                className='ml-auto text-[12px] font-medium text-[#6D7177] hover:text-[#CDCDCD] transition-colors flex items-center gap-1'
-              >
-                {showSettings ? 'Hide' : 'Show'}
-                <svg
-                  className={`w-4 h-4 transition-transform duration-200 ${showSettings ? 'rotate-180' : ''}`}
-                  viewBox='0 0 24 24'
+              <div className='w-[57px] h-[26px]'>
+                <button
+                  className='w-full h-full rounded-[8px] text-[#000] text-[12px] font-semibold font-plus-jakarta-sans flex flex-row items-center justify-center gap-[7px]'
+                  style={{
+                    backgroundColor: isLoading ? '#FFA73D' : '#39BC66',
+                  }}
+                  onClick={isLoading ? onStopExecution : onDataSubmit}
+                  disabled={false}
                 >
-                  <path
-                    fill='none'
-                    stroke='currentColor'
-                    strokeLinecap='round'
-                    strokeLinejoin='round'
-                    strokeWidth='2'
-                    d='M19 9l-7 7-7-7'
-                  />
-                </svg>
-              </button>
-            </div>
-            {showSettings && (
-              <div className='flex flex-col gap-2 p-2 bg-[#1E1E1E] rounded-[8px] border-[1px] border-[#6D7177]/30'>
-                <div className='flex flex-col gap-2'>
-                  <div className='flex items-center gap-2'>
-                    <label className='text-[12px] font-medium text-[#6D7177]'>
-                      Result Number
-                    </label>
-                  </div>
-                  <input
-                    ref={topkRef}
-                    value={top_k}
-                    onChange={() => {
-                      if (topkRef.current) {
-                        setTop_k(
-                          topkRef.current.value === ''
-                            ? undefined
-                            : Number(topkRef.current.value)
-                        );
-                      }
-                    }}
-                    type='number'
-                    className='w-full h-[32px] px-3 bg-[#252525] rounded-[6px] border-[1px] border-[#6D7177]/30 
+                  <span>
+                    {isLoading ? (
+                      <svg width='8' height='8' viewBox='0 0 8 8' fill='none'>
+                        <rect width='8' height='8' fill='currentColor' />
+                      </svg>
+                    ) : (
+                      <svg
+                        xmlns='http://www.w3.org/2000/svg'
+                        width='8'
+                        height='10'
+                        viewBox='0 0 8 10'
+                        fill='none'
+                      >
+                        <path d='M8 5L0 10V0L8 5Z' fill='black' />
+                      </svg>
+                    )}
+                  </span>
+                  <span>{isLoading ? 'Stop' : 'Run'}</span>
+                </button>
+              </div>
+            </li>
+
+            <li>
+              <InputOutputDisplay
+                parentId={id}
+                getNode={getNode}
+                getSourceNodeIdWithLabel={getSourceNodeIdWithLabel}
+                getTargetNodeIdWithLabel={getTargetNodeIdWithLabel}
+                supportedInputTypes={['text']}
+                supportedOutputTypes={['structured']}
+                inputNodeCategory='blocknode'
+                outputNodeCategory='blocknode'
+              />
+            </li>
+
+            <li className='flex flex-col gap-2'>
+              <div className='flex items-center gap-2'>
+                <label className='text-[13px] font-semibold text-[#6D7177]'>
+                  Settings
+                </label>
+                <div className='w-2 h-2 rounded-full bg-[#6D7177]'></div>
+                <button
+                  onClick={() => setShowSettings(!showSettings)}
+                  className='ml-auto text-[12px] font-medium text-[#6D7177] hover:text-[#CDCDCD] transition-colors flex items-center gap-1'
+                >
+                  {showSettings ? 'Hide' : 'Show'}
+                  <svg
+                    className={`w-4 h-4 transition-transform duration-200 ${showSettings ? 'rotate-180' : ''}`}
+                    viewBox='0 0 24 24'
+                  >
+                    <path
+                      fill='none'
+                      stroke='currentColor'
+                      strokeLinecap='round'
+                      strokeLinejoin='round'
+                      strokeWidth='2'
+                      d='M19 9l-7 7-7-7'
+                    />
+                  </svg>
+                </button>
+              </div>
+              {showSettings && (
+                <div className='flex flex-col gap-2 p-2 bg-[#1E1E1E] rounded-[8px] border-[1px] border-[#6D7177]/30'>
+                  <div className='flex flex-col gap-2'>
+                    <div className='flex items-center gap-2'>
+                      <label className='text-[12px] font-medium text-[#6D7177]'>
+                        Result Number
+                      </label>
+                    </div>
+                    <input
+                      ref={topkRef}
+                      value={top_k}
+                      onChange={() => {
+                        if (topkRef.current) {
+                          setTop_k(
+                            topkRef.current.value === ''
+                              ? undefined
+                              : Number(topkRef.current.value)
+                          );
+                        }
+                      }}
+                      type='number'
+                      className='w-full h-[32px] px-3 bg-[#252525] rounded-[6px] border-[1px] border-[#6D7177]/30 
                                             text-[#CDCDCD] text-[12px] font-medium appearance-none cursor-pointer 
                                             hover:border-[#6D7177]/50 transition-colors'
-                    autoComplete='off'
-                    required
-                    onMouseDownCapture={onFocus}
-                    onBlur={onBlur}
-                  />
+                      autoComplete='off'
+                      required
+                      onMouseDownCapture={onFocus}
+                      onBlur={onBlur}
+                    />
+                  </div>
                 </div>
-              </div>
-            )}
-          </li>
-        </ul>
-      )}
-    </div>
-  );
-}
+              )}
+            </li>
+          </ul>
+        )}
+      </div>
+    );
+  }
+);
 
+SearchGoogle.displayName = 'SearchGoogle';
 export default SearchGoogle;

--- a/PuppyFlow/app/components/workflow/edgesNode/edgeNodesNew/SearchPerplexity.tsx
+++ b/PuppyFlow/app/components/workflow/edgesNode/edgeNodesNew/SearchPerplexity.tsx
@@ -1,6 +1,13 @@
 import { Handle, Position, NodeProps, Node, useReactFlow } from '@xyflow/react';
 import { useNodesPerFlowContext } from '@/app/components/states/NodesPerFlowContext';
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import React, {
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+  useMemo,
+  memo,
+} from 'react';
 import InputOutputDisplay from './components/InputOutputDisplay';
 import { PuppyDropdown } from '../../../misc/PuppyDropDown';
 import { UI_COLORS } from '@/app/utils/colors';
@@ -37,395 +44,464 @@ type PerplexityModelNames =
 
 type SearchPerplexityNodeProps = NodeProps<Node<SearchConfigNodeData>>;
 
-function SearchPerplexity({
-  data,
-  isConnectable,
-  id,
-}: SearchPerplexityNodeProps) {
-  const {
-    isOnConnect,
-    activatedEdge,
-    isOnGeneratingNewNode,
-    clearEdgeActivation,
-    activateEdge,
-    clearAll,
-  } = useNodesPerFlowContext();
-  const [isTargetHandleTouched, setIsTargetHandleTouched] = useState(false);
-  const { getNode, setNodes, setEdges } = useReactFlow();
-  const { getSourceNodeIdWithLabel, getTargetNodeIdWithLabel } =
-    useGetSourceTarget();
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const [isLoading, setIsLoading] = useState(false);
-  const menuRef = useRef<HTMLUListElement>(null);
-  const [isHovered, setIsHovered] = useState(false);
-  const [isRunButtonHovered, setIsRunButtonHovered] = useState(false);
-
-  // 获取所有需要的依赖
-  const { streamResult, reportError, resetLoadingUI } = useJsonConstructUtils();
-  const { getAuthHeaders } = useAppSettings();
-
-  // 模型配置
-  const [model, setModel] = useState<PerplexityModelNames>(
-    (getNode(id)?.data as SearchConfigNodeData)?.extra_configs?.model ??
-      'llama-3.1-sonar-small-128k-online'
-  );
-
-  // 创建执行上下文
-  const createExecutionContext = useCallback(
-    (): RunSingleEdgeNodeContext => ({
-      getNode,
-      setNodes,
-      setEdges,
-      getSourceNodeIdWithLabel,
-      getTargetNodeIdWithLabel,
+const SearchPerplexity: React.FC<SearchPerplexityNodeProps> = memo(
+  ({ data, isConnectable, id }) => {
+    const {
+      isOnConnect,
+      activatedEdge,
+      isOnGeneratingNewNode,
+      clearEdgeActivation,
+      activateEdge,
       clearAll,
-      streamResult,
-      reportError,
-      resetLoadingUI,
-      getAuthHeaders,
-    }),
-    [
-      getNode,
-      setNodes,
-      setEdges,
-      getSourceNodeIdWithLabel,
-      getTargetNodeIdWithLabel,
-      clearAll,
-      streamResult,
-      reportError,
-      resetLoadingUI,
-      getAuthHeaders,
-    ]
-  );
+    } = useNodesPerFlowContext();
 
-  // 使用执行函数的 handleDataSubmit
-  const handleDataSubmit = useCallback(async () => {
-    if (isLoading) return;
+    const [isTargetHandleTouched, setIsTargetHandleTouched] = useState(false);
+    const { getNode, setNodes, setEdges } = useReactFlow();
+    const { getSourceNodeIdWithLabel, getTargetNodeIdWithLabel } =
+      useGetSourceTarget();
+    const [isMenuOpen, setIsMenuOpen] = useState(false);
+    const [isLoading, setIsLoading] = useState(false);
+    const menuRef = useRef<HTMLUListElement>(null);
+    const [isHovered, setIsHovered] = useState(false);
+    const [isRunButtonHovered, setIsRunButtonHovered] = useState(false);
 
-    setIsLoading(true);
-    try {
-      const context = createExecutionContext();
-      await runSingleEdgeNode({
-        parentId: id,
-        targetNodeType: 'structured',
-        context,
-        // 可以选择不提供 constructJsonData，使用默认实现
-      });
-    } catch (error) {
-      console.error('执行失败:', error);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [id, isLoading, createExecutionContext]);
+    // 获取所有需要的依赖
+    const { streamResult, reportError, resetLoadingUI } =
+      useJsonConstructUtils();
+    const { getAuthHeaders } = useAppSettings();
 
-  useEffect(() => {
-    if (!isOnGeneratingNewNode) {
-      clearAll();
-      activateEdge(id);
-    }
+    // 使用 useRef 跟踪是否已挂载
+    const hasMountedRef = useRef(false);
 
-    return () => {
+    // 模型配置 - 优化状态初始化，使用函数形式避免重复计算
+    const [model, setModel] = useState<PerplexityModelNames>(
+      () =>
+        (getNode(id)?.data as SearchConfigNodeData)?.extra_configs?.model ??
+        'llama-3.1-sonar-small-128k-online'
+    );
+
+    // 创建执行上下文 - 使用 useCallback 缓存
+    const createExecutionContext = useCallback(
+      (): RunSingleEdgeNodeContext => ({
+        getNode,
+        setNodes,
+        setEdges,
+        getSourceNodeIdWithLabel,
+        getTargetNodeIdWithLabel,
+        clearAll,
+        streamResult,
+        reportError,
+        resetLoadingUI,
+        getAuthHeaders,
+      }),
+      [
+        getNode,
+        setNodes,
+        setEdges,
+        getSourceNodeIdWithLabel,
+        getTargetNodeIdWithLabel,
+        clearAll,
+        streamResult,
+        reportError,
+        resetLoadingUI,
+        getAuthHeaders,
+      ]
+    );
+
+    // 使用执行函数的 handleDataSubmit - 使用 useCallback 缓存
+    const handleDataSubmit = useCallback(async () => {
+      if (isLoading) return;
+
+      setIsLoading(true);
+      try {
+        const context = createExecutionContext();
+        await runSingleEdgeNode({
+          parentId: id,
+          targetNodeType: 'structured',
+          context,
+        });
+      } catch (error) {
+        console.error('执行失败:', error);
+      } finally {
+        setIsLoading(false);
+      }
+    }, [id, isLoading, createExecutionContext]);
+
+    // 辅助函数 - 使用 useCallback 缓存
+    const onFocus = useCallback(() => {
+      const curRef = menuRef.current;
+      if (curRef && !curRef.classList.contains('nodrag')) {
+        curRef.classList.add('nodrag');
+      }
+    }, []);
+
+    const onBlur = useCallback(() => {
+      const curRef = menuRef.current;
+      if (curRef) {
+        curRef.classList.remove('nodrag');
+      }
+    }, []);
+
+    // 组件初始化
+    useEffect(() => {
+      hasMountedRef.current = true;
+    }, []);
+
+    // 状态同步逻辑 - 使用 requestAnimationFrame 延迟执行，避免在节点创建时干扰
+    useEffect(() => {
+      if (!isOnGeneratingNewNode && hasMountedRef.current) {
+        requestAnimationFrame(() => {
+          const node = getNode(id);
+          if (node) {
+            setNodes(prevNodes =>
+              prevNodes.map(n => {
+                if (n.id === id) {
+                  return {
+                    ...n,
+                    data: {
+                      ...n.data,
+                      extra_configs: {
+                        ...(n.data as SearchConfigNodeData).extra_configs,
+                        model: model,
+                      },
+                    },
+                  };
+                }
+                return n;
+              })
+            );
+          }
+        });
+      }
+    }, [id, setNodes, model, isOnGeneratingNewNode]);
+
+    useEffect(() => {
+      if (hasMountedRef.current && !isOnGeneratingNewNode) {
+        clearAll();
+        activateEdge(id);
+      }
+
+      return () => {
+        if (activatedEdge === id) {
+          clearEdgeActivation();
+        }
+      };
+    }, [isOnGeneratingNewNode]);
+
+    // UI 交互函数 - 使用 useCallback 缓存
+    const onClickButton = useCallback(() => {
+      setIsMenuOpen(!isMenuOpen);
+
+      if (isOnGeneratingNewNode) return;
       if (activatedEdge === id) {
         clearEdgeActivation();
+      } else {
+        clearAll();
+        activateEdge(id);
       }
-    };
-  }, []);
+    }, [
+      isMenuOpen,
+      isOnGeneratingNewNode,
+      activatedEdge,
+      id,
+      clearEdgeActivation,
+      clearAll,
+      activateEdge,
+    ]);
 
-  // 同步model状态到ReactFlow
-  useEffect(() => {
-    setNodes(prevNodes =>
-      prevNodes.map(node => {
-        if (node.id === id) {
-          return {
-            ...node,
-            data: {
-              ...node.data,
-              extra_configs: {
-                ...(node.data as SearchConfigNodeData).extra_configs,
-                model: model,
-              },
-            },
-          };
-        }
-        return node;
-      })
+    // 执行函数 - 使用 useCallback 缓存
+    const onDataSubmit = useCallback(() => {
+      handleDataSubmit();
+    }, [handleDataSubmit]);
+
+    // 添加停止函数 - 使用 useCallback 缓存
+    const onStopExecution = useCallback(() => {
+      console.log('Stop execution');
+      setIsLoading(false);
+    }, []);
+
+    // 模型选择处理函数 - 使用 useCallback 缓存
+    const handleModelSelect = useCallback((value: string) => {
+      setModel(value as PerplexityModelNames);
+    }, []);
+
+    // 在组件顶部定义共享样式 - 使用 useMemo 缓存
+    const handleStyle = useMemo(
+      () => ({
+        position: 'absolute' as const,
+        width: 'calc(100%)',
+        height: 'calc(100%)',
+        top: '0',
+        left: '0',
+        borderRadius: '0',
+        transform: 'translate(0px, 0px)',
+        background: 'transparent',
+        border: '3px solid transparent',
+        zIndex: !isOnConnect ? '-1' : '1',
+      }),
+      [isOnConnect]
     );
-  }, [id, setNodes, model]);
 
-  const onClickButton = () => {
-    setIsMenuOpen(!isMenuOpen);
+    // 缓存按钮样式 - 使用 useMemo 缓存
+    const runButtonStyle = useMemo(
+      () => ({
+        backgroundColor: isRunButtonHovered
+          ? isLoading
+            ? '#FFA73D'
+            : '#39BC66'
+          : '#181818',
+        borderColor: isRunButtonHovered
+          ? isLoading
+            ? '#FFA73D'
+            : '#39BC66'
+          : UI_COLORS.EDGENODE_BORDER_GREY,
+        color: isRunButtonHovered ? '#000' : UI_COLORS.EDGENODE_BORDER_GREY,
+      }),
+      [isRunButtonHovered, isLoading]
+    );
 
-    if (isOnGeneratingNewNode) return;
-    if (activatedEdge === id) {
-      clearEdgeActivation();
-    } else {
-      clearAll();
-      activateEdge(id);
-    }
-  };
-
-  // 在组件顶部定义共享样式
-  const handleStyle = {
-    position: 'absolute' as const,
-    width: 'calc(100%)',
-    height: 'calc(100%)',
-    top: '0',
-    left: '0',
-    borderRadius: '0',
-    transform: 'translate(0px, 0px)',
-    background: 'transparent',
-    border: '3px solid transparent',
-    zIndex: !isOnConnect ? '-1' : '1',
-  };
-
-  return (
-    <div className='p-[3px] w-[80px] h-[48px] relative'>
-      {/* Invisible hover area between node and run button */}
-      <div
-        className='absolute -top-[40px] left-0 w-full h-[40px]'
-        onMouseEnter={() => setIsHovered(true)}
-        onMouseLeave={() => setIsHovered(false)}
-      />
-
-      {/* Run button positioned above the node - show when node or run button is hovered */}
-      <button
-        className={`absolute -top-[40px] left-1/2 transform -translate-x-1/2 w-[57px] h-[24px] rounded-[6px] border-[1px] text-[10px] font-[600] font-plus-jakarta-sans flex flex-row items-center justify-center gap-[4px] transition-all duration-200 ${
-          isHovered || isRunButtonHovered ? 'opacity-100' : 'opacity-0'
-        }`}
-        style={{
-          backgroundColor: isRunButtonHovered ? '#39BC66' : '#181818',
-          borderColor: isRunButtonHovered
-            ? '#39BC66'
-            : UI_COLORS.EDGENODE_BORDER_GREY,
-          color: isRunButtonHovered ? '#000' : UI_COLORS.EDGENODE_BORDER_GREY,
-        }}
-        onClick={handleDataSubmit}
-        disabled={isLoading}
-        onMouseEnter={() => setIsRunButtonHovered(true)}
-        onMouseLeave={() => setIsRunButtonHovered(false)}
-      >
-        <span>
-          {isLoading ? (
-            <svg className='animate-spin h-3 w-3' viewBox='0 0 24 24'>
-              <circle
-                className='opacity-25'
-                cx='12'
-                cy='12'
-                r='10'
-                stroke='currentColor'
-                strokeWidth='4'
-              ></circle>
-              <path
-                className='opacity-75'
-                fill='currentColor'
-                d='M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 714 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z'
-              ></path>
-            </svg>
-          ) : (
-            <svg
-              xmlns='http://www.w3.org/2000/svg'
-              width='6'
-              height='8'
-              viewBox='0 0 8 10'
-              fill='none'
-            >
-              <path d='M8 5L0 10V0L8 5Z' fill='currentColor' />
-            </svg>
-          )}
-        </span>
-        <span>{isLoading ? '' : 'Run'}</span>
-      </button>
-
-      <button
-        onClick={onClickButton}
-        onMouseEnter={() => setIsHovered(true)}
-        onMouseLeave={() => setIsHovered(false)}
-        className={`w-full h-full flex-shrink-0 rounded-[8px] border-[2px] bg-[#181818] flex items-center justify-center font-plus-jakarta-sans text-[10px] font-[700] edge-node transition-colors gap-[4px]`}
-        style={{
-          borderColor: isHovered
+    const mainButtonStyle = useMemo(
+      () => ({
+        borderColor: isLoading
+          ? '#FFA73D'
+          : isHovered
             ? UI_COLORS.LINE_ACTIVE
             : UI_COLORS.EDGENODE_BORDER_GREY,
-          color: isHovered
+        color: isLoading
+          ? '#FFA73D'
+          : isHovered
             ? UI_COLORS.LINE_ACTIVE
             : UI_COLORS.EDGENODE_BORDER_GREY,
-        }}
-      >
-        {/* Perplexity icon */}
-        <img
-          src='/Perplexity.svg'
-          alt='Perplexity icon'
-          className='w-[10px] h-[10px]'
-        />
-        <div className='flex flex-col items-center justify-center leading-tight text-[9px]'>
-          <span>Perplexity</span>
-        </div>
+      }),
+      [isLoading, isHovered]
+    );
 
-        <Handle
-          id={`${id}-a`}
-          className='edgeSrcHandle handle-with-icon handle-top'
-          type='source'
-          position={Position.Top}
-        />
-        <Handle
-          id={`${id}-b`}
-          className='edgeSrcHandle handle-with-icon handle-right'
-          type='source'
-          position={Position.Right}
-        />
-        <Handle
-          id={`${id}-c`}
-          className='edgeSrcHandle handle-with-icon handle-bottom'
-          type='source'
-          position={Position.Bottom}
-        />
-        <Handle
-          id={`${id}-d`}
-          className='edgeSrcHandle handle-with-icon handle-left'
-          type='source'
-          position={Position.Left}
+    // 缓存模型选项 - 使用 useMemo 缓存
+    const modelOptions = useMemo(
+      () => [
+        'llama-3.1-sonar-small-128k-online',
+        'llama-3.1-sonar-large-128k-online',
+        'llama-3.1-sonar-huge-128k-online',
+      ],
+      []
+    );
+
+    // 缓存菜单按钮样式 - 使用 useMemo 缓存
+    const menuRunButtonStyle = useMemo(
+      () => ({
+        backgroundColor: isLoading ? '#FFA73D' : '#39BC66',
+      }),
+      [isLoading]
+    );
+
+    return (
+      <div className='p-[3px] w-[80px] h-[48px] relative'>
+        {/* Invisible hover area between node and run button */}
+        <div
+          className='absolute -top-[40px] left-0 w-full h-[40px]'
+          onMouseEnter={() => setIsHovered(true)}
+          onMouseLeave={() => setIsHovered(false)}
         />
 
-        <Handle
-          id={`${id}-a`}
-          type='target'
-          position={Position.Top}
-          style={handleStyle}
-          isConnectable={isConnectable}
-          onMouseEnter={() => setIsTargetHandleTouched(true)}
-          onMouseLeave={() => setIsTargetHandleTouched(false)}
-        />
-        <Handle
-          id={`${id}-b`}
-          type='target'
-          position={Position.Right}
-          style={handleStyle}
-          isConnectable={isConnectable}
-          onMouseEnter={() => setIsTargetHandleTouched(true)}
-          onMouseLeave={() => setIsTargetHandleTouched(false)}
-        />
-        <Handle
-          id={`${id}-c`}
-          type='target'
-          position={Position.Bottom}
-          style={handleStyle}
-          isConnectable={isConnectable}
-          onMouseEnter={() => setIsTargetHandleTouched(true)}
-          onMouseLeave={() => setIsTargetHandleTouched(false)}
-        />
-        <Handle
-          id={`${id}-d`}
-          type='target'
-          position={Position.Left}
-          style={handleStyle}
-          isConnectable={isConnectable}
-          onMouseEnter={() => setIsTargetHandleTouched(true)}
-          onMouseLeave={() => setIsTargetHandleTouched(false)}
-        />
-      </button>
-
-      {/* Configuration Menu */}
-      {isMenuOpen && (
-        <ul
-          ref={menuRef}
-          className={`absolute top-[64px] text-white w-[320px] rounded-[16px] border-[1px] bg-[#1A1A1A] p-[10px] font-plus-jakarta-sans flex flex-col gap-[16px] shadow-lg`}
-          style={{
-            borderColor: UI_COLORS.EDGENODE_BORDER_GREY,
-          }}
+        {/* Run button positioned above the node - show when node or run button is hovered */}
+        <button
+          className={`absolute -top-[40px] left-1/2 transform -translate-x-1/2 w-[57px] h-[24px] rounded-[6px] border-[1px] text-[10px] font-[600] font-plus-jakarta-sans flex flex-row items-center justify-center gap-[4px] transition-all duration-200 ${
+            isHovered || isRunButtonHovered ? 'opacity-100' : 'opacity-0'
+          }`}
+          style={runButtonStyle}
+          onClick={isLoading ? onStopExecution : handleDataSubmit}
+          disabled={false}
+          onMouseEnter={() => setIsRunButtonHovered(true)}
+          onMouseLeave={() => setIsRunButtonHovered(false)}
         >
-          <li className='flex h-[28px] gap-1 items-center justify-between font-plus-jakarta-sans'>
-            <div className='flex flex-row gap-[12px]'>
-              <div className='flex flex-row gap-[8px] justify-center items-center'>
-                <div className='w-[24px] h-[24px] border-[1px] border-main-grey bg-main-black-theme rounded-[8px] flex items-center justify-center'>
-                  <img src='/Perplexity.svg' alt='Perplexity icon' />
-                </div>
-                <div className='flex items-center justify-center text-[14px] font-semibold text-main-grey font-plus-jakarta-sans leading-normal'>
-                  Perplexity
+          <span>
+            {isLoading ? (
+              <svg width='6' height='6' viewBox='0 0 6 6' fill='none'>
+                <rect width='6' height='6' fill='currentColor' />
+              </svg>
+            ) : (
+              <svg
+                xmlns='http://www.w3.org/2000/svg'
+                width='6'
+                height='8'
+                viewBox='0 0 8 10'
+                fill='none'
+              >
+                <path d='M8 5L0 10V0L8 5Z' fill='currentColor' />
+              </svg>
+            )}
+          </span>
+          <span>{isLoading ? 'Stop' : 'Run'}</span>
+        </button>
+
+        <button
+          onClick={onClickButton}
+          onMouseEnter={() => setIsHovered(true)}
+          onMouseLeave={() => setIsHovered(false)}
+          className={`w-full h-full flex-shrink-0 rounded-[8px] border-[2px] bg-[#181818] flex items-center justify-center font-plus-jakarta-sans text-[10px] font-[700] edge-node transition-colors gap-[4px]`}
+          style={mainButtonStyle}
+        >
+          {/* Perplexity icon */}
+          <img
+            src='/Perplexity.svg'
+            alt='Perplexity icon'
+            className='w-[10px] h-[10px]'
+          />
+          <div className='flex flex-col items-center justify-center leading-tight text-[9px]'>
+            <span>Perplexity</span>
+          </div>
+
+          <Handle
+            id={`${id}-a`}
+            className='edgeSrcHandle handle-with-icon handle-top'
+            type='source'
+            position={Position.Top}
+          />
+          <Handle
+            id={`${id}-b`}
+            className='edgeSrcHandle handle-with-icon handle-right'
+            type='source'
+            position={Position.Right}
+          />
+          <Handle
+            id={`${id}-c`}
+            className='edgeSrcHandle handle-with-icon handle-bottom'
+            type='source'
+            position={Position.Bottom}
+          />
+          <Handle
+            id={`${id}-d`}
+            className='edgeSrcHandle handle-with-icon handle-left'
+            type='source'
+            position={Position.Left}
+          />
+
+          <Handle
+            id={`${id}-a`}
+            type='target'
+            position={Position.Top}
+            style={handleStyle}
+            isConnectable={isConnectable}
+            onMouseEnter={() => setIsTargetHandleTouched(true)}
+            onMouseLeave={() => setIsTargetHandleTouched(false)}
+          />
+          <Handle
+            id={`${id}-b`}
+            type='target'
+            position={Position.Right}
+            style={handleStyle}
+            isConnectable={isConnectable}
+            onMouseEnter={() => setIsTargetHandleTouched(true)}
+            onMouseLeave={() => setIsTargetHandleTouched(false)}
+          />
+          <Handle
+            id={`${id}-c`}
+            type='target'
+            position={Position.Bottom}
+            style={handleStyle}
+            isConnectable={isConnectable}
+            onMouseEnter={() => setIsTargetHandleTouched(true)}
+            onMouseLeave={() => setIsTargetHandleTouched(false)}
+          />
+          <Handle
+            id={`${id}-d`}
+            type='target'
+            position={Position.Left}
+            style={handleStyle}
+            isConnectable={isConnectable}
+            onMouseEnter={() => setIsTargetHandleTouched(true)}
+            onMouseLeave={() => setIsTargetHandleTouched(false)}
+          />
+        </button>
+
+        {/* Configuration Menu */}
+        {isMenuOpen && (
+          <ul
+            ref={menuRef}
+            className={`absolute top-[64px] text-white w-[320px] rounded-[16px] border-[1px] bg-[#1A1A1A] p-[10px] font-plus-jakarta-sans flex flex-col gap-[16px] shadow-lg`}
+            style={{
+              borderColor: UI_COLORS.EDGENODE_BORDER_GREY,
+            }}
+          >
+            <li className='flex h-[28px] gap-1 items-center justify-between font-plus-jakarta-sans'>
+              <div className='flex flex-row gap-[12px]'>
+                <div className='flex flex-row gap-[8px] justify-center items-center'>
+                  <div className='w-[24px] h-[24px] border-[1px] border-main-grey bg-main-black-theme rounded-[8px] flex items-center justify-center'>
+                    <img src='/Perplexity.svg' alt='Perplexity icon' />
+                  </div>
+                  <div className='flex items-center justify-center text-[14px] font-semibold text-main-grey font-plus-jakarta-sans leading-normal'>
+                    Perplexity
+                  </div>
                 </div>
               </div>
-            </div>
-            <div className='w-[57px] h-[26px]'>
-              <button
-                className='w-full h-full rounded-[8px] bg-[#39BC66] text-[#000] text-[12px] font-semibold font-plus-jakarta-sans flex flex-row items-center justify-center gap-[7px]'
-                onClick={handleDataSubmit}
-                disabled={isLoading}
-              >
-                <span>
-                  {isLoading ? (
-                    <svg className='animate-spin h-4 w-4' viewBox='0 0 24 24'>
-                      <circle
-                        className='opacity-25'
-                        cx='12'
-                        cy='12'
-                        r='10'
-                        stroke='currentColor'
-                        strokeWidth='4'
-                      ></circle>
-                      <path
-                        className='opacity-75'
-                        fill='currentColor'
-                        d='M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 714 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z'
-                      ></path>
-                    </svg>
-                  ) : (
-                    <svg
-                      xmlns='http://www.w3.org/2000/svg'
-                      width='8'
-                      height='10'
-                      viewBox='0 0 8 10'
-                      fill='none'
-                    >
-                      <path d='M8 5L0 10V0L8 5Z' fill='black' />
-                    </svg>
-                  )}
-                </span>
-                <span>{isLoading ? '' : 'Run'}</span>
-              </button>
-            </div>
-          </li>
+              <div className='w-[57px] h-[26px]'>
+                <button
+                  className='w-full h-full rounded-[8px] text-[#000] text-[12px] font-semibold font-plus-jakarta-sans flex flex-row items-center justify-center gap-[7px]'
+                  style={menuRunButtonStyle}
+                  onClick={isLoading ? onStopExecution : onDataSubmit}
+                  disabled={false}
+                >
+                  <span>
+                    {isLoading ? (
+                      <svg width='8' height='8' viewBox='0 0 8 8' fill='none'>
+                        <rect width='8' height='8' fill='currentColor' />
+                      </svg>
+                    ) : (
+                      <svg
+                        xmlns='http://www.w3.org/2000/svg'
+                        width='8'
+                        height='10'
+                        viewBox='0 0 8 10'
+                        fill='none'
+                      >
+                        <path d='M8 5L0 10V0L8 5Z' fill='black' />
+                      </svg>
+                    )}
+                  </span>
+                  <span>{isLoading ? 'Stop' : 'Run'}</span>
+                </button>
+              </div>
+            </li>
 
-          <li>
-            <InputOutputDisplay
-              parentId={id}
-              getNode={getNode}
-              getSourceNodeIdWithLabel={getSourceNodeIdWithLabel}
-              getTargetNodeIdWithLabel={getTargetNodeIdWithLabel}
-              supportedInputTypes={['text']}
-              supportedOutputTypes={['structured']}
-              inputNodeCategory='blocknode'
-              outputNodeCategory='blocknode'
-            />
-          </li>
-
-          <li className='flex flex-col gap-2'>
-            <div className='flex items-center gap-2'>
-              <label className='text-[13px] font-semibold text-[#6D7177]'>
-                Model
-              </label>
-              <div className='w-[5px] h-[5px] rounded-full bg-[#FF4D4D]'></div>
-            </div>
-            <div className='relative h-[32px] p-0 bg-[#252525] rounded-[6px] border-[1px] border-[#6D7177]/30 hover:border-[#6D7177]/50 transition-colors'>
-              <PuppyDropdown
-                options={[
-                  'llama-3.1-sonar-small-128k-online',
-                  'llama-3.1-sonar-large-128k-online',
-                  'llama-3.1-sonar-huge-128k-online',
-                ]}
-                selectedValue={model}
-                onSelect={(value: string) => {
-                  setModel(value as PerplexityModelNames);
-                }}
-                buttonHeight='32px'
-                buttonBgColor='transparent'
-                menuBgColor='#1A1A1A'
-                listWidth='100%'
-                containerClassnames='w-full'
+            <li>
+              <InputOutputDisplay
+                parentId={id}
+                getNode={getNode}
+                getSourceNodeIdWithLabel={getSourceNodeIdWithLabel}
+                getTargetNodeIdWithLabel={getTargetNodeIdWithLabel}
+                supportedInputTypes={['text']}
+                supportedOutputTypes={['structured']}
+                inputNodeCategory='blocknode'
+                outputNodeCategory='blocknode'
               />
-            </div>
-          </li>
-        </ul>
-      )}
-    </div>
-  );
-}
+            </li>
 
+            <li className='flex flex-col gap-2'>
+              <div className='flex items-center gap-2'>
+                <label className='text-[13px] font-semibold text-[#6D7177]'>
+                  Model
+                </label>
+                <div className='w-[5px] h-[5px] rounded-full bg-[#FF4D4D]'></div>
+              </div>
+              <div className='relative h-[32px] p-0 bg-[#252525] rounded-[6px] border-[1px] border-[#6D7177]/30 hover:border-[#6D7177]/50 transition-colors'>
+                <PuppyDropdown
+                  options={modelOptions}
+                  selectedValue={model}
+                  onSelect={handleModelSelect}
+                  buttonHeight='32px'
+                  buttonBgColor='transparent'
+                  menuBgColor='#1A1A1A'
+                  listWidth='100%'
+                  containerClassnames='w-full'
+                />
+              </div>
+            </li>
+          </ul>
+        )}
+      </div>
+    );
+  }
+);
+
+SearchPerplexity.displayName = 'SearchPerplexity';
 export default SearchPerplexity;

--- a/PuppyFlow/app/components/workflow/edgesNode/edgeNodesNew/ifelse.tsx
+++ b/PuppyFlow/app/components/workflow/edgesNode/edgeNodesNew/ifelse.tsx
@@ -1,6 +1,12 @@
 import { Handle, Position, NodeProps, Node, useReactFlow } from '@xyflow/react';
 import { useNodesPerFlowContext } from '@/app/components/states/NodesPerFlowContext';
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import React, {
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+  useMemo,
+} from 'react';
 import { markerEnd } from '../../connectionLineStyles/ConfigToTargetEdge';
 import InputOutputDisplay from './components/InputOutputDisplay';
 import { PuppyDropdown } from '@/app/components/misc/PuppyDropDown';
@@ -83,113 +89,478 @@ export type ConstructedChooseJsonData = {
   edges: { [key: string]: ChooseEdgeJsonType };
 };
 
-function IfElse({ isConnectable, id, data }: ChooseConfigNodeProps) {
-  const {
-    isOnConnect,
-    activatedEdge,
-    isOnGeneratingNewNode,
-    clearEdgeActivation,
-    activateEdge,
-    clearAll,
-  } = useNodesPerFlowContext();
-  const [isTargetHandleTouched, setIsTargetHandleTouched] = useState(false);
-  const { getNode, setNodes, setEdges } = useReactFlow();
-  const { getSourceNodeIdWithLabel, getTargetNodeIdWithLabel } =
-    useGetSourceTarget();
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const [isLoading, setIsLoading] = useState(false);
-  const menuRef = useRef<HTMLUListElement>(null);
-  const [isHovered, setIsHovered] = useState(false);
-  const [isRunButtonHovered, setIsRunButtonHovered] = useState(false);
-
-  // 获取所有需要的依赖
-  const { streamResult, reportError, resetLoadingUI } = useJsonConstructUtils();
-  const { getAuthHeaders } = useAppSettings();
-
-  // State management
-  const [cases, setCases] = useState<CaseItem[]>(() => {
-    const nodeData = getNode(id)?.data;
-    return (nodeData?.cases as CaseItem[]) || [];
-  });
-  const [switchValue, setSwitchValue] = useState<string>(() => {
-    const nodeData = getNode(id)?.data;
-    return (nodeData?.switch as string) || '';
-  });
-  const [contentValue, setContentValue] = useState<string>(() => {
-    const nodeData = getNode(id)?.data;
-    return (nodeData?.content as string) || '';
-  });
-  const [onValue, setOnValue] = useState<string[]>(() => {
-    const nodeData = getNode(id)?.data;
-    return (nodeData?.ON as string[]) || [];
-  });
-  const [offValue, setOffValue] = useState<string[]>(() => {
-    const nodeData = getNode(id)?.data;
-    return (nodeData?.OFF as string[]) || [];
-  });
-
-  // Source node labels with type info
-  const [sourceNodeLabels, setSourceNodeLabels] = useState<
-    { label: string; type: string }[]
-  >([]);
-
-  // 创建执行上下文
-  const createExecutionContext = useCallback(
-    (): RunSingleEdgeNodeContext => ({
-      getNode,
-      setNodes,
-      setEdges,
-      getSourceNodeIdWithLabel,
-      getTargetNodeIdWithLabel,
+const IfElse: React.FC<ChooseConfigNodeProps> = React.memo(
+  ({ isConnectable, id, data }) => {
+    const {
+      isOnConnect,
+      activatedEdge,
+      isOnGeneratingNewNode,
+      clearEdgeActivation,
+      activateEdge,
       clearAll,
-      streamResult,
-      reportError,
-      resetLoadingUI,
-      getAuthHeaders,
-    }),
-    [
-      getNode,
-      setNodes,
-      setEdges,
-      getSourceNodeIdWithLabel,
-      getTargetNodeIdWithLabel,
-      clearAll,
-      streamResult,
-      reportError,
-      resetLoadingUI,
-      getAuthHeaders,
-    ]
-  );
+    } = useNodesPerFlowContext();
+    const [isTargetHandleTouched, setIsTargetHandleTouched] = useState(false);
+    const { getNode, setNodes, setEdges } = useReactFlow();
+    const { getSourceNodeIdWithLabel, getTargetNodeIdWithLabel } =
+      useGetSourceTarget();
+    const [isMenuOpen, setIsMenuOpen] = useState(false);
+    const [isLoading, setIsLoading] = useState(false);
+    const menuRef = useRef<HTMLUListElement>(null);
+    const [isHovered, setIsHovered] = useState(false);
+    const [isRunButtonHovered, setIsRunButtonHovered] = useState(false);
 
-  // 使用执行函数的 handleDataSubmit
-  const handleDataSubmit = useCallback(async () => {
-    if (isLoading) return;
+    // 获取所有需要的依赖
+    const { streamResult, reportError, resetLoadingUI } =
+      useJsonConstructUtils();
+    const { getAuthHeaders } = useAppSettings();
 
-    setIsLoading(true);
-    try {
-      const context = createExecutionContext();
-      await runSingleEdgeNode({
-        parentId: id,
-        targetNodeType: 'ifelse',
-        context,
-      });
-    } catch (error) {
-      console.error('执行失败:', error);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [id, isLoading, createExecutionContext]);
+    // 使用 useRef 跟踪是否已挂载
+    const hasMountedRef = useRef(false);
 
-  // Initialize component
-  useEffect(() => {
-    if (!isOnGeneratingNewNode) {
-      clearAll();
-      activateEdge(id);
-
-      // 检查并初始化内容
+    // 优化状态初始化 - 使用函数形式避免重复计算
+    const [cases, setCases] = useState<CaseItem[]>(() => {
       const nodeData = getNode(id)?.data;
+      return (nodeData?.cases as CaseItem[]) || [];
+    });
 
-      // 同步所有状态到节点数据
+    const [switchValue, setSwitchValue] = useState<string>(() => {
+      const nodeData = getNode(id)?.data;
+      return (nodeData?.switch as string) || '';
+    });
+
+    const [contentValue, setContentValue] = useState<string>(() => {
+      const nodeData = getNode(id)?.data;
+      return (nodeData?.content as string) || '';
+    });
+
+    const [onValue, setOnValue] = useState<string[]>(() => {
+      const nodeData = getNode(id)?.data;
+      return (nodeData?.ON as string[]) || [];
+    });
+
+    const [offValue, setOffValue] = useState<string[]>(() => {
+      const nodeData = getNode(id)?.data;
+      return (nodeData?.OFF as string[]) || [];
+    });
+
+    // Source node labels with type info
+    const [sourceNodeLabels, setSourceNodeLabels] = useState<
+      { label: string; type: string }[]
+    >([]);
+
+    // 创建执行上下文 - 使用 useCallback 缓存
+    const createExecutionContext = useCallback(
+      (): RunSingleEdgeNodeContext => ({
+        getNode,
+        setNodes,
+        setEdges,
+        getSourceNodeIdWithLabel,
+        getTargetNodeIdWithLabel,
+        clearAll,
+        streamResult,
+        reportError,
+        resetLoadingUI,
+        getAuthHeaders,
+      }),
+      [
+        getNode,
+        setNodes,
+        setEdges,
+        getSourceNodeIdWithLabel,
+        getTargetNodeIdWithLabel,
+        clearAll,
+        streamResult,
+        reportError,
+        resetLoadingUI,
+        getAuthHeaders,
+      ]
+    );
+
+    // 使用执行函数的 handleDataSubmit - 使用 useCallback 缓存
+    const handleDataSubmit = useCallback(async () => {
+      if (isLoading) return;
+
+      setIsLoading(true);
+      try {
+        const context = createExecutionContext();
+        await runSingleEdgeNode({
+          parentId: id,
+          targetNodeType: 'ifelse',
+          context,
+        });
+      } catch (error) {
+        console.error('执行失败:', error);
+      } finally {
+        setIsLoading(false);
+      }
+    }, [id, isLoading, createExecutionContext]);
+
+    // 组件初始化
+    useEffect(() => {
+      hasMountedRef.current = true;
+    }, []);
+
+    // Initialize component
+    useEffect(() => {
+      if (hasMountedRef.current && !isOnGeneratingNewNode) {
+        clearAll();
+        activateEdge(id);
+
+        // 检查并初始化内容
+        const nodeData = getNode(id)?.data;
+
+        // 同步所有状态到节点数据
+        requestAnimationFrame(() => {
+          setNodes(prevNodes =>
+            prevNodes.map(node => {
+              if (node.id === id) {
+                return {
+                  ...node,
+                  data: {
+                    ...node.data,
+                    cases: cases,
+                    switch: switchValue,
+                    content: contentValue,
+                    ON: onValue,
+                    OFF: offValue,
+                  },
+                };
+              }
+              return node;
+            })
+          );
+        });
+      }
+
+      return () => {
+        if (activatedEdge === id) {
+          clearEdgeActivation();
+        }
+      };
+    }, [isOnGeneratingNewNode]);
+
+    // 监听所有状态变化 - 使用 requestAnimationFrame 延迟执行，避免在节点创建时干扰
+    useEffect(() => {
+      if (!isOnGeneratingNewNode && hasMountedRef.current) {
+        requestAnimationFrame(() => {
+          setNodes(prevNodes =>
+            prevNodes.map(node => {
+              if (node.id === id) {
+                return {
+                  ...node,
+                  data: {
+                    ...node.data,
+                    cases: cases,
+                    switch: switchValue,
+                    content: contentValue,
+                    ON: onValue,
+                    OFF: offValue,
+                  },
+                };
+              }
+              return node;
+            })
+          );
+        });
+      }
+    }, [
+      cases,
+      switchValue,
+      contentValue,
+      onValue,
+      offValue,
+      isOnGeneratingNewNode,
+    ]);
+
+    // Update sourceNodeLabels - 使用 useCallback 缓存
+    const updateSourceNodeLabels = useCallback(() => {
+      const sourceNodeIdWithLabelGroup = getSourceNodeIdWithLabel(id);
+      // Collect labels and types
+      const labelsWithTypes = sourceNodeIdWithLabelGroup.map(node => {
+        const nodeInfo = getNode(node.id);
+        const nodeType = nodeInfo?.type || 'text'; // Default to text if type not found
+        return {
+          label: node.label,
+          type: nodeType,
+        };
+      });
+      setSourceNodeLabels(labelsWithTypes);
+    }, [id, getNode, getSourceNodeIdWithLabel]);
+
+    useEffect(() => {
+      updateSourceNodeLabels();
+    }, [updateSourceNodeLabels]);
+
+    // Initialize cases if not already set - 使用 useCallback 缓存
+    const initializeCases = useCallback(() => {
+      if (cases.length === 0 && sourceNodeLabels.length > 0) {
+        const firstSourceNode = getSourceNodeIdWithLabel(id)[0];
+        setCases([
+          {
+            conditions: [
+              {
+                id: firstSourceNode?.id || '',
+                label: firstSourceNode?.label || '',
+                condition: 'contains',
+                cond_v: '',
+                operation: 'AND',
+              },
+            ],
+            actions: [
+              {
+                from_id: id,
+                from_label: 'output',
+                outputs: [],
+              },
+            ],
+          },
+        ]);
+      }
+    }, [cases.length, sourceNodeLabels, getSourceNodeIdWithLabel, id]);
+
+    useEffect(() => {
+      initializeCases();
+    }, [initializeCases]);
+
+    // UI interaction functions - 使用 useCallback 缓存
+    const onClickButton = useCallback(() => {
+      setIsMenuOpen(!isMenuOpen);
+
+      if (isOnGeneratingNewNode) return;
+      if (activatedEdge === id) {
+        clearEdgeActivation();
+      } else {
+        clearAll();
+        activateEdge(id);
+      }
+    }, [
+      isMenuOpen,
+      isOnGeneratingNewNode,
+      activatedEdge,
+      id,
+      clearEdgeActivation,
+      clearAll,
+      activateEdge,
+    ]);
+
+    const onFocus = useCallback(() => {
+      const curRef = menuRef.current;
+      if (curRef && !curRef.classList.contains('nodrag')) {
+        curRef.classList.add('nodrag');
+      }
+    }, []);
+
+    const onBlur = useCallback(() => {
+      const curRef = menuRef.current;
+      if (curRef) {
+        curRef.classList.remove('nodrag');
+      }
+    }, []);
+
+    // Data synchronization functions - 使用 useCallback 缓存
+    const onSwitchValueChange = useCallback(
+      (newValue: string) => {
+        setSwitchValue(newValue);
+        setNodes(prevNodes =>
+          prevNodes.map(node => {
+            if (node.id === id) {
+              return { ...node, data: { ...node.data, switch: newValue } };
+            }
+            return node;
+          })
+        );
+      },
+      [id, setNodes]
+    );
+
+    const onContentValueChange = useCallback(
+      (newValue: string) => {
+        setContentValue(newValue);
+        setNodes(prevNodes =>
+          prevNodes.map(node => {
+            if (node.id === id) {
+              return { ...node, data: { ...node.data, content: newValue } };
+            }
+            return node;
+          })
+        );
+      },
+      [id, setNodes]
+    );
+
+    const onONValueChange = useCallback(
+      (newValues: string[]) => {
+        setOnValue(newValues);
+        setNodes(prevNodes =>
+          prevNodes.map(node => {
+            if (node.id === id) {
+              return { ...node, data: { ...node.data, ON: newValues } };
+            }
+            return node;
+          })
+        );
+      },
+      [id, setNodes]
+    );
+
+    const onOFFValueChange = useCallback(
+      (newValues: string[]) => {
+        setOffValue(newValues);
+        setNodes(prevNodes =>
+          prevNodes.map(node => {
+            if (node.id === id) {
+              return { ...node, data: { ...node.data, OFF: newValues } };
+            }
+            return node;
+          })
+        );
+      },
+      [id, setNodes]
+    );
+
+    const onCasesChange = useCallback((newCases: CaseItem[]) => {
+      setCases(newCases);
+      // No need to sync this to ReactFlow node data as it's handled separately
+    }, []);
+
+    // Case manipulation functions - 使用 useCallback 缓存
+    const onCaseAdd = useCallback(() => {
+      setCases(prevCases => {
+        const newCases = [
+          ...prevCases,
+          {
+            conditions: [
+              {
+                id: nanoid(6),
+                label: sourceNodeLabels[0]?.label || '',
+                condition: 'contains',
+                cond_v: '',
+                operation: 'AND',
+              },
+            ],
+            actions: [
+              {
+                from_id: id,
+                from_label: 'output',
+                outputs: [],
+              },
+            ],
+          },
+        ];
+        onCasesChange(newCases);
+        return newCases;
+      });
+    }, [sourceNodeLabels, id, onCasesChange]);
+
+    const onCaseDelete = useCallback(
+      (caseIndex: number) => {
+        setCases(prevCases => {
+          const newCases = prevCases.filter((_, index) => index !== caseIndex);
+          onCasesChange(newCases);
+          return newCases;
+        });
+      },
+      [onCasesChange]
+    );
+
+    const onConditionAdd = useCallback(
+      (caseIndex: number) => (e: React.MouseEvent) => {
+        e.stopPropagation();
+        setCases(prevCases => {
+          const newCases = [...prevCases];
+          const firstSourceNode = getSourceNodeIdWithLabel(id)[0];
+          newCases[caseIndex].conditions.push({
+            id: firstSourceNode?.id || '',
+            label: firstSourceNode?.label || '',
+            condition: 'contains',
+            cond_v: '',
+            operation: 'AND',
+          });
+          onCasesChange(newCases);
+          return newCases;
+        });
+      },
+      [getSourceNodeIdWithLabel, id, onCasesChange]
+    );
+
+    const onConditionDelete = useCallback(
+      (caseIndex: number, conditionIndex: number) => () => {
+        setCases(prevCases => {
+          const newCases = [...prevCases];
+          if (newCases[caseIndex].conditions.length > 1) {
+            newCases[caseIndex].conditions.splice(conditionIndex, 1);
+            onCasesChange(newCases);
+          }
+          return newCases;
+        });
+      },
+      [onCasesChange]
+    );
+
+    const onAndOrSwitch = useCallback(
+      (caseIndex: number, conditionIndex: number) => () => {
+        setCases(prevCases => {
+          const newCases = [...prevCases];
+          const currentOperation =
+            newCases[caseIndex].conditions[conditionIndex].operation;
+          newCases[caseIndex].conditions[conditionIndex].operation =
+            currentOperation === 'AND' ? 'OR' : 'AND';
+          onCasesChange(newCases);
+          return newCases;
+        });
+      },
+      [onCasesChange]
+    );
+
+    // Update condition values - 使用 useCallback 缓存
+    const updateCondition = useCallback(
+      (
+        caseIndex: number,
+        conditionIndex: number,
+        field: keyof Condition,
+        value: string
+      ) => {
+        setCases(prevCases => {
+          const newCases = [...prevCases];
+          newCases[caseIndex].conditions[conditionIndex][field] = value as any;
+          onCasesChange(newCases);
+          return newCases;
+        });
+      },
+      [onCasesChange]
+    );
+
+    // Helper functions for UI - 使用 useCallback 缓存
+    const getConditionSelections = useCallback((type: string) => {
+      if (type === 'text') {
+        return [
+          'contains',
+          "doesn't contain",
+          'is greater than [N] characters',
+          'is less than [N] characters',
+        ];
+      } else if (type === 'structured') {
+        return [
+          'is empty',
+          'is not empty',
+          'contains',
+          "doesn't contain",
+          'is greater than [N] characters',
+          'is less than [N] characters',
+          'is list',
+          'is dict',
+        ];
+      } else if (type === 'switch') {
+        return ['is True', 'is False'];
+      }
+
+      return [];
+    }, []);
+
+    // Replace the data submission function - 使用 useCallback 缓存
+    const onDataSubmit = useCallback(() => {
+      // Instead of passing cases data directly to the hook,
+      // update the node data which will be read by buildIfElseNodeJson
       setNodes(prevNodes =>
         prevNodes.map(node => {
           if (node.id === id) {
@@ -208,680 +579,420 @@ function IfElse({ isConnectable, id, data }: ChooseConfigNodeProps) {
           return node;
         })
       );
-    }
 
-    return () => {
-      if (activatedEdge === id) {
-        clearEdgeActivation();
-      }
-    };
-  }, []);
+      // Call the new handleDataSubmit without parameters
+      handleDataSubmit();
+    }, [
+      handleDataSubmit,
+      cases,
+      switchValue,
+      contentValue,
+      onValue,
+      offValue,
+      setNodes,
+      id,
+    ]);
 
-  // 监听所有状态变化
-  useEffect(() => {
-    setNodes(prevNodes =>
-      prevNodes.map(node => {
-        if (node.id === id) {
-          return {
-            ...node,
-            data: {
-              ...node.data,
-              cases: cases,
-              switch: switchValue,
-              content: contentValue,
-              ON: onValue,
-              OFF: offValue,
-            },
-          };
-        }
-        return node;
-      })
+    // Handle style for the component - 使用 useMemo 缓存
+    const handleStyle = useMemo(
+      () => ({
+        position: 'absolute' as const,
+        width: 'calc(100%)',
+        height: 'calc(100%)',
+        top: '0',
+        left: '0',
+        borderRadius: '0',
+        transform: 'translate(0px, 0px)',
+        background: 'transparent',
+        border: '3px solid transparent',
+        zIndex: !isOnConnect ? '-1' : '1',
+      }),
+      [isOnConnect]
     );
-  }, [cases, switchValue, contentValue, onValue, offValue]);
 
-  // Update sourceNodeLabels
-  useEffect(() => {
-    const sourceNodeIdWithLabelGroup = getSourceNodeIdWithLabel(id);
-    // Collect labels and types
-    const labelsWithTypes = sourceNodeIdWithLabelGroup.map(node => {
-      const nodeInfo = getNode(node.id);
-      const nodeType = nodeInfo?.type || 'text'; // Default to text if type not found
-      return {
-        label: node.label,
-        type: nodeType,
-      };
-    });
-    setSourceNodeLabels(labelsWithTypes);
-  }, [id, getNode, getSourceNodeIdWithLabel]);
-
-  // Initialize cases if not already set
-  useEffect(() => {
-    if (cases.length === 0 && sourceNodeLabels.length > 0) {
-      const firstSourceNode = getSourceNodeIdWithLabel(id)[0];
-      setCases([
-        {
-          conditions: [
-            {
-              id: firstSourceNode?.id || '',
-              label: firstSourceNode?.label || '',
-              condition: 'contains',
-              cond_v: '',
-              operation: 'AND',
-            },
-          ],
-          actions: [
-            {
-              from_id: id,
-              from_label: 'output',
-              outputs: [],
-            },
-          ],
-        },
-      ]);
-    }
-  }, [sourceNodeLabels]);
-
-  // UI interaction functions
-  const onClickButton = () => {
-    setIsMenuOpen(!isMenuOpen);
-
-    if (isOnGeneratingNewNode) return;
-    if (activatedEdge === id) {
-      clearEdgeActivation();
-    } else {
-      clearAll();
-      activateEdge(id);
-    }
-  };
-
-  const onFocus = () => {
-    const curRef = menuRef.current;
-    if (curRef && !curRef.classList.contains('nodrag')) {
-      curRef.classList.add('nodrag');
-    }
-  };
-
-  const onBlur = () => {
-    const curRef = menuRef.current;
-    if (curRef) {
-      curRef.classList.remove('nodrag');
-    }
-  };
-
-  // Data synchronization functions
-  const onSwitchValueChange = (newValue: string) => {
-    setSwitchValue(newValue);
-    setNodes(prevNodes =>
-      prevNodes.map(node => {
-        if (node.id === id) {
-          return { ...node, data: { ...node.data, switch: newValue } };
-        }
-        return node;
-      })
-    );
-  };
-
-  const onContentValueChange = (newValue: string) => {
-    setContentValue(newValue);
-    setNodes(prevNodes =>
-      prevNodes.map(node => {
-        if (node.id === id) {
-          return { ...node, data: { ...node.data, content: newValue } };
-        }
-        return node;
-      })
-    );
-  };
-
-  const onONValueChange = (newValues: string[]) => {
-    setOnValue(newValues);
-    setNodes(prevNodes =>
-      prevNodes.map(node => {
-        if (node.id === id) {
-          return { ...node, data: { ...node.data, ON: newValues } };
-        }
-        return node;
-      })
-    );
-  };
-
-  const onOFFValueChange = (newValues: string[]) => {
-    setOffValue(newValues);
-    setNodes(prevNodes =>
-      prevNodes.map(node => {
-        if (node.id === id) {
-          return { ...node, data: { ...node.data, OFF: newValues } };
-        }
-        return node;
-      })
-    );
-  };
-
-  const onCasesChange = (newCases: CaseItem[]) => {
-    setCases(newCases);
-    // No need to sync this to ReactFlow node data as it's handled separately
-  };
-
-  // Case manipulation functions
-  const onCaseAdd = () => {
-    setCases(prevCases => {
-      const newCases = [
-        ...prevCases,
-        {
-          conditions: [
-            {
-              id: nanoid(6),
-              label: sourceNodeLabels[0]?.label || '',
-              condition: 'contains',
-              cond_v: '',
-              operation: 'AND',
-            },
-          ],
-          actions: [
-            {
-              from_id: id,
-              from_label: 'output',
-              outputs: [],
-            },
-          ],
-        },
-      ];
-      onCasesChange(newCases);
-      return newCases;
-    });
-  };
-
-  const onCaseDelete = (caseIndex: number) => {
-    setCases(prevCases => {
-      const newCases = prevCases.filter((_, index) => index !== caseIndex);
-      onCasesChange(newCases);
-      return newCases;
-    });
-  };
-
-  const onConditionAdd = (caseIndex: number) => (e: React.MouseEvent) => {
-    e.stopPropagation();
-    setCases(prevCases => {
-      const newCases = [...prevCases];
-      const firstSourceNode = getSourceNodeIdWithLabel(id)[0];
-      newCases[caseIndex].conditions.push({
-        id: firstSourceNode?.id || '',
-        label: firstSourceNode?.label || '',
-        condition: 'contains',
-        cond_v: '',
-        operation: 'AND',
-      });
-      onCasesChange(newCases);
-      return newCases;
-    });
-  };
-
-  const onConditionDelete =
-    (caseIndex: number, conditionIndex: number) => () => {
-      setCases(prevCases => {
-        const newCases = [...prevCases];
-        if (newCases[caseIndex].conditions.length > 1) {
-          newCases[caseIndex].conditions.splice(conditionIndex, 1);
+    const onActionAdd = useCallback(
+      (caseIndex: number) => () => {
+        setCases(prevCases => {
+          const newCases = [...prevCases];
+          newCases[caseIndex].actions.push({
+            from_id: id,
+            from_label: 'output',
+            outputs: [],
+          });
           onCasesChange(newCases);
-        }
-        return newCases;
-      });
-    };
-
-  const onAndOrSwitch = (caseIndex: number, conditionIndex: number) => () => {
-    setCases(prevCases => {
-      const newCases = [...prevCases];
-      const currentOperation =
-        newCases[caseIndex].conditions[conditionIndex].operation;
-      newCases[caseIndex].conditions[conditionIndex].operation =
-        currentOperation === 'AND' ? 'OR' : 'AND';
-      onCasesChange(newCases);
-      return newCases;
-    });
-  };
-
-  // Update condition values
-  const updateCondition = (
-    caseIndex: number,
-    conditionIndex: number,
-    field: keyof Condition,
-    value: string
-  ) => {
-    setCases(prevCases => {
-      const newCases = [...prevCases];
-      newCases[caseIndex].conditions[conditionIndex][field] = value as any;
-      onCasesChange(newCases);
-      return newCases;
-    });
-  };
-
-  // Helper functions for UI
-  const getConditionSelections = (type: string) => {
-    if (type === 'text') {
-      return [
-        'contains',
-        "doesn't contain",
-        'is greater than [N] characters',
-        'is less than [N] characters',
-      ];
-    } else if (type === 'structured') {
-      return [
-        'is empty',
-        'is not empty',
-        'contains',
-        "doesn't contain",
-        'is greater than [N] characters',
-        'is less than [N] characters',
-        'is list',
-        'is dict',
-      ];
-    } else if (type === 'switch') {
-      return ['is True', 'is False'];
-    }
-
-    return [];
-  };
-
-  // Replace the data submission function
-  const onDataSubmit = useCallback(() => {
-    // Instead of passing cases data directly to the hook,
-    // update the node data which will be read by buildIfElseNodeJson
-    setNodes(prevNodes =>
-      prevNodes.map(node => {
-        if (node.id === id) {
-          return {
-            ...node,
-            data: {
-              ...node.data,
-              cases: cases,
-              switch: switchValue,
-              content: contentValue,
-              ON: onValue,
-              OFF: offValue,
-            },
-          };
-        }
-        return node;
-      })
+          return newCases;
+        });
+      },
+      [id, onCasesChange]
     );
 
-    // Call the new handleDataSubmit without parameters
-    handleDataSubmit();
-  }, [
-    handleDataSubmit,
-    cases,
-    switchValue,
-    contentValue,
-    onValue,
-    offValue,
-    setNodes,
-    id,
-  ]);
+    // 添加停止函数 - 使用 useCallback 缓存
+    const onStopExecution = useCallback(() => {
+      console.log('Stop execution');
+      setIsLoading(false);
+      // 暂时可以留空，或者调用相应的停止API
+    }, []);
 
-  // Handle style for the component
-  const handleStyle = {
-    position: 'absolute' as const,
-    width: 'calc(100%)',
-    height: 'calc(100%)',
-    top: '0',
-    left: '0',
-    borderRadius: '0',
-    transform: 'translate(0px, 0px)',
-    background: 'transparent',
-    border: '3px solid transparent',
-    zIndex: !isOnConnect ? '-1' : '1',
-  };
+    // 缓存按钮样式 - 使用 useMemo 缓存
+    const runButtonStyle = useMemo(
+      () => ({
+        backgroundColor: isRunButtonHovered
+          ? isLoading
+            ? '#FFA73D'
+            : '#39BC66'
+          : '#181818',
+        borderColor: isRunButtonHovered
+          ? isLoading
+            ? '#FFA73D'
+            : '#39BC66'
+          : UI_COLORS.EDGENODE_BORDER_GREY,
+        color: isRunButtonHovered ? '#000' : UI_COLORS.EDGENODE_BORDER_GREY,
+      }),
+      [isRunButtonHovered, isLoading]
+    );
 
-  const onActionAdd = (caseIndex: number) => () => {
-    setCases(prevCases => {
-      const newCases = [...prevCases];
-      newCases[caseIndex].actions.push({
-        from_id: id,
-        from_label: 'output',
-        outputs: [],
-      });
-      onCasesChange(newCases);
-      return newCases;
-    });
-  };
-
-  // 添加停止函数
-  const onStopExecution = useCallback(() => {
-    console.log('Stop execution');
-    setIsLoading(false);
-    // 暂时可以留空，或者调用相应的停止API
-  }, []);
-
-  return (
-    <div className='p-[3px] w-[80px] h-[48px] relative'>
-      {/* Invisible hover area between node and run button */}
-      <div
-        className='absolute -top-[40px] left-0 w-full h-[40px]'
-        onMouseEnter={() => setIsHovered(true)}
-        onMouseLeave={() => setIsHovered(false)}
-      />
-
-      {/* Run button positioned above the node - show when node or run button is hovered */}
-      <button
-        className={`absolute -top-[40px] left-1/2 transform -translate-x-1/2 w-[57px] h-[24px] rounded-[6px] border-[1px] text-[10px] font-[600] font-plus-jakarta-sans flex flex-row items-center justify-center gap-[4px] transition-all duration-200 ${
-          isHovered || isRunButtonHovered ? 'opacity-100' : 'opacity-0'
-        }`}
-        style={{
-          backgroundColor: isRunButtonHovered
-            ? isLoading
-              ? '#FFA73D'
-              : '#39BC66'
-            : '#181818',
-          borderColor: isRunButtonHovered
-            ? isLoading
-              ? '#FFA73D'
-              : '#39BC66'
+    const mainButtonStyle = useMemo(
+      () => ({
+        borderColor: isLoading
+          ? '#FFA73D'
+          : isHovered
+            ? UI_COLORS.LINE_ACTIVE
             : UI_COLORS.EDGENODE_BORDER_GREY,
-          color: isRunButtonHovered ? '#000' : UI_COLORS.EDGENODE_BORDER_GREY,
-        }}
-        onClick={isLoading ? onStopExecution : onDataSubmit}
-        disabled={false}
-        onMouseEnter={() => setIsRunButtonHovered(true)}
-        onMouseLeave={() => setIsRunButtonHovered(false)}
-      >
-        <span>
-          {isLoading ? (
-            <svg width='6' height='6' viewBox='0 0 6 6' fill='none'>
-              <rect width='6' height='6' fill='currentColor' />
-            </svg>
-          ) : (
-            <svg
-              xmlns='http://www.w3.org/2000/svg'
-              width='6'
-              height='8'
-              viewBox='0 0 8 10'
-              fill='none'
-            >
-              <path d='M8 5L0 10V0L8 5Z' fill='currentColor' />
-            </svg>
-          )}
-        </span>
-        <span>{isLoading ? 'Stop' : 'Run'}</span>
-      </button>
+        color: isLoading
+          ? '#FFA73D'
+          : isHovered
+            ? UI_COLORS.LINE_ACTIVE
+            : UI_COLORS.EDGENODE_BORDER_GREY,
+      }),
+      [isLoading, isHovered]
+    );
 
-      <button
-        onClick={onClickButton}
-        onMouseEnter={() => setIsHovered(true)}
-        onMouseLeave={() => setIsHovered(false)}
-        className={`w-full h-full flex-shrink-0 rounded-[8px] border-[2px] bg-[#181818] flex items-center justify-center font-plus-jakarta-sans text-[10px] font-[700] edge-node transition-colors gap-[4px]`}
-        style={{
-          borderColor: isLoading
-            ? '#FFA73D'
-            : isHovered
-              ? UI_COLORS.LINE_ACTIVE
-              : UI_COLORS.EDGENODE_BORDER_GREY,
-          color: isLoading
-            ? '#FFA73D'
-            : isHovered
-              ? UI_COLORS.LINE_ACTIVE
-              : UI_COLORS.EDGENODE_BORDER_GREY,
-        }}
-      >
-        {/* IF/ELSE SVG icon */}
-        <svg
-          xmlns='http://www.w3.org/2000/svg'
-          width='10'
-          height='10'
-          viewBox='0 0 12 12'
-          fill='none'
+    return (
+      <div className='p-[3px] w-[80px] h-[48px] relative'>
+        {/* Invisible hover area between node and run button */}
+        <div
+          className='absolute -top-[40px] left-0 w-full h-[40px]'
+          onMouseEnter={() => setIsHovered(true)}
+          onMouseLeave={() => setIsHovered(false)}
+        />
+
+        {/* Run button positioned above the node - show when node or run button is hovered */}
+        <button
+          className={`absolute -top-[40px] left-1/2 transform -translate-x-1/2 w-[57px] h-[24px] rounded-[6px] border-[1px] text-[10px] font-[600] font-plus-jakarta-sans flex flex-row items-center justify-center gap-[4px] transition-all duration-200 ${
+            isHovered || isRunButtonHovered ? 'opacity-100' : 'opacity-0'
+          }`}
+          style={runButtonStyle}
+          onClick={isLoading ? onStopExecution : onDataSubmit}
+          disabled={false}
+          onMouseEnter={() => setIsRunButtonHovered(true)}
+          onMouseLeave={() => setIsRunButtonHovered(false)}
         >
-          <path d='M6 12V7' stroke='currentColor' strokeWidth='2' />
-          <path d='M10 2V7L2 7V2' stroke='currentColor' strokeWidth='1.5' />
-          <path
-            d='M0.934259 2.5L2 0.901388L3.06574 2.5H0.934259Z'
-            fill='currentColor'
-            stroke='currentColor'
-          />
-          <path
-            d='M8.93426 2.5L10 0.901388L11.0657 2.5H8.93426Z'
-            fill='currentColor'
-            stroke='currentColor'
-          />
-        </svg>
-        <div className='flex flex-col items-center justify-center leading-tight text-[9px]'>
-          <span>IF/ELSE</span>
-        </div>
-
-        <Handle
-          id={`${id}-a`}
-          className='edgeSrcHandle handle-with-icon handle-top'
-          type='source'
-          position={Position.Top}
-        />
-        <Handle
-          id={`${id}-b`}
-          className='edgeSrcHandle handle-with-icon handle-right'
-          type='source'
-          position={Position.Right}
-        />
-        <Handle
-          id={`${id}-c`}
-          className='edgeSrcHandle handle-with-icon handle-bottom'
-          type='source'
-          position={Position.Bottom}
-        />
-        <Handle
-          id={`${id}-d`}
-          className='edgeSrcHandle handle-with-icon handle-left'
-          type='source'
-          position={Position.Left}
-        />
-
-        <Handle
-          id={`${id}-a`}
-          type='target'
-          position={Position.Top}
-          style={handleStyle}
-          isConnectable={isConnectable}
-          onMouseEnter={() => setIsTargetHandleTouched(true)}
-          onMouseLeave={() => setIsTargetHandleTouched(false)}
-        />
-        <Handle
-          id={`${id}-b`}
-          type='target'
-          position={Position.Right}
-          style={handleStyle}
-          isConnectable={isConnectable}
-          onMouseEnter={() => setIsTargetHandleTouched(true)}
-          onMouseLeave={() => setIsTargetHandleTouched(false)}
-        />
-        <Handle
-          id={`${id}-c`}
-          type='target'
-          position={Position.Bottom}
-          style={handleStyle}
-          isConnectable={isConnectable}
-          onMouseEnter={() => setIsTargetHandleTouched(true)}
-          onMouseLeave={() => setIsTargetHandleTouched(false)}
-        />
-        <Handle
-          id={`${id}-d`}
-          type='target'
-          position={Position.Left}
-          style={handleStyle}
-          isConnectable={isConnectable}
-          onMouseEnter={() => setIsTargetHandleTouched(true)}
-          onMouseLeave={() => setIsTargetHandleTouched(false)}
-        />
-      </button>
-
-      {/* Configuration Menu (integrated directly) */}
-      {isMenuOpen && (
-        <ul
-          ref={menuRef}
-          className='w-[535px] absolute top-[64px] text-white rounded-[16px] border-[1px] bg-[#1A1A1A] p-[12px] font-plus-jakarta-sans flex flex-col gap-[16px] shadow-lg'
-          style={{
-            borderColor: UI_COLORS.EDGENODE_BORDER_GREY,
-          }}
-        >
-          <li className='flex h-[28px] gap-1 items-center justify-between font-plus-jakarta-sans'>
-            <div className='flex flex-row gap-[12px]'>
-              <div className='flex flex-row gap-[8px] justify-center items-center'>
-                <div className='w-[24px] h-[24px] border-[1px] border-main-grey bg-main-black-theme rounded-[8px] flex items-center justify-center'>
-                  <svg
-                    xmlns='http://www.w3.org/2000/svg'
-                    width='12'
-                    height='12'
-                    viewBox='0 0 12 12'
-                    fill='none'
-                  >
-                    <path d='M6 12V7' stroke='#D9D9D9' strokeWidth='2' />
-                    <path
-                      d='M10 2V7L2 7V2'
-                      stroke='#D9D9D9'
-                      strokeWidth='1.5'
-                    />
-                    <path
-                      d='M0.934259 2.5L2 0.901388L3.06574 2.5H0.934259Z'
-                      fill='#D9D9D9'
-                      stroke='#D9D9D9'
-                    />
-                    <path
-                      d='M8.93426 2.5L10 0.901388L11.0657 2.5H8.93426Z'
-                      fill='#D9D9D9'
-                      stroke='#D9D9D9'
-                    />
-                  </svg>
-                </div>
-                <div className='flex items-center justify-center text-[14px] font-semibold text-main-grey font-plus-jakarta-sans leading-normal'>
-                  If/Else
-                </div>
-              </div>
-            </div>
-            <div className='flex flex-row gap-[8px] items-center justify-center'>
-              <button
-                className='w-[57px] h-[26px] rounded-[8px] text-[#000] text-[12px] font-semibold font-plus-jakarta-sans flex flex-row items-center justify-center gap-[7px]'
-                style={{
-                  backgroundColor: isLoading ? '#FFA73D' : '#39BC66',
-                }}
-                onClick={isLoading ? onStopExecution : onDataSubmit}
-                disabled={false}
+          <span>
+            {isLoading ? (
+              <svg width='6' height='6' viewBox='0 0 6 6' fill='none'>
+                <rect width='6' height='6' fill='currentColor' />
+              </svg>
+            ) : (
+              <svg
+                xmlns='http://www.w3.org/2000/svg'
+                width='6'
+                height='8'
+                viewBox='0 0 8 10'
+                fill='none'
               >
-                <span>
-                  {isLoading ? (
-                    <svg width='8' height='8' viewBox='0 0 8 8' fill='none'>
-                      <rect width='8' height='8' fill='currentColor' />
-                    </svg>
-                  ) : (
+                <path d='M8 5L0 10V0L8 5Z' fill='currentColor' />
+              </svg>
+            )}
+          </span>
+          <span>{isLoading ? 'Stop' : 'Run'}</span>
+        </button>
+
+        <button
+          onClick={onClickButton}
+          onMouseEnter={() => setIsHovered(true)}
+          onMouseLeave={() => setIsHovered(false)}
+          className={`w-full h-full flex-shrink-0 rounded-[8px] border-[2px] bg-[#181818] flex items-center justify-center font-plus-jakarta-sans text-[10px] font-[700] edge-node transition-colors gap-[4px]`}
+          style={mainButtonStyle}
+        >
+          {/* IF/ELSE SVG icon */}
+          <svg
+            xmlns='http://www.w3.org/2000/svg'
+            width='10'
+            height='10'
+            viewBox='0 0 12 12'
+            fill='none'
+          >
+            <path d='M6 12V7' stroke='currentColor' strokeWidth='2' />
+            <path d='M10 2V7L2 7V2' stroke='currentColor' strokeWidth='1.5' />
+            <path
+              d='M0.934259 2.5L2 0.901388L3.06574 2.5H0.934259Z'
+              fill='currentColor'
+              stroke='currentColor'
+            />
+            <path
+              d='M8.93426 2.5L10 0.901388L11.0657 2.5H8.93426Z'
+              fill='currentColor'
+              stroke='currentColor'
+            />
+          </svg>
+          <div className='flex flex-col items-center justify-center leading-tight text-[9px]'>
+            <span>IF/ELSE</span>
+          </div>
+
+          <Handle
+            id={`${id}-a`}
+            className='edgeSrcHandle handle-with-icon handle-top'
+            type='source'
+            position={Position.Top}
+          />
+          <Handle
+            id={`${id}-b`}
+            className='edgeSrcHandle handle-with-icon handle-right'
+            type='source'
+            position={Position.Right}
+          />
+          <Handle
+            id={`${id}-c`}
+            className='edgeSrcHandle handle-with-icon handle-bottom'
+            type='source'
+            position={Position.Bottom}
+          />
+          <Handle
+            id={`${id}-d`}
+            className='edgeSrcHandle handle-with-icon handle-left'
+            type='source'
+            position={Position.Left}
+          />
+
+          <Handle
+            id={`${id}-a`}
+            type='target'
+            position={Position.Top}
+            style={handleStyle}
+            isConnectable={isConnectable}
+            onMouseEnter={() => setIsTargetHandleTouched(true)}
+            onMouseLeave={() => setIsTargetHandleTouched(false)}
+          />
+          <Handle
+            id={`${id}-b`}
+            type='target'
+            position={Position.Right}
+            style={handleStyle}
+            isConnectable={isConnectable}
+            onMouseEnter={() => setIsTargetHandleTouched(true)}
+            onMouseLeave={() => setIsTargetHandleTouched(false)}
+          />
+          <Handle
+            id={`${id}-c`}
+            type='target'
+            position={Position.Bottom}
+            style={handleStyle}
+            isConnectable={isConnectable}
+            onMouseEnter={() => setIsTargetHandleTouched(true)}
+            onMouseLeave={() => setIsTargetHandleTouched(false)}
+          />
+          <Handle
+            id={`${id}-d`}
+            type='target'
+            position={Position.Left}
+            style={handleStyle}
+            isConnectable={isConnectable}
+            onMouseEnter={() => setIsTargetHandleTouched(true)}
+            onMouseLeave={() => setIsTargetHandleTouched(false)}
+          />
+        </button>
+
+        {/* Configuration Menu (integrated directly) */}
+        {isMenuOpen && (
+          <ul
+            ref={menuRef}
+            className='w-[535px] absolute top-[64px] text-white rounded-[16px] border-[1px] bg-[#1A1A1A] p-[12px] font-plus-jakarta-sans flex flex-col gap-[16px] shadow-lg'
+            style={{
+              borderColor: UI_COLORS.EDGENODE_BORDER_GREY,
+            }}
+          >
+            <li className='flex h-[28px] gap-1 items-center justify-between font-plus-jakarta-sans'>
+              <div className='flex flex-row gap-[12px]'>
+                <div className='flex flex-row gap-[8px] justify-center items-center'>
+                  <div className='w-[24px] h-[24px] border-[1px] border-main-grey bg-main-black-theme rounded-[8px] flex items-center justify-center'>
                     <svg
                       xmlns='http://www.w3.org/2000/svg'
-                      width='8'
-                      height='10'
-                      viewBox='0 0 8 10'
+                      width='12'
+                      height='12'
+                      viewBox='0 0 12 12'
                       fill='none'
                     >
-                      <path d='M8 5L0 10V0L8 5Z' fill='black' />
-                    </svg>
-                  )}
-                </span>
-                <span>{isLoading ? 'Stop' : 'Run'}</span>
-              </button>
-            </div>
-          </li>
-
-          {/* Input/Output display */}
-          <li>
-            <InputOutputDisplay
-              parentId={id}
-              getNode={getNode}
-              getSourceNodeIdWithLabel={getSourceNodeIdWithLabel}
-              getTargetNodeIdWithLabel={getTargetNodeIdWithLabel}
-              supportedInputTypes={['text', 'structured']}
-              supportedOutputTypes={['text', 'structured']}
-            />
-          </li>
-
-          {cases.map((case_value, case_index) => (
-            <li key={case_index} className='flex flex-col gap-2'>
-              {/* Case Header - 使用类似 LLM 配置菜单的样式 */}
-              <div className='flex items-center gap-2'>
-                <label className='text-[13px] font-semibold text-[#6D7177]'>
-                  Case {case_index + 1}
-                </label>
-                <div className='w-[5px] h-[5px] rounded-full bg-[#FF4D4D]'></div>
-                {/* Delete Case Button */}
-                {cases.length > 1 && (
-                  <button
-                    onClick={() => {
-                      onCaseDelete(case_index);
-                    }}
-                    className='ml-auto p-0.5 w-6 h-6 flex items-center justify-center text-[#6D7177] hover:text-[#ff4d4d] transition-colors'
-                  >
-                    <svg
-                      width='14'
-                      height='14'
-                      viewBox='0 0 24 24'
-                      fill='none'
-                      stroke='currentColor'
-                    >
+                      <path d='M6 12V7' stroke='#D9D9D9' strokeWidth='2' />
                       <path
-                        d='M18 6L6 18M6 6l12 12'
-                        strokeWidth='2'
-                        strokeLinecap='round'
+                        d='M10 2V7L2 7V2'
+                        stroke='#D9D9D9'
+                        strokeWidth='1.5'
+                      />
+                      <path
+                        d='M0.934259 2.5L2 0.901388L3.06574 2.5H0.934259Z'
+                        fill='#D9D9D9'
+                        stroke='#D9D9D9'
+                      />
+                      <path
+                        d='M8.93426 2.5L10 0.901388L11.0657 2.5H8.93426Z'
+                        fill='#D9D9D9'
+                        stroke='#D9D9D9'
                       />
                     </svg>
-                  </button>
-                )}
+                  </div>
+                  <div className='flex items-center justify-center text-[14px] font-semibold text-main-grey font-plus-jakarta-sans leading-normal'>
+                    If/Else
+                  </div>
+                </div>
               </div>
+              <div className='flex flex-row gap-[8px] items-center justify-center'>
+                <button
+                  className='w-[57px] h-[26px] rounded-[8px] text-[#000] text-[12px] font-semibold font-plus-jakarta-sans flex flex-row items-center justify-center gap-[7px]'
+                  style={{
+                    backgroundColor: isLoading ? '#FFA73D' : '#39BC66',
+                  }}
+                  onClick={isLoading ? onStopExecution : onDataSubmit}
+                  disabled={false}
+                >
+                  <span>
+                    {isLoading ? (
+                      <svg width='8' height='8' viewBox='0 0 8 8' fill='none'>
+                        <rect width='8' height='8' fill='currentColor' />
+                      </svg>
+                    ) : (
+                      <svg
+                        xmlns='http://www.w3.org/2000/svg'
+                        width='8'
+                        height='10'
+                        viewBox='0 0 8 10'
+                        fill='none'
+                      >
+                        <path d='M8 5L0 10V0L8 5Z' fill='black' />
+                      </svg>
+                    )}
+                  </span>
+                  <span>{isLoading ? 'Stop' : 'Run'}</span>
+                </button>
+              </div>
+            </li>
 
-              {/* Case Content Container */}
-              <div className='flex flex-col gap-2 p-2 bg-[#1E1E1E] rounded-[8px] border-[1px] border-[#6D7177]/30'>
-                {/* 保持现有的 IF/THEN 内容不变，稍后我们会继续优化这部分 */}
-                <div className='flex flex-col w-full gap-[8px] p-3'>
-                  <label className='text-[11px] font-regular text-[#6D7177] ml-1'>
-                    Condition
+            {/* Input/Output display */}
+            <li>
+              <InputOutputDisplay
+                parentId={id}
+                getNode={getNode}
+                getSourceNodeIdWithLabel={getSourceNodeIdWithLabel}
+                getTargetNodeIdWithLabel={getTargetNodeIdWithLabel}
+                supportedInputTypes={['text', 'structured']}
+                supportedOutputTypes={['text', 'structured']}
+              />
+            </li>
+
+            {cases.map((case_value, case_index) => (
+              <li key={case_index} className='flex flex-col gap-2'>
+                {/* Case Header - 使用类似 LLM 配置菜单的样式 */}
+                <div className='flex items-center gap-2'>
+                  <label className='text-[13px] font-semibold text-[#6D7177]'>
+                    Case {case_index + 1}
                   </label>
-                  {case_value.conditions.map(
-                    (condition_value, conditions_index) => (
-                      <>
-                        <div className='inline-flex space-x-[12px] items-center justify-start w-full'>
-                          <ul
-                            key={conditions_index}
-                            className='flex-col border-[#6D7177] rounded-[4px] w-full bg-black'
-                          >
-                            <li className='flex gap-1 h-[32px] items-center justify-start rounded-md border-[1px] border-[#6D7177]/30 bg-[#252525] min-w-[280px]'>
-                              {/* 第一个元素：节点选择 */}
-                              <div className='flex flex-row flex-wrap gap-[10px] items-center justify-start px-[10px]'>
-                                <PuppyDropdown
-                                  options={getSourceNodeIdWithLabel(id)}
-                                  onSelect={(node: {
-                                    id: string;
-                                    label: string;
-                                  }) => {
-                                    const cases_clone = [...cases];
-                                    cases_clone[case_index].conditions[
-                                      conditions_index
-                                    ] = {
-                                      ...cases_clone[case_index].conditions[
+                  <div className='w-[5px] h-[5px] rounded-full bg-[#FF4D4D]'></div>
+                  {/* Delete Case Button */}
+                  {cases.length > 1 && (
+                    <button
+                      onClick={() => {
+                        onCaseDelete(case_index);
+                      }}
+                      className='ml-auto p-0.5 w-6 h-6 flex items-center justify-center text-[#6D7177] hover:text-[#ff4d4d] transition-colors'
+                    >
+                      <svg
+                        width='14'
+                        height='14'
+                        viewBox='0 0 24 24'
+                        fill='none'
+                        stroke='currentColor'
+                      >
+                        <path
+                          d='M18 6L6 18M6 6l12 12'
+                          strokeWidth='2'
+                          strokeLinecap='round'
+                        />
+                      </svg>
+                    </button>
+                  )}
+                </div>
+
+                {/* Case Content Container */}
+                <div className='flex flex-col gap-2 p-2 bg-[#1E1E1E] rounded-[8px] border-[1px] border-[#6D7177]/30'>
+                  {/* 保持现有的 IF/THEN 内容不变，稍后我们会继续优化这部分 */}
+                  <div className='flex flex-col w-full gap-[8px] p-3'>
+                    <label className='text-[11px] font-regular text-[#6D7177] ml-1'>
+                      Condition
+                    </label>
+                    {case_value.conditions.map(
+                      (condition_value, conditions_index) => (
+                        <React.Fragment key={conditions_index}>
+                          <div className='inline-flex space-x-[12px] items-center justify-start w-full'>
+                            <ul
+                              key={conditions_index}
+                              className='flex-col border-[#6D7177] rounded-[4px] w-full bg-black'
+                            >
+                              <li className='flex gap-1 h-[32px] items-center justify-start rounded-md border-[1px] border-[#6D7177]/30 bg-[#252525] min-w-[280px]'>
+                                {/* 第一个元素：节点选择 */}
+                                <div className='flex flex-row flex-wrap gap-[10px] items-center justify-start px-[10px]'>
+                                  <PuppyDropdown
+                                    options={getSourceNodeIdWithLabel(id)}
+                                    onSelect={(node: {
+                                      id: string;
+                                      label: string;
+                                    }) => {
+                                      const cases_clone = [...cases];
+                                      cases_clone[case_index].conditions[
                                         conditions_index
-                                      ],
-                                      id: node.id,
-                                      label: node.label,
-                                      type: getNode(node.id)?.type,
-                                    };
-                                    onCasesChange(cases_clone);
-                                  }}
-                                  selectedValue={condition_value.id}
-                                  optionBadge={false}
-                                  listWidth='200px'
-                                  buttonHeight='24px'
-                                  buttonBgColor='transparent'
-                                  containerClassnames='w-fit'
-                                  mapValueTodisplay={(
-                                    value:
-                                      | string
-                                      | { id: string; label: string }
-                                  ) => {
-                                    if (typeof value === 'string') {
-                                      const nodeType = getNode(value)?.type;
-                                      const label =
-                                        getNode(value)?.data?.label || value;
-                                      const displayText = `{{${label}}}`;
+                                      ] = {
+                                        ...cases_clone[case_index].conditions[
+                                          conditions_index
+                                        ],
+                                        id: node.id,
+                                        label: node.label,
+                                        type: getNode(node.id)?.type,
+                                      };
+                                      onCasesChange(cases_clone);
+                                    }}
+                                    selectedValue={condition_value.id}
+                                    optionBadge={false}
+                                    listWidth='200px'
+                                    buttonHeight='24px'
+                                    buttonBgColor='transparent'
+                                    containerClassnames='w-fit'
+                                    mapValueTodisplay={(
+                                      value:
+                                        | string
+                                        | { id: string; label: string }
+                                    ) => {
+                                      if (typeof value === 'string') {
+                                        const nodeType = getNode(value)?.type;
+                                        const label =
+                                          getNode(value)?.data?.label || value;
+                                        const displayText = `{{${label}}}`;
+
+                                        if (nodeType === 'text') {
+                                          return (
+                                            <span className='text-[#3B9BFF]'>
+                                              {displayText}
+                                            </span>
+                                          );
+                                        } else if (nodeType === 'structured') {
+                                          return (
+                                            <span className='text-[#9B7EDB]'>
+                                              {displayText}
+                                            </span>
+                                          );
+                                        }
+                                        return displayText;
+                                      }
+
+                                      const nodeType = getNode(value.id)?.type;
+                                      const displayText = `{{${value.label || value.id}}}`;
 
                                       if (nodeType === 'text') {
                                         return (
@@ -897,444 +1008,199 @@ function IfElse({ isConnectable, id, data }: ChooseConfigNodeProps) {
                                         );
                                       }
                                       return displayText;
-                                    }
+                                    }}
+                                    showDropdownIcon={false}
+                                  />
+                                </div>
 
-                                    const nodeType = getNode(value.id)?.type;
-                                    const displayText = `{{${value.label || value.id}}}`;
-
-                                    if (nodeType === 'text') {
-                                      return (
-                                        <span className='text-[#3B9BFF]'>
-                                          {displayText}
-                                        </span>
+                                {/* 第二个元素：条件选择 */}
+                                <div className='h-[30px] border-r-[1px] border-l-[1px] px-[8px] border-[#6D7177]/30 flex items-center justify-start'>
+                                  <PuppyDropdown
+                                    options={getConditionSelections(
+                                      condition_value.type || 'text'
+                                    )}
+                                    onSelect={(option: string) => {
+                                      updateCondition(
+                                        case_index,
+                                        conditions_index,
+                                        'condition',
+                                        option
                                       );
-                                    } else if (nodeType === 'structured') {
-                                      return (
-                                        <span className='text-[#9B7EDB]'>
-                                          {displayText}
-                                        </span>
-                                      );
-                                    }
-                                    return displayText;
-                                  }}
-                                  showDropdownIcon={false}
-                                />
-                              </div>
+                                    }}
+                                    selectedValue={condition_value.condition}
+                                    optionBadge={false}
+                                    listWidth='200px'
+                                    buttonHeight='24px'
+                                    buttonBgColor='transparent'
+                                    containerClassnames='w-fit'
+                                    showDropdownIcon={false}
+                                  />
+                                </div>
 
-                              {/* 第二个元素：条件选择 */}
-                              <div className='h-[30px] border-r-[1px] border-l-[1px] px-[8px] border-[#6D7177]/30 flex items-center justify-start'>
-                                <PuppyDropdown
-                                  options={getConditionSelections(
-                                    getNode(
-                                      cases[case_index].conditions[
-                                        conditions_index
-                                      ].id
-                                    )?.type || 'text'
-                                  )}
-                                  onSelect={(value: string) => {
-                                    const cases_clone = [...cases];
-                                    cases_clone[case_index].conditions[
-                                      conditions_index
-                                    ] = {
-                                      ...cases_clone[case_index].conditions[
-                                        conditions_index
-                                      ],
-                                      cond_v: value,
-                                    };
-                                    onSwitchValueChange(value);
-                                    onCasesChange(cases_clone);
-                                  }}
-                                  selectedValue={
-                                    cases[case_index].conditions[
-                                      conditions_index
-                                    ].cond_v
-                                  }
-                                  optionBadge={false}
-                                  listWidth='200px'
-                                  buttonHeight='24px'
-                                  buttonBgColor='transparent'
-                                  containerClassnames='w-[150px]'
-                                  textColor='#CDCDCD'
-                                  fontSize='11px'
-                                  fontWeight='500'
-                                  showDropdownIcon={true}
-                                />
-                              </div>
+                                {/* 第三个元素：条件值输入 */}
+                                {(condition_value.condition === 'contains' ||
+                                  condition_value.condition ===
+                                    "doesn't contain" ||
+                                  condition_value.condition ===
+                                    'is greater than [N] characters' ||
+                                  condition_value.condition ===
+                                    'is less than [N] characters') && (
+                                  <div className='flex-1 px-[8px]'>
+                                    <input
+                                      type='text'
+                                      value={condition_value.cond_v}
+                                      onChange={e => {
+                                        updateCondition(
+                                          case_index,
+                                          conditions_index,
+                                          'cond_v',
+                                          e.target.value
+                                        );
+                                      }}
+                                      className='w-full h-[24px] bg-transparent border-none outline-none text-[#CDCDCD] text-[12px] placeholder-[#6D7177]'
+                                      placeholder='Enter value...'
+                                      onFocus={onFocus}
+                                      onBlur={onBlur}
+                                    />
+                                  </div>
+                                )}
 
-                              {/* 第三个元素：输入框 */}
-                              <div className='flex flex-row flex-wrap gap-[10px] items-center justify-start flex-1 py-[8px] px-[10px]'>
-                                <input
-                                  value={
-                                    cases[case_index].conditions[
+                                {/* 删除条件按钮 */}
+                                {case_value.conditions.length > 1 && (
+                                  <button
+                                    onClick={onConditionDelete(
+                                      case_index,
                                       conditions_index
-                                    ].cond_input || ''
-                                  }
-                                  onChange={e => {
-                                    const cases_clone = [...cases];
-                                    cases_clone[case_index].conditions[
-                                      conditions_index
-                                    ] = {
-                                      ...cases_clone[case_index].conditions[
-                                        conditions_index
-                                      ],
-                                      cond_input: e.target.value,
-                                    };
-                                    onContentValueChange(e.target.value);
-                                    onCasesChange(cases_clone);
-                                  }}
-                                  placeholder={
-                                    [
-                                      'is True',
-                                      'is False',
-                                      'is not empty',
-                                      'is list',
-                                      'is dict',
-                                      'is empty',
-                                      'condition',
-                                    ].includes(
-                                      cases[case_index].conditions[
-                                        conditions_index
-                                      ].cond_v
-                                    )
-                                      ? 'No input needed'
-                                      : 'Enter value'
-                                  }
-                                  disabled={[
-                                    'is True',
-                                    'is False',
-                                    'is not empty',
-                                    'is list',
-                                    'is dict',
-                                    'is empty',
-                                    'condition',
-                                  ].includes(
-                                    cases[case_index].conditions[
-                                      conditions_index
-                                    ].cond_v
-                                  )}
-                                  className='h-[24px] w-full text-[#CDCDCD] bg-[#252525] caret-white px-2 text-[12px] outline-none disabled:opacity-50 placeholder-[#6D7177]/50'
-                                />
-                              </div>
-                            </li>
-                          </ul>
-                          {/* 删除按钮 - 移到外面并调整间距 */}
-                          <button
-                            onClick={() => {
-                              onConditionDelete(case_index, conditions_index)();
-                            }}
-                            className={`p-0.5 w-6 h-6 flex items-center justify-center text-[#6D7177] hover:text-[#ff4d4d] transition-colors ${case_value.conditions.length <= 1 ? 'invisible' : ''}`}
-                          >
-                            <svg
-                              width='14'
-                              height='14'
-                              viewBox='0 0 24 24'
-                              fill='none'
-                              stroke='currentColor'
-                            >
-                              <path
-                                d='M18 6L6 18M6 6l12 12'
-                                strokeWidth='2'
-                                strokeLinecap='round'
-                              />
-                            </svg>
-                          </button>
-                          {conditions_index !==
-                            case_value.conditions.length - 1 && (
-                            <button
-                              onClick={() => {
-                                onAndOrSwitch(case_index, conditions_index)();
-                              }}
-                              className='px-2 h-[20px] flex items-center justify-center rounded-[4px] 
-                                                                          bg-[#252525] border-[1px] border-[#6D7177]/30
-                                                                          text-[#6D7177] text-[10px] font-medium
-                                                                          hover:border-[#6D7177]/50 hover:bg-[#1E1E1E] 
-                                                                          transition-colors'
-                            >
-                              {case_value.conditions[
-                                conditions_index
-                              ].operation.toUpperCase()}
-                            </button>
-                          )}
-                        </div>
-                      </>
-                    )
-                  )}
-                  {/* Add new condition button at the bottom */}
-                  <div className='flex justify-start mt-[8px]'>
+                                    )}
+                                    className='p-1 text-[#6D7177] hover:text-[#ff4d4d] transition-colors'
+                                  >
+                                    <svg
+                                      width='12'
+                                      height='12'
+                                      viewBox='0 0 24 24'
+                                      fill='none'
+                                      stroke='currentColor'
+                                    >
+                                      <path
+                                        d='M18 6L6 18M6 6l12 12'
+                                        strokeWidth='2'
+                                        strokeLinecap='round'
+                                      />
+                                    </svg>
+                                  </button>
+                                )}
+                              </li>
+                            </ul>
+
+                            {/* AND/OR 切换按钮 */}
+                            {conditions_index <
+                              case_value.conditions.length - 1 && (
+                              <button
+                                onClick={onAndOrSwitch(
+                                  case_index,
+                                  conditions_index
+                                )}
+                                className='px-2 py-1 text-[10px] font-medium rounded border border-[#6D7177]/30 bg-[#252525] text-[#CDCDCD] hover:border-[#6D7177]/50 transition-colors'
+                              >
+                                {condition_value.operation}
+                              </button>
+                            )}
+                          </div>
+                        </React.Fragment>
+                      )
+                    )}
+
+                    {/* 添加条件按钮 */}
                     <button
-                      onClick={e => onConditionAdd(case_index)(e)}
-                      className='w-[24px] h-[24px] flex items-center justify-center rounded-md
-                                                    bg-[#252525] border-[1px] border-[#6D7177]/30
-                                                    text-[#6D7177] text-[10px] font-medium
-                                                    hover:border-[#6D7177]/50 hover:bg-[#1E1E1E] 
-                                                    transition-colors'
+                      onClick={onConditionAdd(case_index)}
+                      className='flex items-center gap-2 px-3 py-2 text-[12px] text-[#6D7177] hover:text-[#CDCDCD] border border-[#6D7177]/30 hover:border-[#6D7177]/50 rounded-md bg-[#252525] hover:bg-[#2A2A2A] transition-colors'
                     >
-                      <svg width='10' height='10' viewBox='0 0 14 14'>
-                        <path
-                          d='M7 0v14M0 7h14'
-                          stroke='currentColor'
-                          strokeWidth='2'
-                        />
-                      </svg>
-                    </button>
-                  </div>
-                </div>
-
-                {/* the divider */}
-                <div className='flex items-center gap-2 px-3'>
-                  <div className='h-[1px] flex-1 bg-[#6D7177]/30'></div>
-                  <span className='text-[11px] font-regular text-[#6D7177]'>
-                    When conditions are met, execute the following actions
-                  </span>
-                  <div className='h-[1px] flex-1 bg-[#6D7177]/30'></div>
-                </div>
-
-                {/* Action List*/}
-                <div className='flex flex-col border-[#6D7177] p-3 gap-[8px] w-full justify-start'>
-                  <label className='text-[11px] font-regular text-[#6D7177] ml-1'>
-                    Action
-                  </label>
-
-                  {case_value.actions.map((action_value, action_index) => (
-                    <div
-                      key={action_index}
-                      className='inline-flex space-x-[12px] items-center justify-start w-full'
-                    >
-                      <ul className='flex-col border-[#6D7177] rounded-[4px] w-full bg-black'>
-                        <li className='flex gap-1 h-[32px] items-center justify-start rounded-md border-[1px] border-[#6D7177]/30 bg-[#252525] min-w-[280px]'>
-                          {/* 第一个元素：节点选择 */}
-                          <div className='flex flex-row flex-wrap gap-[10px] items-center justify-start px-[10px]'>
-                            <PuppyDropdown
-                              options={getSourceNodeIdWithLabel(id)}
-                              onSelect={(node: {
-                                id: string;
-                                label: string;
-                              }) => {
-                                const cases_clone = [...cases];
-                                cases_clone[case_index].actions[action_index] =
-                                  {
-                                    ...cases_clone[case_index].actions[
-                                      action_index
-                                    ],
-                                    from_id: node.id,
-                                    from_label: node.label,
-                                  };
-                                onCasesChange(cases_clone);
-                              }}
-                              selectedValue={action_value.from_id}
-                              optionBadge={false}
-                              listWidth='200px'
-                              buttonHeight='24px'
-                              buttonBgColor='transparent'
-                              containerClassnames='w-fit'
-                              mapValueTodisplay={(
-                                value: string | { id: string; label: string }
-                              ) => {
-                                if (typeof value === 'string') {
-                                  const nodeType = getNode(value)?.type;
-                                  const label =
-                                    getNode(value)?.data?.label || value;
-                                  const displayText = `{{${label}}}`;
-
-                                  if (nodeType === 'text') {
-                                    return (
-                                      <span className='text-[#3B9BFF]'>
-                                        {displayText}
-                                      </span>
-                                    );
-                                  } else if (nodeType === 'structured') {
-                                    return (
-                                      <span className='text-[#9B7EDB]'>
-                                        {displayText}
-                                      </span>
-                                    );
-                                  }
-                                  return displayText;
-                                }
-
-                                const nodeType = getNode(value.id)?.type;
-                                const displayText = `{{${value.label || value.id}}}`;
-
-                                if (nodeType === 'text') {
-                                  return (
-                                    <span className='text-[#3B9BFF]'>
-                                      {displayText}
-                                    </span>
-                                  );
-                                } else if (nodeType === 'structured') {
-                                  return (
-                                    <span className='text-[#9B7EDB]'>
-                                      {displayText}
-                                    </span>
-                                  );
-                                }
-                                return displayText;
-                              }}
-                              showDropdownIcon={false}
-                            />
-                          </div>
-                          <div className='h-[30px] border-r-[1px] border-l-[1px] px-[8px] border-[#6D7177]/30 flex items-center justify-start'>
-                            <span className='text-[#6D7177] text-[12px] font-medium'>
-                              {' '}
-                              copy to
-                            </span>
-                          </div>
-                          <div className='flex flex-row flex-wrap gap-[10px] items-center justify-start px-[10px]'>
-                            <PuppyDropdown
-                              options={getTargetNodeIdWithLabel(id).map(
-                                node => {
-                                  return {
-                                    id: node.id,
-                                    label: node.label,
-                                  };
-                                }
-                              )}
-                              onSelect={(node: {
-                                id: string;
-                                label: string;
-                              }) => {
-                                const cases_clone = [...cases];
-                                cases_clone[case_index].actions[
-                                  action_index
-                                ].outputs = [node.id || node.label];
-
-                                onCasesChange(cases_clone);
-                              }}
-                              selectedValue={action_value.outputs[0]}
-                              optionBadge={false}
-                              listWidth='200px'
-                              buttonHeight='24px'
-                              buttonBgColor='transparent'
-                              containerClassnames='w-fit'
-                              mapValueTodisplay={(
-                                value: string | { id: string; label: string }
-                              ) => {
-                                if (typeof value === 'string') {
-                                  const nodeType = getNode(value)?.type;
-                                  const label =
-                                    getNode(value)?.data?.label || value;
-                                  const displayText = `{{${label}}}`;
-
-                                  if (nodeType === 'text') {
-                                    return (
-                                      <span className='text-[#3B9BFF]'>
-                                        {displayText}
-                                      </span>
-                                    );
-                                  } else if (nodeType === 'structured') {
-                                    return (
-                                      <span className='text-[#9B7EDB]'>
-                                        {displayText}
-                                      </span>
-                                    );
-                                  }
-                                  return displayText;
-                                }
-
-                                const nodeType = getNode(value.id)?.type;
-                                const displayText = `{{${value.label || value.id}}}`;
-
-                                if (nodeType === 'text') {
-                                  return (
-                                    <span className='text-[#3B9BFF]'>
-                                      {displayText}
-                                    </span>
-                                  );
-                                } else if (nodeType === 'structured') {
-                                  return (
-                                    <span className='text-[#9B7EDB]'>
-                                      {displayText}
-                                    </span>
-                                  );
-                                }
-                                return displayText;
-                              }}
-                              showDropdownIcon={false}
-                            />
-                          </div>
-                        </li>
-                      </ul>
-
-                      {/* 删除按钮 */}
-                      <button
-                        onClick={() => {
-                          const cases_clone = [...cases];
-                          if (cases_clone[case_index].actions.length > 1) {
-                            cases_clone[case_index].actions.splice(
-                              action_index,
-                              1
-                            );
-                            onCasesChange(cases_clone);
-                          }
-                        }}
-                        className={`p-0.5 w-6 h-6 flex items-center justify-center text-[#6D7177] hover:text-[#ff4d4d] transition-colors ${case_value.actions.length <= 1 ? 'invisible' : ''}`}
+                      <svg
+                        width='12'
+                        height='12'
+                        viewBox='0 0 24 24'
+                        fill='none'
+                        stroke='currentColor'
                       >
-                        <svg
-                          width='14'
-                          height='14'
-                          viewBox='0 0 24 24'
-                          fill='none'
-                          stroke='currentColor'
-                        >
-                          <path
-                            d='M18 6L6 18M6 6l12 12'
-                            strokeWidth='2'
-                            strokeLinecap='round'
-                          />
-                        </svg>
-                      </button>
-                    </div>
-                  ))}
-
-                  {/* 底部添加按钮保持不变 */}
-                  <div className='flex justify-start mt-[8px]'>
-                    <button
-                      onClick={() => {
-                        onActionAdd(case_index)();
-                      }}
-                      className='w-[24px] h-[24px] flex items-center justify-center rounded-md
-                                                    bg-[#252525] border-[1px] border-[#6D7177]/30
-                                                    text-[#6D7177] text-[10px] font-medium
-                                                    hover:border-[#6D7177]/50 hover:bg-[#1E1E1E] 
-                                                    transition-colors'
-                    >
-                      <svg width='10' height='10' viewBox='0 0 14 14'>
                         <path
-                          d='M7 0v14M0 7h14'
-                          stroke='currentColor'
+                          d='M12 5v14M5 12h14'
                           strokeWidth='2'
+                          strokeLinecap='round'
                         />
                       </svg>
+                      Add Condition
+                    </button>
+                  </div>
+
+                  {/* THEN 部分 */}
+                  <div className='flex flex-col w-full gap-[8px] p-3 border-t border-[#6D7177]/30'>
+                    <label className='text-[11px] font-regular text-[#6D7177] ml-1'>
+                      Then
+                    </label>
+                    {case_value.actions.map((action, action_index) => (
+                      <div
+                        key={action_index}
+                        className='flex gap-2 h-[32px] items-center justify-start rounded-md border-[1px] border-[#6D7177]/30 bg-[#252525] px-3'
+                      >
+                        <span className='text-[12px] text-[#CDCDCD]'>
+                          Output to connected nodes
+                        </span>
+                      </div>
+                    ))}
+
+                    {/* 添加 Action 按钮 */}
+                    <button
+                      onClick={onActionAdd(case_index)}
+                      className='flex items-center gap-2 px-3 py-2 text-[12px] text-[#6D7177] hover:text-[#CDCDCD] border border-[#6D7177]/30 hover:border-[#6D7177]/50 rounded-md bg-[#252525] hover:bg-[#2A2A2A] transition-colors'
+                    >
+                      <svg
+                        width='12'
+                        height='12'
+                        viewBox='0 0 24 24'
+                        fill='none'
+                        stroke='currentColor'
+                      >
+                        <path
+                          d='M12 5v14M5 12h14'
+                          strokeWidth='2'
+                          strokeLinecap='round'
+                        />
+                      </svg>
+                      Add Action
                     </button>
                   </div>
                 </div>
-              </div>
-            </li>
-          ))}
-          {/* Add Case Button - 使用更现代的样式 */}
-          <div className='flex items-center'>
-            <button
-              onClick={onCaseAdd}
-              className='h-[26px] px-2 flex items-center gap-1 rounded-md
-                                bg-[#252525] border-[1px] border-[#6D7177]/30
-                                text-[#6D7177] text-[10px] font-medium
-                                hover:border-[#6D7177]/50 hover:bg-[#1E1E1E] 
-                                transition-colors'
-            >
-              <svg width='10' height='10' viewBox='0 0 14 14'>
-                <path
-                  d='M7 0v14M0 7h14'
-                  stroke='currentColor'
-                  strokeWidth='2'
-                />
-              </svg>
-              Add Case
-            </button>
-          </div>
-        </ul>
-      )}
-    </div>
-  );
-}
+              </li>
+            ))}
 
+            {/* 添加新 Case 按钮 */}
+            <li>
+              <button
+                onClick={onCaseAdd}
+                className='w-full flex items-center justify-center gap-2 px-4 py-3 text-[13px] font-medium text-[#6D7177] hover:text-[#CDCDCD] border border-[#6D7177]/30 hover:border-[#6D7177]/50 rounded-md bg-[#1E1E1E] hover:bg-[#252525] transition-colors'
+              >
+                <svg
+                  width='14'
+                  height='14'
+                  viewBox='0 0 24 24'
+                  fill='none'
+                  stroke='currentColor'
+                >
+                  <path
+                    d='M12 5v14M5 12h14'
+                    strokeWidth='2'
+                    strokeLinecap='round'
+                  />
+                </svg>
+                Add New Case
+              </button>
+            </li>
+          </ul>
+        )}
+      </div>
+    );
+  }
+);
+
+IfElse.displayName = 'IfElse';
 export default IfElse;

--- a/docs/TEMPLATE-FORMATTING-GUIDE.md
+++ b/docs/TEMPLATE-FORMATTING-GUIDE.md
@@ -1,0 +1,131 @@
+# 目标
+
+在前端增加对后端新操作 apply_template 的支持，用一个“模板”结构严格约束输出结构，并把“源”结构中同路径的值拷贝过去（数组按模板长度对齐、源短补 null、源长截断）。推荐在同一条 modify 边里先执行 variable_replace 再执行 apply_template。
+
+# 集成点概览
+
+- 文件：PuppyFlow/app/components/workflow/edgesNode/edgeNodesNew/EditStructured.tsx
+- 相关：runSingleEdgeNode 及其 JSON 构建（通常在 edgeNodeJsonBuilders.ts 或 useEdgeNodeBackEndJsonBuilder.ts）
+
+# UI 与交互改造
+
+## 新增模式常量与选项
+
+- 新增 const MODIFY_APPLY_TEMPLATE = 'apply_template'
+- 下拉 Mode 选项加入 apply_template，展示名可用 “apply template”
+- 该模式下无需 Path 编辑器，隐藏路径编辑 UI
+
+## 输入/输出连线
+
+- 输入要求：两个 structured 输入  
+  - “源”结构：作为 edge content  
+  - “模板”结构：作为 operations[1].params.value_template  
+- 输出：一个 structured 输出
+
+## 选择模板来源
+
+- 提供一个下拉（或使用已连接输入的 label）让用户指定哪个输入作为模板
+- 可选：支持配置 variable_replace.plugins（键值对）作为第一步操作
+
+# 前端 JSON 构建规则
+
+- modify 边基础字段：  
+  - type: "modify"  
+  - data.modify_type: "edit_structured"  
+  - data.content: "{{<源输入label>}}"  
+  - data.extra_configs.operations: 顺序执行  
+- 可选 variable_replace：  
+  ```json
+  {"type": "variable_replace", "params": {"plugins": { "<key>": "<value>" }}}
+  ```
+- 必选 apply_template：  
+  ```json
+  {"type": "apply_template", "params": {"value_template": "{{<模板输入label>}}"}}
+  ```
+- data.inputs 必须包含“源”和“模板”两个 block_id→label
+- data.outputs 指定输出 block
+
+# 关键代码片段
+
+## 增加选项与 UI 切换（片段）
+
+```tsx
+// 1) 常量
+const MODIFY_APPLY_TEMPLATE = 'apply_template';
+// 2) Mode 下拉加入
+<PuppyDropdown
+  options={[
+    MODIFY_GET_TYPE,
+    MODIFY_DEL_TYPE,
+    MODIFY_REPL_TYPE,
+    MODIFY_GET_ALL_KEYS,
+    MODIFY_GET_ALL_VAL,
+    MODIFY_APPLY_TEMPLATE,    // 新增
+  ]}
+  onSelect={(option: string) => setExecMode(option)}
+  selectedValue={execMode}
+/>
+// 3) 隐藏 Path 编辑器（apply_template 不需要 path）
+{!(execMode === MODIFY_GET_ALL_KEYS || execMode === MODIFY_GET_ALL_VAL || execMode === MODIFY_APPLY_TEMPLATE) && (
+  <TreePathEditor ... />
+)}
+```
+
+## 构建 modify 边 payload（示例，落在 JSON 构建函数中）
+
+```ts
+// 假设已取到：sourceLabel, templateLabel, outputBlockId
+const operations = [];
+if (plugins && Object.keys(plugins).length > 0) {
+  operations.push({
+    type: 'variable_replace',
+    params: { plugins },
+  });
+}
+operations.push({
+  type: 'apply_template',
+  params: { value_template: `{{${templateLabel}}}` },
+});
+const modifyEdge = {
+  type: 'modify',
+  data: {
+    modify_type: 'edit_structured',
+    content: `{{${sourceLabel}}}`,
+    extra_configs: { operations },
+    inputs: {
+      [sourceBlockId]: sourceLabel,
+      [templateBlockId]: templateLabel,
+    },
+    outputs: {
+      [outputBlockId]: getNode(outputBlockId)?.data?.label ?? 'Result',
+    },
+  },
+};
+```
+
+## 示例 payload（最小化）
+
+```json
+{
+  "type": "modify",
+  "data": {
+    "modify_type": "edit_structured",
+    "content": "{{Source}}",
+    "extra_configs": {
+      "operations": [
+        { "type": "variable_replace", "params": { "plugins": { "nick": "Alice" } } },
+        { "type": "apply_template", "params": { "value_template": "{{Template}}" } }
+      ]
+    },
+    "inputs": { "src_block": "Source", "tmpl_block": "Template" },
+    "outputs": { "out_block": "Result" }
+  }
+}
+```
+
+# 校验与错误提示
+
+- 校验连接：必须选择或检测到“源”和“模板”两个输入，且都是 structured；缺一时报错。
+- 校验输出：必须选择一个 structured 输出；缺失时报错。
+- 可选：在 apply_template 模式下禁用 Path 编辑器的交互并提示“模板驱动，无需路径”。
+```

--- a/docs/WHY_STUCK_AFTER_GENERATING_NODES.md
+++ b/docs/WHY_STUCK_AFTER_GENERATING_NODES.md
@@ -1,0 +1,97 @@
+# 技术文档：修复创建节点后UI卡死的问题
+
+## 1. 问题现象
+
+在开发流程画布功能时，我们遇到了一个间歇性的UI卡死问题。具体表现为：
+
+-   当用户从侧边栏拖拽某些“边节点”（如 `Convert2Structured`, `EditText`）到画布上时，操作偶尔会导致整个画布“卡住”。
+-   这个问题在快速连续创建多个节点时尤其容易复现。
+-   一旦卡住，用户无法再从侧边栏创建新节点，也无法与画布上任何已有的节点或边进行交互。整个UI处于无响应的锁定状态。
+
+---
+
+## 2. 根源分析：异步操作引发的竞态条件 (Race Condition)
+
+经过深入排查，我们定位到问题的根源在于一个典型的**竞态条件**。它是由组件状态的同步更新和异步操作之间不可预测的时序冲突所导致的。
+
+### 错误的逻辑：`useEffect` + `requestAnimationFrame`
+
+在有问题的组件中，节点的“自动激活”逻辑（即调用 `clearAll()` 和 `activateEdge(id)`）被放置在一个 `useEffect` 钩子中，并使用 `requestAnimationFrame` (rAF) 来延迟执行。
+
+**代码意图**：
+开发者的初衷是好的，希望通过 `rAF` 确保节点在DOM中完全渲染完毕后才被激活，从而避免潜在的渲染问题。
+
+**实际执行流程（问题所在）：**
+
+让我们分解当用户快速创建第二个节点时，冲突是如何发生的：
+
+1.  **创建第一个节点**：
+    *   用户开始拖动节点，全局状态 `isOnGeneratingNewNode` 变为 `true`，UI暂时锁定以防误操作。
+    *   用户将节点放置到画布上，`isOnGeneratingNewNode` 状态变为 `false`。
+    *   节点的 `useEffect` 被触发。
+    *   **关键点**：`useEffect` 内部的 `requestAnimationFrame` **并没有立即执行**激活操作，而是将 `clearAll()` 和 `activateEdge(id)` **“安排”**到未来的某个时间点（即下一次浏览器重绘前）执行。这就创造了一个微小但致命的时间窗口。
+
+2.  **创建第二个节点（在 `rAF` 回调执行前）**：
+    *   用户操作很快，在第一个节点的 `rAF` 回调函数触发之前，又立即开始拖动第二个节点。
+    *   此时，全局状态 `isOnGeneratingNewNode` **再次变为 `true`**，UI 再次被锁定。
+
+3.  **冲突爆发**：
+    *   现在，浏览器的下一个绘制时机到来，第一个节点“安排”的 `rAF` 回调函数开始执行。
+    *   它首先调用 `clearAll()`，该函数会重置整个画布的状态。
+    *   **致命问题**：`clearAll()` 在一个完全错误的时间点被执行了。此时的应用程序正处于“正在创建第二个节点”的状态中（因为 `isOnGeneratingNewNode` 是 `true`）。`clearAll()` 强行重置了所有状态，直接破坏了这个正在进行中的流程。
+    *   紧接着，它尝试激活第一个节点，但为时已晚，应用程序的状态已经因为这次意外的 `clearAll()` 调用而变得混乱和不一致。
+
+**最终结果**：
+应用程序的状态被卡住了。`isOnGeneratingNewNode` 可能仍然是 `true`，但能触发它变回 `false` 的正常流程已经被打断。因此，UI 保持在“锁定”状态，用户无法进行任何操作。这就是为什么问题时好时坏——它完全取决于用户的操作速度是否快过了 `requestAnimationFrame` 的回调时机。
+
+---
+
+## 3. 解决方案：同步执行与逻辑分离
+
+最终的修复方案借鉴了其他工作正常的组件（如 `LLM.tsx`）中更健壮的模式。核心思想是**消除异步带来的不确定性**。
+
+```typescript
+// Hook 1: 标记组件已挂载
+useEffect(() => {
+  hasMountedRef.current = true;
+}, []); // 这个 effect 只在组件首次渲染后运行一次
+
+// Hook 2: 处理激活逻辑
+useEffect(() => {
+  // 确保组件已挂载，且当前不是正在创建新节点的状态
+  if (hasMountedRef.current && !isOnGeneratingNewNode) {
+    clearAll();
+    activateEdge(id);
+  }
+
+  // 组件卸载或 isOnGeneratingNewNode 变化时执行清理
+  return () => {
+    if (activatedEdge === id) {
+      clearEdgeActivation();
+    }
+  };
+}, [isOnGeneratingNewNode]); // 只依赖于 isOnGeneratingNewNode
+```
+
+**这个修改的优势在于两点：**
+
+1.  **移除了不确定性（同步执行）**：
+    *   最关键的改动是**完全移除了 `requestAnimationFrame`**。
+    *   现在，当您放下节点，`isOnGeneratingNewNode` 变为 `false` 时，第二个 `useEffect` 会被触发，`clearAll()` 和 `activateEdge(id)` 会**立即、同步地**在同一个React渲染周期内执行。
+    *   这关闭了竞态条件的时间窗口。用户的任何后续操作都必须等待这个激活过程完全结束后才能开始。
+
+2.  **清晰的逻辑分离（双 `useEffect` 模式）**：
+    *   第一个 `useEffect`（带有空依赖数组 `[]`）专门用于处理“组件首次挂载”这一事件，只做一件事：设置 `hasMountedRef.current = true`。
+    *   第二个 `useEffect` 专门用于响应 `isOnGeneratingNewNode` 这个状态的变化。`hasMountedRef.current` 这个检查确保了激活逻辑不会在组件的初始渲染帧上意外触发。
+
+### 总结对比
+
+| 对比项 | 错误的原逻辑 | 健壮的修复逻辑 |
+| :--- | :--- | :--- |
+| **执行时机** | **异步** (通过 `rAF`) | **同步** (在React渲染周期内) |
+| **可靠性** | **不可靠**，依赖用户操作速度，导致竞态条件。 | **可靠**，状态更新和副作用紧密绑定，是原子性的操作。 |
+| **逻辑结构** | 将挂载逻辑和状态响应逻辑混合。 | 使用两个独立的 `useEffect`，清晰地分离了不同职责。 |
+
+<br>
+
+通过确保状态更新和其副作用的**同步执行**，我们保证了应用程序状态的**一致性**，从而彻底修复了UI卡住的问题。


### PR DESCRIPTION
### Detailed Update Log (English Translation)

#### 1. Fix: UI Freeze After Generating Edge Node

* **Why:**
  In previous versions, creating a new Edge Node (e.g., `SearchPerplexity` or `IfElse`) often caused the UI to freeze or become unresponsive. The root cause was issues with the dependencies of the `useEffect` hook and improper state cleanup logic. When a new node was generated, the `useEffect` cleanup function incorrectly cleared the currently active Edge, causing inconsistent state and rendering loops that ultimately led to the UI freeze.

* **How:**
  1. **Introduce `hasMountedRef`:** Added a `useRef` hook (`hasMountedRef`) in multiple Edge Node components (such as `SearchPerplexity`, `Generate`, `IfElse`) to track whether the component has already mounted.
  2. **Delay State Sync:** Used `requestAnimationFrame` to delay state synchronization for node data. This ensures state updates do not happen immediately within the same render cycle as node creation, avoiding rendering conflicts.
  3. **Conditional `useEffect` Cleanup:** Modified the `useEffect` hook to only perform activation and cleanup logic when **not** in the process of generating a new node (`!isOnGeneratingNewNode`). This prevents accidentally clearing active states during new node creation, resolving the freeze issue.

---

#### 2. Fix: Edge Node Cannot Connect and Run in `external_storage` Mode

* **Why:**
  When a Block Node (e.g., a file node) is set to `external_storage` mode, its processing in the backend is asynchronous. After processing, the backend creates a `_completed.marker` file to mark the node as ready. However, the previous backend logic had flaws in polling for this marker file, causing the backend to think the previous process was not finished and refusing to execute subsequent Edge Nodes even though the file was ready.

* **How:**
  1. **Optimize Polling Logic (`ManifestPoller`):** Improved the `ManifestPoller` class in the frontend (`runSingleEdgeNodeExecutor.ts`) to more reliably poll the storage manifest (`manifest.json`) and correctly handle the `_completed.marker` file.
  2. **Introduce `STREAM_STARTED` Event:** The backend now sends a server-sent event (SSE) named `STREAM_STARTED`. Upon receiving this event, the frontend starts a `ManifestPoller` instance for the corresponding Block Node to begin polling, ensuring timely checks.
  3. **Ensure `_completed.marker` Creation:** Fixed backend `PuppyEngine` logic to always generate the `_completed.marker` file in the designated storage path after finishing processing file chunks in `external_storage` mode.

---

#### 3. Fix: Backend Pydantic Validation Too Strict, Causing Search Nodes to Fail

* **Why:**
  The backend Pydantic data validation model (`SearchEdgeData` in `schemas.py`) hardcoded the `search_type` field to only accept `"vector"` (`Literal["vector"]`). This caused nodes like `SearchGoogle` (`search_type = "web"`) and `SearchPerplexity` (`search_type = "qa"`) to be rejected at runtime by backend validation, returning 500 errors.

* **How:**
  1. **Model Splitting and Refinement:** Split the original single `SearchEdgeData` model into multiple dedicated Pydantic models, each corresponding to one `search_type`:
     - `VectorSearchModel` for `"vector"` search.
     - `KeywordSearchModel` for `"keyword"` search.
     - `QASearchModel` for `"qa"` search.
     - `WebSearchModel` for `"web"` search.
  2. **Dynamic Validation:** Added new logic in the `EdgeModel` validator (`_validate_by_type`) to check the `search_type` field when the edge type is `"search"`, and then validate using the corresponding dedicated model from above.