### PR TITLE
Cherry-pick latest from chore/init-env-in-dockerfiles to qubits

### DIFF
--- a/PuppyFlow/app/components/workflow/blockNode/hooks/useIndexingUtils.ts
+++ b/PuppyFlow/app/components/workflow/blockNode/hooks/useIndexingUtils.ts
@@ -108,8 +108,16 @@ export default function useIndexingUtils() {
           };
 
           // 创建 chunk 对象并添加到 chunks 数组
+          // 确保 content 为字符串，符合后端 Pydantic 校验
+          const contentString =
+            indexContent === null || indexContent === undefined
+              ? ''
+              : typeof indexContent === 'string'
+              ? indexContent
+              : JSON.stringify(indexContent);
+
           chunks.push({
-            content: indexContent,
+            content: contentString,
             metadata: metadata,
           });
         }
@@ -144,7 +152,9 @@ export default function useIndexingUtils() {
               method: 'POST',
               headers: {
                 'Content-Type': 'application/json',
+                Accept: 'application/json',
               },
+              credentials: 'include',
               body: JSON.stringify(payloadData),
             }
           );
@@ -237,7 +247,9 @@ export default function useIndexingUtils() {
               method: 'POST',
               headers: {
                 'Content-Type': 'application/json',
+                Accept: 'application/json',
               },
+              credentials: 'include',
               body: JSON.stringify(deleteParams),
             }
           );

--- a/PuppyStorage/requirements.txt
+++ b/PuppyStorage/requirements.txt
@@ -1,11 +1,11 @@
-python-dotenv==1.1.1
+python-dotenv==1.1.0
 PyYAML==6.0.2
 python-multipart==0.0.20
 
 # Embedding
 openai==1.95.1
 transformers==4.53.2
-sentence_transformers==5.0.0
+sentence-transformers>=3,<4
 
 # Vector Database
 vecs==0.4.5
@@ -18,15 +18,14 @@ chromadb==1.0.15
 
 # Server
 boto3==1.39.4
-fastapi==0.116.1
-axiom-py==0.9.0
+fastapi>=0.115,<0.116
+axiom_py==0.9.0
 hypercorn==0.17.3
 
-# Unknown -- Delete?
+# gRPC related packages - keep, but remove non-PyPI plugin
 grpcio==1.67.1
 grpcio-tools==1.67.1
 protobuf==5.29.5
-protoc-gen-openapiv2==0.0.1
 googleapis-common-protos==1.70.0
 
 # Test


### PR DESCRIPTION
## Summary
- Cherry-pick latest commit 7bd9473 from `chore/init-env-in-dockerfiles` onto branch from `qubits`.
- Fixes vector embed 422 by ensuring chunk.content is string and sending credentials.

## Details
- File: `PuppyFlow/app/components/workflow/blockNode/hooks/useIndexingUtils.ts`
- Ensures `chunks[].content` is stringified when not a string
- Adds `credentials: 'include'` and Accept header for proxy auth consistency

## Test plan
- Reproduce indexing flow and verify POST /api/storage/vector/embed returns 200 and backend receives request.