### PR TITLE
storage: lightweight health check via adapter.ping()

### DIFF
--- a/PuppyStorage/storage/base.py
+++ b/PuppyStorage/storage/base.py
@@ -95,3 +95,13 @@ class StorageAdapter(ABC):
             async iterator: 文件内容的异步迭代器，以及状态码、范围头、文件大小
         """
         pass
+
+    @abstractmethod
+    def ping(self) -> Dict[str, Any]:
+        """
+        轻量健康检查接口，用于检测存储后端可用性。
+
+        Returns:
+            Dict[str, Any]: 包含至少键 `ok` 的结果；`ok=True` 表示存储可访问。
+        """
+        pass

--- a/PuppyStorage/storage/local.py
+++ b/PuppyStorage/storage/local.py
@@ -744,6 +744,25 @@ class LocalStorageAdapter(StorageAdapter):
             log_error(f"列出本地对象失败: {str(e)}")
             raise
 
+    def ping(self) -> Dict[str, Any]:
+        """
+        轻量健康检查：确认基础目录存在且可写。
+        """
+        try:
+            # 目录存在性
+            os.makedirs(self.base_path, exist_ok=True)
+            # 可写性测试（不落地大文件，仅touch并删除）
+            test_dir = os.path.join(self.base_path, ".health")
+            os.makedirs(test_dir, exist_ok=True)
+            test_file = os.path.join(test_dir, "ping.tmp")
+            with open(test_file, "w") as f:
+                f.write("ok")
+            os.remove(test_file)
+            return {"ok": True, "type": "local", "base_path": self.base_path}
+        except Exception as e:
+            log_error(f"Local storage ping failed: {str(e)}")
+            return {"ok": False, "type": "local", "error": str(e)}
+
 if __name__ == "__main__":
     # 创建适配器实例并运行测试
     adapter = LocalStorageAdapter()


### PR DESCRIPTION
## Summary
- Replace heavy OSS precheck in PuppyStorage health with lightweight ping()
- Add ping() to StorageAdapter; implement for Local and S3/R2
- Fetch adapter per request; run ping in background thread to avoid blocking
- Always return 200 with status in body (healthy/degraded/unhealthy)

## Context
Previous health used list_multipart_uploads and a module-global adapter, causing:
- Over-permission and latency on R2/S3
- False 503s leading to probe flaps
- Stale adapter on hot-reload/tests

## Changes
- storage/base.py: define ping() abstract method
- storage/local.py: implement writable-dir ping
- storage/S3.py: implement list_objects_v2(Bucket, MaxKeys=1) ping
- server/routes/health_routes.py: dynamic adapter fetch, asyncio.to_thread ping, new response schema

## Test plan
- Local: start PuppyStorage, GET /health returns { status: healthy, storage.ok: true }
- Remote (R2/S3): with valid creds, /health returns healthy; with broken creds, returns degraded but 200
- Check event loop is not blocked (concurrent requests still served)