### PR TITLE
refactor(block): decouple internal/external handling from edge executor

### DIFF
--- a/PuppyFlow/app/components/workflow/blockNode/utils/blockUpdateApplier.ts
+++ b/PuppyFlow/app/components/workflow/blockNode/utils/blockUpdateApplier.ts
@@ -1,0 +1,120 @@
+// Block-side adapter to apply internal/external block updates
+// Ensures content is normalized for UI (string for editors)
+
+import { ensurePollerStarted, ensurePollerStoppedAndFinalize, ContentType } from './manifestPoller';
+
+export type NodesSetter = (updater: (nodes: any[]) => any[]) => void;
+
+export interface BlockApplierContext {
+  setNodes: NodesSetter;
+  resetLoadingUI?: (nodeId: string) => void;
+}
+
+export type BlockUpdateInternal = {
+  block_id: string;
+  storage_class?: 'internal';
+  type?: 'text' | 'structured';
+  content: any;
+};
+
+export type BlockUpdateExternal = {
+  block_id: string;
+  storage_class: 'external';
+  external_metadata: {
+    resource_key: string;
+    content_type: ContentType | string;
+    version_id?: string;
+    chunked?: boolean;
+    uploaded_at?: string;
+  };
+};
+
+export function applyBlockUpdate(
+  ctx: BlockApplierContext,
+  update: BlockUpdateInternal | BlockUpdateExternal
+) {
+  const isExternal = (update as BlockUpdateExternal).external_metadata !== undefined || update.storage_class === 'external';
+  if (isExternal) {
+    const u = update as BlockUpdateExternal;
+    const normalizedContentType: ContentType =
+      u.external_metadata.content_type === 'structured' ? 'structured' : 'text';
+
+    // Mark node as external and start/refresh poller
+    ctx.setNodes(prev =>
+      prev.map(node =>
+        node.id === u.block_id
+          ? {
+              ...node,
+              data: {
+                ...node.data,
+                storage_class: 'external',
+                external_metadata: {
+                  ...u.external_metadata,
+                  content_type: normalizedContentType,
+                },
+                isLoading: true,
+                isWaitingForFlow: true,
+                isExternalStorage: true,
+                content: '',
+              },
+            }
+          : node
+      )
+    );
+
+    ensurePollerStarted(
+      { setNodes: ctx.setNodes, resetLoadingUI: ctx.resetLoadingUI },
+      u.external_metadata.resource_key,
+      u.block_id,
+      normalizedContentType
+    );
+    return;
+  }
+
+  // Internal: normalize content to string for UI
+  const u = update as BlockUpdateInternal;
+  const contentType: ContentType = u.type === 'structured' ? 'structured' : 'text';
+
+  let stringContent: string;
+  try {
+    if (contentType === 'structured') {
+      stringContent =
+        typeof u.content === 'string' ? u.content : JSON.stringify(u.content ?? null, null, 2);
+    } else {
+      stringContent = String(u.content ?? '');
+    }
+  } catch (e) {
+    stringContent = String(u.content ?? '');
+  }
+
+  ctx.setNodes(prev =>
+    prev.map(node =>
+      node.id === u.block_id
+        ? {
+            ...node,
+            data: {
+              ...node.data,
+              content: stringContent,
+              isLoading: false,
+              isWaitingForFlow: false,
+              isExternalStorage: false,
+            },
+          }
+        : node
+    )
+  );
+}
+
+export async function finalizeExternal(
+  ctx: BlockApplierContext,
+  block_id: string,
+  resource_key: string,
+  content_type: ContentType = 'text'
+) {
+  await ensurePollerStoppedAndFinalize(
+    { setNodes: ctx.setNodes, resetLoadingUI: ctx.resetLoadingUI },
+    resource_key,
+    block_id,
+    content_type
+  );
+}

--- a/PuppyFlow/app/components/workflow/blockNode/utils/manifestPoller.ts
+++ b/PuppyFlow/app/components/workflow/blockNode/utils/manifestPoller.ts
@@ -1,0 +1,268 @@
+// Shared ManifestPoller for external storage structured/text content
+// Centralizes polling and reconstruction of chunked content.
+
+export type ContentType = 'text' | 'structured';
+
+export interface PollerContext {
+  setNodes: (updater: (nodes: any[]) => any[]) => void;
+  resetLoadingUI?: (nodeId: string) => void;
+}
+
+interface ManifestChunk {
+  name: string;
+  size: number;
+  index: number;
+  state?: 'processing' | 'done';
+}
+
+interface Manifest {
+  chunks: ManifestChunk[];
+  content_type: string;
+  total_size: number;
+}
+
+class ManifestPoller {
+  private poller: NodeJS.Timeout | null = null;
+  private knownChunks = new Set<string>();
+  private context: PollerContext;
+  private resource_key: string;
+  private block_id: string;
+  private content_type: ContentType;
+  private chunks: string[] = [];
+  private isStopped = false;
+  // Structured JSONL incremental parsing state
+  private parsedRecords: any[] = [];
+  private leftoverPartialLine = '';
+  private totalRecords = 0;
+  private parseErrors = 0;
+
+  constructor(
+    context: PollerContext,
+    resource_key: string,
+    block_id: string,
+    content_type: ContentType = 'text'
+  ) {
+    this.context = context;
+    this.resource_key = resource_key;
+    this.block_id = block_id;
+    this.content_type = content_type;
+  }
+
+  start() {
+    this.context.setNodes(prevNodes =>
+      prevNodes.map(node =>
+        node.id === this.block_id
+          ? {
+              ...node,
+              data: {
+                ...node.data,
+                content: '',
+                isLoading: true,
+                isExternalStorage: true,
+                external_metadata: {
+                  ...(node.data?.external_metadata || {}),
+                  resource_key: this.resource_key,
+                  content_type: this.content_type,
+                },
+              },
+            }
+          : node
+      )
+    );
+    this.poll();
+  }
+
+  private poll() {
+    if (this.isStopped) return;
+    this.poller = setTimeout(async () => {
+      await this.fetchManifestAndChunks();
+      if (!this.isStopped) this.poll();
+    }, 1000);
+  }
+
+  async stop() {
+    this.isStopped = true;
+    if (this.poller) {
+      clearTimeout(this.poller);
+      this.poller = null;
+    }
+    await this.fetchManifestAndChunks();
+    if (this.content_type === 'structured') {
+      this.finalizeStructuredParsing();
+      const finalContent = this.reconstructContent({
+        chunks: [],
+        content_type: this.content_type,
+        total_size: 0,
+      });
+      this.context.setNodes(prevNodes =>
+        prevNodes.map(node =>
+          node.id === this.block_id
+            ? {
+                ...node,
+                data: {
+                  ...node.data,
+                  content: finalContent,
+                  isLoading: false,
+                  isExternalStorage: true,
+                  external_metadata: {
+                    ...(node.data?.external_metadata || {}),
+                    resource_key: this.resource_key,
+                    content_type: this.content_type,
+                    loadedChunks: this.chunks.length,
+                    totalRecords: this.totalRecords,
+                    parsedRecords: this.parsedRecords.length,
+                    parseErrors: this.parseErrors,
+                  },
+                },
+              }
+            : node
+        )
+      );
+    }
+    if (this.context.resetLoadingUI) this.context.resetLoadingUI(this.block_id);
+  }
+
+  private async fetchManifestAndChunks() {
+    try {
+      const manifestUrl = await this.getDownloadUrl(
+        `${this.resource_key}/manifest.json`
+      );
+      const manifestResponse = await fetch(manifestUrl);
+      if (!manifestResponse.ok) return;
+      const manifest: Manifest = await manifestResponse.json();
+
+      const newChunks = manifest.chunks
+        .filter(c => !this.knownChunks.has(c.name) && c.state === 'done')
+        .sort((a, b) => (a.index ?? 0) - (b.index ?? 0));
+      if (newChunks.length === 0) return;
+
+      for (const chunkInfo of newChunks) {
+        this.knownChunks.add(chunkInfo.name);
+        const chunkUrl = await this.getDownloadUrl(
+          `${this.resource_key}/${chunkInfo.name}`
+        );
+        const chunkResponse = await fetch(chunkUrl);
+        const chunkData = await chunkResponse.text();
+        this.chunks.push(chunkData);
+        if (this.content_type === 'structured') {
+          this.parseStructuredChunk(chunkData, chunkInfo.name);
+        }
+      }
+
+      const reconstructedContent = this.reconstructContent(manifest);
+      this.context.setNodes(prevNodes =>
+        prevNodes.map(node =>
+          node.id === this.block_id
+            ? {
+                ...node,
+                data: {
+                  ...node.data,
+                  content: reconstructedContent,
+                  isLoading: true,
+                  isExternalStorage: true,
+                  external_metadata: {
+                    ...(node.data?.external_metadata || {}),
+                    resource_key: this.resource_key,
+                    content_type: this.content_type,
+                    totalChunks: manifest.chunks.length,
+                    loadedChunks: this.chunks.length,
+                    totalRecords: this.totalRecords,
+                    parsedRecords: this.parsedRecords.length,
+                    parseErrors: this.parseErrors,
+                  },
+                },
+              }
+            : node
+        )
+      );
+    } catch (err) {
+      console.error('[ManifestPoller] Error fetching manifest/chunk:', err);
+    }
+  }
+
+  private reconstructContent(manifest: Manifest): string {
+    if (this.content_type === 'structured') {
+      try {
+        return JSON.stringify(this.parsedRecords, null, 2);
+      } catch (e) {
+        console.warn('[ManifestPoller] Failed stringify records:', e);
+        return '[]';
+      }
+    }
+    return this.chunks.join('');
+  }
+
+  private parseStructuredChunk(chunkText: string, chunkName: string) {
+    let dataToProcess = (this.leftoverPartialLine || '') + chunkText;
+    this.leftoverPartialLine = '';
+    const lines = dataToProcess.split(/\r?\n/);
+    const possibleLeftover = lines.pop() ?? '';
+
+    for (let i = 0; i < lines.length; i++) {
+      const rawLine = lines[i];
+      const line = rawLine.trim();
+      if (!line) continue;
+      this.totalRecords += 1;
+      try {
+        const parsed = JSON.parse(line);
+        this.parsedRecords.push(parsed);
+      } catch (err) {
+        this.parseErrors += 1;
+        console.warn(
+          `[ManifestPoller] JSONL parse error in ${chunkName} at record #${this.totalRecords}:`,
+          err
+        );
+        console.warn('[ManifestPoller] Offending line:', rawLine.slice(0, 500));
+      }
+    }
+
+    this.leftoverPartialLine = possibleLeftover;
+  }
+
+  private async getDownloadUrl(key: string): Promise<string> {
+    const response = await fetch(
+      `/api/storage/download/url?key=${encodeURIComponent(key)}`
+    );
+    if (!response.ok) {
+      throw new Error(`Failed to get download URL for ${key}`);
+    }
+    const data = await response.json();
+    return data.download_url;
+  }
+}
+
+const pollers = new Map<string, ManifestPoller>();
+const makeKey = (resourceKey: string, blockId: string) => `${resourceKey}_${blockId}`;
+
+export function ensurePollerStarted(
+  context: PollerContext,
+  resourceKey: string,
+  blockId: string,
+  contentType: ContentType = 'text'
+) {
+  const key = makeKey(resourceKey, blockId);
+  if (pollers.has(key)) return;
+  const poller = new ManifestPoller(context, resourceKey, blockId, contentType);
+  pollers.set(key, poller);
+  poller.start();
+}
+
+export async function ensurePollerStoppedAndFinalize(
+  context: PollerContext,
+  resourceKey: string,
+  blockId: string,
+  contentType: ContentType = 'text'
+) {
+  const key = makeKey(resourceKey, blockId);
+  if (!pollers.has(key)) {
+    // one-shot fetch/finalize
+    const poller = new ManifestPoller(context, resourceKey, blockId, contentType);
+    pollers.set(key, poller);
+    await poller.stop();
+    pollers.delete(key);
+    return;
+  }
+  const poller = pollers.get(key)!;
+  await poller.stop();
+  pollers.delete(key);
+}

--- a/PuppyFlow/app/components/workflow/edgesNode/edgeNodesNew/hook/runSingleEdgeNodeExecutor.ts
+++ b/PuppyFlow/app/components/workflow/edgesNode/edgeNodesNew/hook/runSingleEdgeNodeExecutor.ts
@@ -18,6 +18,8 @@ import {
 } from './edgeNodeJsonBuilders';
 import { SYSTEM_URLS } from '@/config/urls';
 import { syncBlockContent } from '../../../../../components/workflow/utils/externalStorage';
+import { applyBlockUpdate, finalizeExternal } from '../../../blockNode/utils/blockUpdateApplier';
+import { ensurePollerStarted } from '../../../blockNode/utils/manifestPoller';
 
 // 导入NodeCategory类型定义
 type NodeCategory =
@@ -35,313 +37,7 @@ interface ServerSentEvent {
   data?: any; // 可选，因为BLOCK_UPDATED事件的数据在根级别
 }
 
-// 新增：External Metadata 接口定义
-interface ExternalMetadata {
-  resource_key: string;
-  content_type: string;
-  version_id: string;
-  chunked: boolean;
-  uploaded_at: string;
-}
-
-// 新增：Manifest 接口定义
-interface Manifest {
-  chunks: Array<{
-    name: string;
-    size: number;
-    index: number;
-    state?: 'processing' | 'done';
-  }>;
-  content_type: string;
-  total_size: number;
-}
-
-// 新增：External Metadata 接口定义
-interface ExternalMetadata {
-  resource_key: string;
-  content_type: string;
-  version_id: string;
-  chunked: boolean;
-  uploaded_at: string;
-}
-
-// 新增：Manifest 接口定义
-interface Manifest {
-  chunks: Array<{
-    name: string;
-    size: number;
-    index: number;
-    state?: 'processing' | 'done';
-  }>;
-  content_type: string;
-  total_size: number;
-}
-
-// 新增：Manifest Poller 类 - 改进版本
-class ManifestPoller {
-  private poller: NodeJS.Timeout | null = null;
-  private knownChunks = new Set<string>();
-  private context: RunSingleEdgeNodeContext;
-  private resource_key: string;
-  private block_id: string;
-  private content_type: string;
-  private chunks: string[] = [];
-  private isStopped = false;
-  // Structured content incremental parsing state
-  private parsedRecords: any[] = [];
-  private leftoverPartialLine: string = '';
-  private totalRecords: number = 0; // count of non-empty JSONL lines seen (including flushed leftover)
-  private parseErrors: number = 0;
-
-  constructor(
-    context: RunSingleEdgeNodeContext,
-    resource_key: string,
-    block_id: string,
-    content_type: string = 'text'
-  ) {
-    this.context = context;
-    this.resource_key = resource_key;
-    this.block_id = block_id;
-    this.content_type = content_type;
-  }
-
-  start() {
-    console.log(
-      `[ManifestPoller] Starting for ${this.resource_key}, content_type: ${this.content_type}`
-    );
-    this.context.setNodes(prevNodes =>
-      prevNodes.map(node =>
-        node.id === this.block_id
-          ? {
-              ...node,
-              data: {
-                ...node.data,
-                content: '',
-                isLoading: true,
-                isExternalStorage: true,
-                external_metadata: {
-                  resource_key: this.resource_key,
-                  content_type: this.content_type,
-                },
-              },
-            }
-          : node
-      )
-    );
-    this.poll();
-  }
-
-  private poll() {
-    if (this.isStopped) return;
-
-    this.poller = setTimeout(async () => {
-      await this.fetchManifestAndChunks();
-      if (!this.isStopped) {
-        this.poll();
-      }
-    }, 1000); // 轮询间隔
-  }
-
-  async stop() {
-    console.log(`[ManifestPoller] Stopping for ${this.resource_key}`);
-    this.isStopped = true;
-
-    if (this.poller) {
-      clearTimeout(this.poller);
-      this.poller = null;
-    }
-
-    // 最后再拉取一次，确保数据完整
-    await this.fetchManifestAndChunks();
-    // 对 structured 进行最终收尾，补齐最后一行残片
-    if (this.content_type === 'structured') {
-      this.finalizeStructuredParsing();
-      const finalContent = this.reconstructContent({
-        chunks: [],
-        content_type: this.content_type,
-        total_size: 0,
-      });
-      this.context.setNodes(prevNodes =>
-        prevNodes.map(node =>
-          node.id === this.block_id
-            ? {
-                ...node,
-                data: {
-                  ...node.data,
-                  content: finalContent,
-                  isLoading: false,
-                  isExternalStorage: true,
-                  external_metadata: {
-                    ...(node.data?.external_metadata || {}),
-                    resource_key: this.resource_key,
-                    content_type: this.content_type,
-                    loadedChunks: this.chunks.length,
-                    totalRecords: this.totalRecords,
-                    parsedRecords: this.parsedRecords.length,
-                    parseErrors: this.parseErrors,
-                  },
-                },
-              }
-            : node
-        )
-      );
-    }
-    this.context.resetLoadingUI(this.block_id);
-  }
-
-  private async fetchManifestAndChunks() {
-    try {
-      const manifestUrl = await this.getDownloadUrl(
-        `${this.resource_key}/manifest.json`
-      );
-      const manifestResponse = await fetch(manifestUrl);
-      if (!manifestResponse.ok) return;
-
-      const manifest: Manifest = await manifestResponse.json();
-      const newChunks = manifest.chunks
-        .filter(
-          chunk => !this.knownChunks.has(chunk.name) && chunk.state === 'done'
-        )
-        .sort((a, b) => (a.index ?? 0) - (b.index ?? 0));
-
-      if (newChunks.length === 0) return;
-
-      console.log(
-        `[ManifestPoller] Found ${newChunks.length} new chunks for ${this.resource_key}`
-      );
-
-      for (const chunkInfo of newChunks) {
-        this.knownChunks.add(chunkInfo.name);
-        const chunkUrl = await this.getDownloadUrl(
-          `${this.resource_key}/${chunkInfo.name}`
-        );
-        const chunkResponse = await fetch(chunkUrl);
-        const chunkData = await chunkResponse.text();
-
-        this.chunks.push(chunkData);
-        if (this.content_type === 'structured') {
-          this.parseStructuredChunk(chunkData, chunkInfo.name);
-        }
-      }
-
-      // 根据content_type处理数据
-      const reconstructedContent = this.reconstructContent(manifest);
-
-      this.context.setNodes(prevNodes =>
-        prevNodes.map(node =>
-          node.id === this.block_id
-            ? {
-                ...node,
-                data: {
-                  ...node.data,
-                  content: reconstructedContent,
-                  isLoading: false,
-                  isExternalStorage: true,
-                  external_metadata: {
-                    resource_key: this.resource_key,
-                    content_type: this.content_type,
-                    totalChunks: manifest.chunks.length,
-                    loadedChunks: this.chunks.length,
-                    totalRecords: this.totalRecords,
-                    parsedRecords: this.parsedRecords.length,
-                    parseErrors: this.parseErrors,
-                  },
-                },
-              }
-            : node
-        )
-      );
-    } catch (error) {
-      console.error(
-        '[ManifestPoller] Error fetching manifest or chunk:',
-        error
-      );
-    }
-  }
-
-  private reconstructContent(manifest: Manifest): string {
-    if (this.content_type === 'structured') {
-      // Return JSON array string for structured content
-      try {
-        return JSON.stringify(this.parsedRecords, null, 2);
-      } catch (e) {
-        console.warn('[ManifestPoller] Failed to stringify parsed records:', e);
-        return '[]';
-      }
-    } else {
-      // 对于文本数据，直接拼接
-      return this.chunks.join('');
-    }
-  }
-
-  // Incrementally parse a JSONL chunk and accumulate parsed records
-  private parseStructuredChunk(chunkText: string, chunkName: string) {
-    let dataToProcess = (this.leftoverPartialLine || '') + chunkText;
-    this.leftoverPartialLine = '';
-
-    const lines = dataToProcess.split(/\r?\n/);
-    const possibleLeftover = lines.pop() ?? '';
-
-    for (let i = 0; i < lines.length; i++) {
-      const rawLine = lines[i];
-      const line = rawLine.trim();
-      if (!line) continue;
-      this.totalRecords += 1;
-      try {
-        const parsed = JSON.parse(line);
-        this.parsedRecords.push(parsed);
-      } catch (err) {
-        this.parseErrors += 1;
-        console.warn(
-          `[ManifestPoller] JSONL parse error in ${chunkName} at record #${this.totalRecords}:`,
-          err
-        );
-        console.warn(
-          '[ManifestPoller] Offending line (truncated):',
-          rawLine.slice(0, 500)
-        );
-      }
-    }
-
-    this.leftoverPartialLine = possibleLeftover;
-  }
-
-  // On stream end, flush leftover line (if any) as a final record
-  private finalizeStructuredParsing() {
-    const leftover = this.leftoverPartialLine.trim();
-    if (!leftover) {
-      this.leftoverPartialLine = '';
-      return;
-    }
-    this.totalRecords += 1;
-    try {
-      const parsed = JSON.parse(leftover);
-      this.parsedRecords.push(parsed);
-    } catch (err) {
-      this.parseErrors += 1;
-      console.warn('[ManifestPoller] Final leftover JSONL parse error:', err);
-      console.warn(
-        '[ManifestPoller] Offending leftover (truncated):',
-        leftover.slice(0, 500)
-      );
-    } finally {
-      this.leftoverPartialLine = '';
-    }
-  }
-
-  private async getDownloadUrl(key: string): Promise<string> {
-    const response = await fetch(
-      `/api/storage/download/url?key=${encodeURIComponent(key)}`
-    );
-    if (!response.ok) {
-      throw new Error(`Failed to get download URL for ${key}`);
-    }
-    const data = await response.json();
-    return data.download_url;
-  }
-}
-
-const pollers = new Map<string, ManifestPoller>();
+// External polling handled by shared block-side utils
 
 // 执行上下文接口
 export interface RunSingleEdgeNodeContext {
@@ -645,86 +341,29 @@ async function sendDataToTargets(
                 }
                 break;
               case 'STREAM_STARTED':
-                if (
-                  data?.block_id &&
-                  data?.resource_key &&
-                  data?.content_type
-                ) {
-                  // Normalize to supported types only: text | structured
+                if (data?.block_id && data?.resource_key) {
                   const normalizedContentType =
-                    data.content_type === 'structured' ? 'structured' : 'text';
-                  // 为每个目标节点创建一个 poller
+                    data?.content_type === 'structured' ? 'structured' : 'text';
+                  // 启动外部内容轮询，标记节点状态
                   targetNodeIdWithLabelGroup.forEach(targetNode => {
-                    const poller = new ManifestPoller(
-                      context,
+                    ensurePollerStarted(
+                      { setNodes: context.setNodes, resetLoadingUI: context.resetLoadingUI },
                       data.resource_key,
                       targetNode.id,
                       normalizedContentType
-                    );
-                    pollers.set(
-                      `${data.resource_key}_${targetNode.id}`,
-                      poller
-                    );
-                    poller.start();
-                  });
-
-                  // 设置所有目标节点为等待状态
-                  targetNodeIdWithLabelGroup.forEach(targetNode => {
-                    context.setNodes(prevNodes =>
-                      prevNodes.map(node =>
-                        node.id === targetNode.id
-                          ? {
-                              ...node,
-                              data: {
-                                ...node.data,
-                                isLoading: true,
-                                isWaitingForFlow: true,
-                                isExternalStorage: true,
-                                external_metadata: {
-                                  ...(node.data?.external_metadata || {}),
-                                  resource_key: data.resource_key,
-                                  content_type: normalizedContentType,
-                                },
-                              },
-                            }
-                          : node
-                      )
                     );
                   });
                 }
                 break;
               case 'STREAM_ENDED':
                 if (data?.block_id && data?.resource_key) {
-                  // 若此前已在 STREAM_STARTED 启动过，则停止并完成最后一次拉取
-                  const existingKeys: string[] = [];
-                  targetNodeIdWithLabelGroup.forEach(t => {
-                    existingKeys.push(`${data.resource_key}_${t.id}`);
-                  });
-
-                  // 若未曾启动过（由于 STREAM_STARTED 无 resource_key），这里启动一次性拉取并立即停止
-                  if (existingKeys.every(k => !pollers.has(k))) {
-                    const pollerKey = `${data.resource_key}_${data.block_id}`;
-                    if (!pollers.has(pollerKey)) {
-                      const poller = new ManifestPoller(
-                        context,
-                        data.resource_key,
-                        data.block_id,
-                        'text'
-                      );
-                      pollers.set(pollerKey, poller);
-                      // 一次性拉取（stop 内部会做最后一次 fetch）
-                      await poller.stop();
-                      pollers.delete(pollerKey);
-                    }
-                  } else {
-                    // 停止所有相关的 poller，完成最后一次拉取
-                    targetNodeIdWithLabelGroup.forEach(async targetNode => {
-                      const pollerKey = `${data.resource_key}_${targetNode.id}`;
-                      if (pollers.has(pollerKey)) {
-                        await pollers.get(pollerKey)?.stop();
-                        pollers.delete(pollerKey);
-                      }
-                    });
+                  // 完成所有目标节点的外部内容拉取并最终写回
+                  for (const targetNode of targetNodeIdWithLabelGroup) {
+                    await finalizeExternal(
+                      { setNodes: context.setNodes, resetLoadingUI: context.resetLoadingUI },
+                      targetNode.id,
+                      data.resource_key
+                    );
                   }
                 }
                 break;
@@ -796,74 +435,19 @@ async function sendDataToTargets(
 
                   // 检查是否为external存储模式
                   const isExternalStorage =
-                    data.storage_class === 'external' ||
-                    data.external_metadata !== undefined;
+                    data.storage_class === 'external' || data.external_metadata !== undefined;
 
                   if (isExternalStorage) {
-                    // External存储模式：使用external_metadata
-                    const externalMetadata =
-                      data.external_metadata as ExternalMetadata;
-
-                    if (!externalMetadata || !externalMetadata.resource_key) {
-                      console.error(
-                        '❌ BLOCK_UPDATED: Missing external_metadata or resource_key',
-                        data
-                      );
-                      break;
-                    }
-
-                    // 更新节点为external存储模式（normalize content_type to text/structured only）
-                    const normalizedContentType =
-                      externalMetadata.content_type === 'structured'
-                        ? 'structured'
-                        : 'text';
-                    context.setNodes(prevNodes => {
-                      const updatedNodes = prevNodes.map(node => {
-                        if (node.id === data.block_id) {
-                          return {
-                            ...node,
-                            data: {
-                              ...node.data,
-                              storage_class: 'external',
-                              external_metadata: {
-                                ...externalMetadata,
-                                content_type: normalizedContentType,
-                              },
-                              isLoading: false,
-                              isWaitingForFlow: false,
-                              isExternalStorage: true,
-                              // 对于external存储，content为空，需要通过ManifestPoller下载
-                              content: '',
-                            },
-                          };
-                        }
-                        return node;
-                      });
-
-                      return updatedNodes;
-                    });
-
-                    console.log(
-                      `✅ BLOCK_UPDATED: External storage block ${data.block_id} updated with metadata`
+                    // 交给 block 适配层处理 external 指针并启动轮询
+                    applyBlockUpdate(
+                      { setNodes: context.setNodes, resetLoadingUI: context.resetLoadingUI },
+                      {
+                        block_id: data.block_id,
+                        storage_class: 'external',
+                        external_metadata: data.external_metadata,
+                      } as any
                     );
-
-                    // 如未进行过拉取，这里基于 external_metadata 启动一次性拉取
-                    if (externalMetadata?.resource_key && data.block_id) {
-                      const pollerKey = `${externalMetadata.resource_key}_${data.block_id}`;
-                      if (!pollers.has(pollerKey)) {
-                        const poller = new ManifestPoller(
-                          context,
-                          externalMetadata.resource_key,
-                          data.block_id,
-                          normalizedContentType || 'text'
-                        );
-                        pollers.set(pollerKey, poller);
-                        await poller.stop();
-                        pollers.delete(pollerKey);
-                      }
-                    }
                   } else {
-                    // Internal存储模式：直接使用content
                     if (data.content === undefined) {
                       console.error(
                         '❌ BLOCK_UPDATED: content is undefined for internal storage',
@@ -871,30 +455,15 @@ async function sendDataToTargets(
                       );
                       break;
                     }
-
-                    // 更新节点内容并设置加载状态为false
-                    context.setNodes(prevNodes => {
-                      const updatedNodes = prevNodes.map(node => {
-                        if (node.id === data.block_id) {
-                          return {
-                            ...node,
-                            data: {
-                              ...node.data,
-                              content: data.content,
-                              isLoading: false,
-                              isWaitingForFlow: false,
-                              isExternalStorage: false,
-                            },
-                          };
-                        }
-                        return node;
-                      });
-
-                      return updatedNodes;
-                    });
-
-                    console.log(
-                      `✅ BLOCK_UPDATED: Internal storage block ${data.block_id} updated with content`
+                    // 交给 block 适配层做类型归一（对象/数组→字符串）
+                    applyBlockUpdate(
+                      { setNodes: context.setNodes, resetLoadingUI: context.resetLoadingUI },
+                      {
+                        block_id: data.block_id,
+                        storage_class: 'internal',
+                        type: data.type,
+                        content: data.content,
+                      } as any
                     );
                   }
                 } catch (error) {


### PR DESCRIPTION
## Summary
- Move internal/external block data handling to block-side adapters
- manifestPoller: shared JSONL/text polling and reconstruction
- blockUpdateApplier: unify BLOCK_UPDATED handling; normalize UI content to string
- Edge executors delegate to adapters; editors no longer receive non-string content

## Why
Internal structured outputs set `content` to object/array; JSON editors call `.trim()` on `value` and crash. Decoupling ensures editors always get strings and edge logic stays transport-focused.

## Scope
- runSingleEdgeNodeExecutor.ts
- runAllNodesExecutor.ts
- + blockNode/utils/manifestPoller.ts
- + blockNode/utils/blockUpdateApplier.ts

## Tests
- LLM structured_output=true (internal): UI renders JSON without error
- LLM structured_output=true (external): chunks polled & aggregated then displayed
- Text blocks unaffected

## Risk
Medium-low. Touches SSE handling but behavior is equivalent with improved typing.