### PR TITLE
fix(structured): normalize editor input string to prevent .trim() crash

### DIFF
--- a/PuppyFlow/app/components/workflow/blockNode/JsonNodeNew.tsx
+++ b/PuppyFlow/app/components/workflow/blockNode/JsonNodeNew.tsx
@@ -293,6 +293,18 @@ const JsonBlockNode = React.memo<JsonBlockNodeProps>(
       [id, setNodes]
     );
 
+    // 始终向 JSON 编辑器传入字符串，避免对非字符串执行 trim 报错
+    const contentString = useMemo(() => {
+      try {
+        // content 在运行时可能是对象/数组（例如结构化输出），需要字符串化
+        return typeof content === 'string'
+          ? content
+          : JSON.stringify(content ?? null, null, 2);
+      } catch (e) {
+        return String(content ?? '');
+      }
+    }, [content]);
+
     // 基于内容长度的动态存储策略切换（2s防抖），structured
     useEffect(() => {
       const node = getNode(id);
@@ -841,7 +853,7 @@ const JsonBlockNode = React.memo<JsonBlockNodeProps>(
                   preventParentDrag={onFocus}
                   allowParentDrag={onBlur}
                   placeholder='Create your JSON structure...'
-                  value={content || ''}
+                  value={contentString}
                   onChange={updateNodeContent}
                   widthStyle={0}
                   heightStyle={0}
@@ -852,7 +864,7 @@ const JsonBlockNode = React.memo<JsonBlockNodeProps>(
                   preventParentDrag={onFocus}
                   allowParentDrag={onBlur}
                   placeholder='{"key": "value"}'
-                  value={content || ''}
+                  value={contentString}
                   onChange={updateNodeContent}
                   widthStyle={0}
                   heightStyle={0}


### PR DESCRIPTION
## Summary
- Normalize structured block editor input to always be a string
- Prevent TypeError when internal structured output sets content to object/array
- Keeps external (manifest/JSONL) path unchanged; UI remains consistent

## Context
When LLM structured output is returned via internal storage, `BLOCK_UPDATED` writes object/array to `node.data.content`. JSON editors expect `value: string` and call `trim()`, causing crash. This change stringifies content at the render boundary in `JsonNodeNew`.

## Test plan
- LLM with structured_output=true → internal path: UI renders without crash
- external path with ManifestPoller: still renders aggregated JSON
- Text node and other edges unaffected

## Risk
Low; localized to `JsonNodeNew` value plumbing. No backend contract changes.