### PR TITLE
fix(search/perplexity): route Perplexity via OpenRouter and normalize model names

### DIFF
--- a/PuppyEngine/ModularEdges/LLMEdge/llm_settings.py
+++ b/PuppyEngine/ModularEdges/LLMEdge/llm_settings.py
@@ -35,17 +35,19 @@ open_router_supported_models = [
     "openai/gpt-4-turbo",
     "deepseek/deepseek-chat-v3-0324:free",
     "deepseek/deepseek-r1-zero:free",
-    "deepseek/deepseek-r1"
+    "deepseek/deepseek-r1",
     "anthropic/claude-3.5-haiku",
     "anthropic/claude-3.5-sonnet",
     "anthropic/claude-3.7-sonnet",
     "perplexity/sonar-reasoning-pro",
     "perplexity/sonar-pro",
-    "perplexity/sonar-deep-research"
+    "perplexity/sonar-deep-research",
     "perplexity/r1-1776",
     "perplexity/sonar-reasoning",
     "perplexity/sonar",
     "perplexity/llama-3.1-sonar-large-128k-online",
+    "perplexity/llama-3.1-sonar-small-128k-online",
+    "perplexity/llama-3.1-sonar-huge-128k-online",
     "perplexity/llama-3-sonar-large-32k-online",
     "perplexity/llama-3-sonar-small-32k-online",
 ]

--- a/PuppyEngine/ModularEdges/SearchEdge/qa_search.py
+++ b/PuppyEngine/ModularEdges/SearchEdge/qa_search.py
@@ -56,11 +56,18 @@ class LLMQASearchStrategy(SearchStrategy):
             },
         ]
 
+        # Normalize model name: accept shorthand like "sonar" and expand to "perplexity/sonar"
+        raw_model = self.extra_configs.get("model", "perplexity/sonar")
+        model = raw_model if isinstance(raw_model, str) else list(raw_model.keys())[0]
+        if isinstance(model, str) and "/" not in model:
+            model = f"perplexity/{model}"
+
         return remote_llm_chat(
             messages=messages,
-            api_key=os.environ.get("PERPLEXITY_API_KEY"),
-            base_url=os.environ.get("PERPLEXITY_BASE_URL"),
-            model=self.extra_configs.get("model", "perplexity/sonar"),
+            # Use OpenRouter credentials for Perplexity via OpenRouter
+            api_key=None,
+            base_url=None,
+            model=model,
             hoster="openrouter"
         )
 


### PR DESCRIPTION
## Summary
- Fix Perplexity QA search to work through OpenRouter credentials
- Normalize model names (support shorthand and expand to `perplexity/<model>`)
- Correct supported models list (missing commas) and add latest Perplexity online models
- Create OpenAI client per-request when api_key/base_url provided

## Details
- Backend `qa_search.py`: expand shorthand models; call with hoster `openrouter` and let OpenRouter credentials flow
- Backend `llm_settings.py`: fix list typos and include `perplexity/llama-3.1-sonar-*` variants
- Backend `llm_chat.py`: use provided `api_key`/`base_url` per-call; fallback to env defaults if not provided

## Why
Frontend Perplexity node and DeepResearcher Perplexity search were failing due to model name mismatches and client misconfiguration.

## Test Plan
- Set env: `OPENROUTER_API_KEY`, `OPENROUTER_BASE_URL=https://openrouter.ai/api/v1`
- In UI, add Perplexity edge and pick `llama-3.1-sonar-small-128k-online`; run and expect streamed text output
- Run backend example: `SearcherFactory.execute(init_configs={"query": "test", "search_type": "qa"}, extra_configs={"model": "sonar", "sub_search_type": "perplexity"})` returns content

## Notes
This PR does not require `PERPLEXITY_API_KEY` for direct Perplexity; it routes via OpenRouter.