### PR TITLE
fix(docker): unblock build by correcting package versions and adding system deps

### DIFF
--- a/PuppyEngine/Dockerfile
+++ b/PuppyEngine/Dockerfile
@@ -1,17 +1,21 @@
 # Use Python 3.12 base image
 FROM python:3.12-slim
 
-# Install build-essential
-RUN apt-get update && apt-get install -y \
+# Install OS dependencies needed by some Python packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
+    ffmpeg \
+    libgl1 \
+    libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
 
 # Set a working directory for the app
 WORKDIR /app
 
-# Copy requirements.txt and install dependencies
+# Upgrade pip tooling, then install Python dependencies
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel \
+    && pip install --no-cache-dir -r requirements.txt
 
 # Copy the entire project directory to the container
 COPY . .

--- a/PuppyEngine/requirements.txt
+++ b/PuppyEngine/requirements.txt
@@ -10,10 +10,10 @@ anyio==4.9.0
 gunicorn==23.0.0
 waitress==3.0.2
 hypercorn==0.17.3
-beautifulsoup4==4.13.4
+beautifulsoup4==4.12.3
 lxml==5.4.0
 readability-lxml==0.8.4.1
-fastapi[standard]==0.115.12
+fastapi[standard]>=0.115,<0.116
 pydantic==2.11.5
 
 # Edges
@@ -33,7 +33,7 @@ langdetect==1.0.9
 scikit-learn==1.7.0
 pyyaml==6.0.2 # for transformers
 transformers==4.52.4
-sentence_transformers==4.1.0
+sentence-transformers>=3,<4
 
 # File
 fpdf==1.7.2


### PR DESCRIPTION
## Summary
- Correct invalid/nonexistent Python package versions in `requirements.txt`
- Add required OS deps (`ffmpeg`, `libgl1`, `libglib2.0-0`) for cv/ocr/whisper
- Upgrade `pip/setuptools/wheel` before installing requirements

## Context
`docker build` failed at `pip install -r requirements.txt` due to invalid versions.
This PR makes the build pass locally. Verified by building image `puppyengine:dev`.

## Test plan
- docker build -t puppyengine:dev PuppyEngine
- Ensure dependency installation succeeds and image builds
- docker run --rm -p 8001:8001 puppyengine:dev
- Hit `http://localhost:8001` to verify server boots