### PR TITLE
fix(flow-auth): include service key in internal /api/auth/verify

### DIFF
--- a/PuppyFlow/lib/auth/serverUser.ts
+++ b/PuppyFlow/lib/auth/serverUser.ts
@@ -1,4 +1,5 @@
 import { cookies } from 'next/headers';
+import { SERVER_ENV } from '@/lib/serverEnv';
 
 export async function getCurrentUserId(request: Request): Promise<string> {
   // Non-cloud deployments do not require user verification
@@ -31,9 +32,18 @@ export async function getCurrentUserId(request: Request): Promise<string> {
 
   // Cloud mode: Call internal verify endpoint
   const url = new URL('/api/auth/verify', request.url).toString();
+  const headers: Record<string, string> = {
+    'content-type': 'application/json',
+    authorization: authHeader,
+  };
+  // Include service key for internal verification if configured
+  if (SERVER_ENV.SERVICE_KEY) {
+    headers['x-service-key'] = SERVER_ENV.SERVICE_KEY;
+  }
+
   const res = await fetch(url, {
     method: 'GET',
-    headers: { 'content-type': 'application/json', authorization: authHeader },
+    headers,
   });
   if (!res.ok) throw new Error(`verify failed: ${res.status}`);
 


### PR DESCRIPTION
## Summary
- Fix internal auth verification by including required X-Service-Key header in cloud mode
- Unblocks /api/workspace/* endpoints which depend on /api/auth/verify

## Root cause
- `/api/auth/verify` enforces presence of `SERVICE_KEY` via `x-service-key` (or `ALLOW_VERIFY_WITHOUT_SERVICE_KEY=true`)
- `serverUser.ts` called the internal verifier without `x-service-key`, causing 403/500 and failing early in `getCurrentUserId`
- As a result, downstream workspace calls (e.g. `/api/workspace/list`) never reached PuppyUserSystem

## Change
- In `PuppyFlow/lib/auth/serverUser.ts`, when calling `/api/auth/verify`, inject `x-service-key` from `SERVER_ENV.SERVICE_KEY` if configured

## Why this is correct
- Aligns with the verifier's security contract and existing proxy patterns where the service key is injected server-side
- No behavior change for local mode; only affects cloud path

## Impact
- Cloud deployments with `SERVICE_KEY` set can successfully verify and reach PuppyUserSystem for workspace operations
- Backward-compatible; devs can still use `ALLOW_VERIFY_WITHOUT_SERVICE_KEY=true` if needed

## Test plan
- Set `DEPLOYMENT_MODE=cloud`, `SERVICE_KEY`, `USER_SYSTEM_BACKEND`
- With a valid `access_token` cookie, call `/api/workspace/list` and expect 200
- `/api/auth/verify` should return 200 and delegate to PuppyUserSystem