### PR TITLE
fix(perplexity): map UI Perplexity models to OpenRouter IDs to avoid 404

### DIFF
--- a/PuppyEngine/ModularEdges/LLMEdge/llm_settings.py
+++ b/PuppyEngine/ModularEdges/LLMEdge/llm_settings.py
@@ -45,9 +45,7 @@ open_router_supported_models = [
     "perplexity/r1-1776",
     "perplexity/sonar-reasoning",
     "perplexity/sonar",
-    "perplexity/llama-3.1-sonar-large-128k-online",
-    "perplexity/llama-3.1-sonar-small-128k-online",
-    "perplexity/llama-3.1-sonar-huge-128k-online",
+    # OpenRouter-valid Perplexity IDs (note the 32k suffix in OpenRouter)
     "perplexity/llama-3-sonar-large-32k-online",
     "perplexity/llama-3-sonar-small-32k-online",
 ]

--- a/PuppyEngine/ModularEdges/SearchEdge/qa_search.py
+++ b/PuppyEngine/ModularEdges/SearchEdge/qa_search.py
@@ -56,11 +56,24 @@ class LLMQASearchStrategy(SearchStrategy):
             },
         ]
 
-        # Normalize model name: accept shorthand like "sonar" and expand to "perplexity/sonar"
+        # Normalize model name: accept UI shorthand and map to valid OpenRouter IDs
         raw_model = self.extra_configs.get("model", "perplexity/sonar")
         model = raw_model if isinstance(raw_model, str) else list(raw_model.keys())[0]
-        if isinstance(model, str) and "/" not in model:
-            model = f"perplexity/{model}"
+
+        # Map UI-facing Perplexity online models to OpenRouter-supported IDs
+        ui_to_openrouter = {
+            "llama-3.1-sonar-small-128k-online": "perplexity/llama-3-sonar-small-32k-online",
+            "llama-3.1-sonar-large-128k-online": "perplexity/llama-3-sonar-large-32k-online",
+            "llama-3.1-sonar-huge-128k-online": "perplexity/sonar-pro",
+        }
+
+        if isinstance(model, str):
+            # First, translate UI aliases
+            if model in ui_to_openrouter:
+                model = ui_to_openrouter[model]
+            # Then, prefix plain names like "sonar"/"sonar-pro"
+            elif "/" not in model:
+                model = f"perplexity/{model}"
 
         return remote_llm_chat(
             messages=messages,


### PR DESCRIPTION
## Summary
Map UI-facing Perplexity model ids to the actual OpenRouter-supported ids and trim unsupported entries to prevent 404s.

## Changes
- qa_search.py: translate `llama-3.1-sonar-*-128k-online` to `perplexity/llama-3-sonar-*-32k-online` (and huge-> `perplexity/sonar-pro`), prefix bare names with `perplexity/`
- llm_settings.py: keep supported-models in sync with OpenRouter catalogue

## Why
OpenRouter returns 404 for `perplexity/llama-3.1-sonar-*-128k-online`. The UI uses these ids; this PR maps them to available endpoints.

## Test Plan
- Set `OPENROUTER_API_KEY`, `OPENROUTER_BASE_URL=https://openrouter.ai/api/v1`
- Run Perplexity edge with model `llama-3.1-sonar-small-128k-online`; expect success
- Backend: `SearcherFactory.execute({"query":"hi","search_type":"qa"}, {"model":"llama-3.1-sonar-small-128k-online","sub_search_type":"perplexity"})` returns content