### PR TITLE
fix(flow-auth): use configured user login URL for 401 redirect

### DIFF
--- a/PuppyFlow/config/urls.ts
+++ b/PuppyFlow/config/urls.ts
@@ -3,7 +3,12 @@
 
 export const SYSTEM_URLS = {
   USER_SYSTEM: {
-    FRONTEND: process.env.USER_SYSTEM_FRONTEND_URL || 'http://localhost:3000',
+    // Prefer runtime server env on the server; fall back to client-exposed public env
+    // Client bundle will only have NEXT_PUBLIC_* available
+    FRONTEND:
+      process.env.USER_SYSTEM_FRONTEND_URL ||
+      (process.env.NEXT_PUBLIC_USER_SYSTEM_FRONTEND_URL as string) ||
+      'http://localhost:3000',
   },
   // Client code must use same-origin API proxies; direct bases removed
   PUPPY_ENGINE: { BASE: '' },

--- a/PuppyFlow/next.config.mjs
+++ b/PuppyFlow/next.config.mjs
@@ -27,6 +27,8 @@ const nextConfig = {
   // 统一把服务端 DEPLOYMENT_MODE 注入到客户端公开变量
   env: {
     NEXT_PUBLIC_DEPLOYMENT_MODE: process.env.DEPLOYMENT_MODE,
+    // 将用户系统前端地址在构建期注入到客户端，避免客户端回退到 localhost:3000
+    NEXT_PUBLIC_USER_SYSTEM_FRONTEND_URL: process.env.USER_SYSTEM_FRONTEND_URL,
   },
   // 你的其他配置保持不变
 };


### PR DESCRIPTION
## Summary
- Inject USER_SYSTEM_FRONTEND_URL into client as NEXT_PUBLIC_USER_SYSTEM_FRONTEND_URL
- Client and middleware now resolve user web URL without falling back to localhost:3000 in cloud

## Context
In cloud builds, client-side code could not read server-only envs, causing the 401 prompt to redirect to http://localhost:3000. This change makes the value available at build time and reads from NEXT_PUBLIC_* in the client bundle.

## Test plan
- Set USER_SYSTEM_FRONTEND_URL=https://userweb.example.com
- Build and deploy PuppyFlow
- Trigger a 401; the prompt should navigate to the configured domain with return_to set to the current page