### PR TITLE
feat(perplexity): align frontend/backed with current OpenRouter models

### DIFF
--- a/PuppyEngine/ModularEdges/LLMEdge/llm_settings.py
+++ b/PuppyEngine/ModularEdges/LLMEdge/llm_settings.py
@@ -39,15 +39,9 @@ open_router_supported_models = [
     "anthropic/claude-3.5-haiku",
     "anthropic/claude-3.5-sonnet",
     "anthropic/claude-3.7-sonnet",
-    "perplexity/sonar-reasoning-pro",
-    "perplexity/sonar-pro",
-    "perplexity/sonar-deep-research",
-    "perplexity/r1-1776",
-    "perplexity/sonar-reasoning",
     "perplexity/sonar",
-    # OpenRouter-valid Perplexity IDs (note the 32k suffix in OpenRouter)
-    "perplexity/llama-3-sonar-large-32k-online",
-    "perplexity/llama-3-sonar-small-32k-online",
+    "perplexity/sonar-pro",
+    "perplexity/sonar-reasoning-pro",
 ]
 
 local_supported_models = [

--- a/PuppyEngine/ModularEdges/SearchEdge/qa_search.py
+++ b/PuppyEngine/ModularEdges/SearchEdge/qa_search.py
@@ -8,7 +8,7 @@ import sys
 from typing import List
 from duckduckgo_search import DDGS
 from ModularEdges.LLMEdge.llm_edge import remote_llm_chat
-from Utils.puppy_exception import global_exception_handler
+from Utils.puppy_exception import PuppyException, global_exception_handler
 from ModularEdges.SearchEdge.search_strategy import SearchStrategy
 
 
@@ -45,6 +45,10 @@ class LLMQASearchStrategy(SearchStrategy):
         - sonar
         """
 
+        # Guard against empty queries to avoid Perplexity 400 errors
+        if not self.query or not str(self.query).strip():
+            raise PuppyException(3504, "Empty query for Perplexity search", "Provide non-empty query")
+
         messages = [
             {
                 "role": "system",
@@ -60,11 +64,14 @@ class LLMQASearchStrategy(SearchStrategy):
         raw_model = self.extra_configs.get("model", "perplexity/sonar")
         model = raw_model if isinstance(raw_model, str) else list(raw_model.keys())[0]
 
-        # Map UI-facing Perplexity online models to OpenRouter-supported IDs
+        # Map UI-facing Perplexity aliases to OpenRouter-supported IDs
         ui_to_openrouter = {
-            "llama-3.1-sonar-small-128k-online": "perplexity/llama-3-sonar-small-32k-online",
-            "llama-3.1-sonar-large-128k-online": "perplexity/llama-3-sonar-large-32k-online",
+            # Prefer stable IDs available on OpenRouter provider page
             "llama-3.1-sonar-huge-128k-online": "perplexity/sonar-pro",
+            # Allow simple aliases used by UI
+            "sonar": "perplexity/sonar",
+            "sonar-pro": "perplexity/sonar-pro",
+            "sonar-reasoning-pro": "perplexity/sonar-reasoning-pro",
         }
 
         if isinstance(model, str):

--- a/PuppyEngine/TestTools/test_perplexity_models.py
+++ b/PuppyEngine/TestTools/test_perplexity_models.py
@@ -1,0 +1,128 @@
+"""
+Test all referenced Perplexity models using .env credentials.
+- Direct OpenRouter IDs via remote_llm_chat
+- UI aliases via LLMQASearchStrategy (qa_search.py mapping)
+"""
+import os
+import sys
+import time
+from typing import List, Tuple
+
+# Ensure we can import from PuppyEngine
+CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
+ENGINE_DIR = os.path.dirname(CURRENT_DIR)
+REPO_ROOT = os.path.dirname(ENGINE_DIR)
+sys.path.append(ENGINE_DIR)
+
+from ModularEdges.LLMEdge.llm_edge import remote_llm_chat
+from ModularEdges.LLMEdge.llm_settings import open_router_supported_models
+from ModularEdges.SearchEdge.qa_search import LLMQASearchStrategy
+
+
+def load_env_from_file(path: str) -> None:
+    if not path or not os.path.exists(path):
+        return
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                if "=" not in line:
+                    continue
+                key, value = line.split("=", 1)
+                key = key.strip()
+                value = value.strip().strip("'\"")
+                if key and value and key not in os.environ:
+                    os.environ[key] = value
+    except Exception:
+        pass
+
+
+# Load potential .env files (repo root and engine)
+load_env_from_file(os.path.join(REPO_ROOT, ".env"))
+load_env_from_file(os.path.join(ENGINE_DIR, ".env"))
+
+
+def mask_key(key: str, show: int = 6) -> str:
+    if not key:
+        return "<missing>"
+    if len(key) <= show:
+        return "*" * len(key)
+    return key[:show] + "…" + "*" * 6
+
+
+def test_openrouter_ids(models: List[str]) -> List[Tuple[str, bool, str]]:
+    results = []
+    for model in models:
+        try:
+            resp = remote_llm_chat(
+                model=model,
+                messages=[
+                    {"role": "system", "content": "You are a terse assistant."},
+                    {"role": "user", "content": "Reply with OK only."},
+                ],
+                max_tokens=8,
+                hoster="openrouter",
+                temperature=0.1,
+                stream=False,
+            )
+            ok = isinstance(resp, str) and len(resp.strip()) > 0
+            results.append((model, ok, ""))
+        except Exception as e:
+            results.append((model, False, str(e)))
+        time.sleep(0.6)  # be gentle with rate limits
+    return results
+
+
+def test_ui_aliases(aliases: List[str]) -> List[Tuple[str, bool, str]]:
+    results = []
+    for alias in aliases:
+        try:
+            s = LLMQASearchStrategy(
+                query="Reply with OK only.",
+                extra_configs={"model": alias, "sub_search_type": "perplexity"},
+            )
+            resp_list = s.search()
+            ok = isinstance(resp_list, list) and len(resp_list) == 1 and isinstance(resp_list[0], str)
+            results.append((alias, ok, ""))
+        except Exception as e:
+            results.append((alias, False, str(e)))
+        time.sleep(0.6)
+    return results
+
+
+if __name__ == "__main__":
+    openrouter_key = os.environ.get("OPENROUTER_API_KEY")
+    openrouter_base = os.environ.get("OPENROUTER_BASE_URL")
+
+    print("Env:")
+    print("  OPENROUTER_API_KEY:", mask_key(openrouter_key))
+    print("  OPENROUTER_BASE_URL:", openrouter_base or "<default>")
+
+    # Collect referenced Perplexity OpenRouter IDs from settings
+    perplexity_ids = [m for m in open_router_supported_models if m.startswith("perplexity/")]
+    print("\nTesting Perplexity OpenRouter IDs (remote_llm_chat):")
+    id_results = test_openrouter_ids(perplexity_ids)
+    for model, ok, err in id_results:
+        status = "PASS" if ok else "FAIL"
+        print(f"  [{status}] {model}" + (f"  -> {err}" if not ok else ""))
+
+    # UI aliases defined/handled by qa_search.py
+    ui_aliases = [
+        # Three primary UI aliases supported across frontend/backed
+        "sonar",
+        "sonar-pro",
+        "sonar-reasoning-pro",
+        # Keep this alias for backward compatibility mapping
+        "llama-3.1-sonar-huge-128k-online",
+    ]
+    print("\nTesting Perplexity UI aliases (qa_search mapping):")
+    alias_results = test_ui_aliases(ui_aliases)
+    for alias, ok, err in alias_results:
+        status = "PASS" if ok else "FAIL"
+        print(f"  [{status}] {alias}" + (f"  -> {err}" if not ok else ""))
+
+    total = len(id_results) + len(alias_results)
+    passed = sum(1 for _, ok, _ in id_results + alias_results if ok)
+    print(f"\nSummary: {passed}/{total} succeeded")

--- a/PuppyFlow/app/components/workflow/edgesNode/edgeNodesNew/SearchPerplexity.tsx
+++ b/PuppyFlow/app/components/workflow/edgesNode/edgeNodesNew/SearchPerplexity.tsx
@@ -28,19 +28,12 @@ export type SearchConfigNodeData = {
   query_id: { id: string; label: string } | undefined;
   vector_db: { id: string; label: string } | undefined;
   extra_configs: {
-    model:
-      | 'llama-3.1-sonar-small-128k-online'
-      | 'llama-3.1-sonar-large-128k-online'
-      | 'llama-3.1-sonar-huge-128k-online'
-      | undefined;
+    model: 'sonar' | 'sonar-pro' | 'sonar-reasoning-pro' | undefined;
     threshold: number | undefined;
   };
 };
 
-type PerplexityModelNames =
-  | 'llama-3.1-sonar-small-128k-online'
-  | 'llama-3.1-sonar-large-128k-online'
-  | 'llama-3.1-sonar-huge-128k-online';
+type PerplexityModelNames = 'sonar' | 'sonar-pro' | 'sonar-reasoning-pro';
 
 type SearchPerplexityNodeProps = NodeProps<Node<SearchConfigNodeData>>;
 
@@ -77,7 +70,7 @@ const SearchPerplexity: React.FC<SearchPerplexityNodeProps> = memo(
     const [model, setModel] = useState<PerplexityModelNames>(
       () =>
         (getNode(id)?.data as SearchConfigNodeData)?.extra_configs?.model ??
-        'llama-3.1-sonar-small-128k-online'
+        'sonar-pro'
     );
 
     // 创建执行上下文 - 使用 useCallback 缓存
@@ -277,14 +270,7 @@ const SearchPerplexity: React.FC<SearchPerplexityNodeProps> = memo(
     );
 
     // 缓存模型选项 - 使用 useMemo 缓存
-    const modelOptions = useMemo(
-      () => [
-        'llama-3.1-sonar-small-128k-online',
-        'llama-3.1-sonar-large-128k-online',
-        'llama-3.1-sonar-huge-128k-online',
-      ],
-      []
-    );
+    const modelOptions = useMemo(() => ['sonar', 'sonar-pro', 'sonar-reasoning-pro'], []);
 
     // 缓存菜单按钮样式 - 使用 useMemo 缓存
     const menuRunButtonStyle = useMemo(

--- a/PuppyFlow/app/components/workflow/edgesNode/edgeNodesNew/hook/edgeNodeJsonBuilders.ts
+++ b/PuppyFlow/app/components/workflow/edgesNode/edgeNodesNew/hook/edgeNodeJsonBuilders.ts
@@ -625,8 +625,7 @@ function buildSearchPerplexityNodeJson(
   const perplexityNodeData = context.getNode(nodeId)?.data;
 
   // 添加正确的类型检查
-  let perplexityModel: perplexityModelNames =
-    'llama-3.1-sonar-small-128k-online'; // 默认值
+  let perplexityModel: perplexityModelNames = 'sonar-pro'; // 默认值
 
   // 检查extra_configs是否存在并有model属性
   if (
@@ -639,11 +638,11 @@ function buildSearchPerplexityNodeJson(
       .model;
 
     // 验证是允许的模型名称之一
-    if (
-      configModel === 'llama-3.1-sonar-small-128k-online' ||
-      configModel === 'llama-3.1-sonar-large-128k-online' ||
-      configModel === 'llama-3.1-sonar-huge-128k-online'
-    ) {
+  if (
+    configModel === 'sonar' ||
+    configModel === 'sonar-pro' ||
+    configModel === 'sonar-reasoning-pro'
+  ) {
       perplexityModel = configModel;
     }
   }

--- a/PuppyFlow/app/components/workflow/edgesNode/edgeNodesNew/hook/hookhistory/useEdgeNodeBackEndJsonBuilder.ts
+++ b/PuppyFlow/app/components/workflow/edgesNode/edgeNodesNew/hook/hookhistory/useEdgeNodeBackEndJsonBuilder.ts
@@ -144,9 +144,9 @@ export type SearchGoogleEdgeJsonType = {
 
 // 添加 Perplexity 类型
 export type perplexityModelNames =
-  | 'llama-3.1-sonar-small-128k-online'
-  | 'llama-3.1-sonar-large-128k-online'
-  | 'llama-3.1-sonar-huge-128k-online';
+  | 'sonar'
+  | 'sonar-pro'
+  | 'sonar-reasoning-pro';
 
 export type SearchPerplexityEdgeJsonType = {
   type: 'search';
@@ -971,8 +971,7 @@ export function useEdgeNodeBackEndJsonBuilder() {
     const perplexityNodeData = getNode(nodeId)?.data;
 
     // 添加正确的类型检查
-    let perplexityModel: perplexityModelNames =
-      'llama-3.1-sonar-small-128k-online'; // 默认值
+    let perplexityModel: perplexityModelNames = 'sonar-pro'; // 默认值
 
     // 检查extra_configs是否存在并有model属性
     if (
@@ -987,9 +986,9 @@ export function useEdgeNodeBackEndJsonBuilder() {
 
       // 验证是允许的模型名称之一
       if (
-        configModel === 'llama-3.1-sonar-small-128k-online' ||
-        configModel === 'llama-3.1-sonar-large-128k-online' ||
-        configModel === 'llama-3.1-sonar-huge-128k-online'
+        configModel === 'sonar' ||
+        configModel === 'sonar-pro' ||
+        configModel === 'sonar-reasoning-pro'
       ) {
         perplexityModel = configModel;
       }


### PR DESCRIPTION
- Verified available IDs from OpenRouter provider: sonar, sonar-pro, sonar-reasoning-pro (plus others)
- Frontend: restrict Perplexity options to 3 working aliases and default to sonar-pro
- Backend: map UI aliases to OpenRouter IDs and drop offline llama-3-sonar-32k endpoints
- Settings: trim supported Perplexity IDs to the 3 working ones
- Tests: update alias list; keep huge-128k alias for back-compat mapping