### PR TITLE
feat: add .tree/ and .vscode/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,7 @@ json_received.json
 *.patch.xz
 *.diff.xz
 
+# Tree and VSCode directories
+.tree/
+.vscode/
+


### PR DESCRIPTION
## Summary
- Add `.tree/` directory to gitignore to exclude tree structure files
- Add `.vscode/` directory to gitignore for complete VSCode settings exclusion  
- Improves repository cleanliness by ignoring editor and utility directories

## Test plan
- [x] Verify `.tree/` directory is ignored by git
- [x] Verify `.vscode/` directory is ignored by git
- [x] Confirm existing gitignore patterns still work correctly