### PR TITLE
feat(frontend): unify client deployment mode via NEXT_PUBLIC_DEPLOYMENT_MODE

### DIFF
--- a/PuppyFlow/app/components/sidebar/DeploymentTypeLogo.tsx
+++ b/PuppyFlow/app/components/sidebar/DeploymentTypeLogo.tsx
@@ -16,7 +16,7 @@ function DeploymentTypeLogo() {
         onClick={handleDeploymentTypeClick}
       >
         {/* Conditional icon for deployment type */}
-        {(process.env.DEPLOYMENT_MODE || '').toLowerCase() !== 'cloud' ? (
+        {(process.env.NEXT_PUBLIC_DEPLOYMENT_MODE || '').toLowerCase() !== 'cloud' ? (
           <svg
             className='w-4 h-4 text-[#5D6065]'
             fill='currentColor'
@@ -49,7 +49,7 @@ function DeploymentTypeLogo() {
           <div className='flex flex-col space-y-1 text-[#AAAAAA]'>
             <div>
               Type:{' '}<span className='text-white'>
-                {(process.env.DEPLOYMENT_MODE || '').toLowerCase() === 'cloud' ? 'Cloud' : 'Local'}
+                {(process.env.NEXT_PUBLIC_DEPLOYMENT_MODE || '').toLowerCase() === 'cloud' ? 'Cloud' : 'Local'}
               </span>
             </div>
             <div>

--- a/PuppyFlow/app/components/states/AppSettingsContext.tsx
+++ b/PuppyFlow/app/components/states/AppSettingsContext.tsx
@@ -246,7 +246,7 @@ export const AppSettingsProvider: React.FC<{ children: ReactNode }> = ({
 }) => {
   // 检查部署类型
   const isLocalDeployment =
-    (process.env.DEPLOYMENT_MODE || '').toLowerCase() !== 'cloud';
+    (process.env.NEXT_PUBLIC_DEPLOYMENT_MODE || '').toLowerCase() !== 'cloud';
 
   // 使用 Ollama hook
   const {

--- a/PuppyFlow/app/page.tsx
+++ b/PuppyFlow/app/page.tsx
@@ -47,7 +47,7 @@ function MainApplication() {
 
     // Client-side boot log and env check
     try {
-      const type = (process.env.DEPLOYMENT_MODE || '').toLowerCase() === 'cloud' ? 'cloud' : 'local';
+      const type = (process.env.NEXT_PUBLIC_DEPLOYMENT_MODE || '').toLowerCase() === 'cloud' ? 'cloud' : 'local';
       // Safe to log NEXT_PUBLIC_* values directly
       console.log('🐶 [PuppyFlow] Client boot:', {
         deploymentType: type,

--- a/PuppyFlow/next.config.mjs
+++ b/PuppyFlow/next.config.mjs
@@ -24,6 +24,10 @@ console.log('[PuppyFlow] Env check (safe):', safeEnvSummary);
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  // 统一把服务端 DEPLOYMENT_MODE 注入到客户端公开变量
+  env: {
+    NEXT_PUBLIC_DEPLOYMENT_MODE: process.env.DEPLOYMENT_MODE,
+  },
   // 你的其他配置保持不变
 };
 


### PR DESCRIPTION
## Summary
- Inject NEXT_PUBLIC_DEPLOYMENT_MODE from DEPLOYMENT_MODE in next.config
- Switch client-side checks (isLocalDeployment, UI label, client boot log) to NEXT_PUBLIC_DEPLOYMENT_MODE

## Files
- PuppyFlow/next.config.mjs
- PuppyFlow/app/components/states/AppSettingsContext.tsx
- PuppyFlow/app/components/sidebar/DeploymentTypeLogo.tsx
- PuppyFlow/app/page.tsx

## Reasoning
- Use server-side DEPLOYMENT_MODE as single source of truth; expose a non-sensitive mirror to client so SSR/CSR are consistent (Cloud vs Local).

## Test plan
1) On Railway set DEPLOYMENT_MODE=cloud
2) Build & start (ensure Next binds $PORT)
3) Server logs show Cloud mode; client console shows Cloud mode