### PR TITLE
fix: correct internal BLOCK_UPDATED type to prevent [object Object] (…

### DIFF
--- a/PuppyEngine/Server/EventFactory.py
+++ b/PuppyEngine/Server/EventFactory.py
@@ -98,10 +98,22 @@ class EventFactory:
     @staticmethod
     def create_block_updated_event_internal(block_id: str, content: Any) -> Dict[str, Any]:
         """Create BLOCK_UPDATED event for internal storage"""
+        # Determine semantic content type for clients to render correctly
+        # - list/dict => structured
+        # - others (str/number/bool/None) => text
+        try:
+            if isinstance(content, (list, dict)):
+                content_type = "structured"
+            else:
+                content_type = "text"
+        except Exception:
+            content_type = "text"
+
         return {
             "event_type": "BLOCK_UPDATED",
             "block_id": block_id,
             "storage_class": "internal",
+            "type": content_type,
             "content": content,
             "timestamp": datetime.utcnow().isoformat()
         }

--- a/PuppyFlow/app/components/workflow/Workflow.tsx
+++ b/PuppyFlow/app/components/workflow/Workflow.tsx
@@ -376,8 +376,14 @@ function Workflow() {
             .sort((a: any, b: any) => {
               const aName = typeof a === 'string' ? a : a.name;
               const bName = typeof b === 'string' ? b : b.name;
-              const aIdx = typeof a === 'object' && typeof a.index === 'number' ? a.index : extractIndex(aName || '');
-              const bIdx = typeof b === 'object' && typeof b.index === 'number' ? b.index : extractIndex(bName || '');
+              const aIdx =
+                typeof a === 'object' && typeof a.index === 'number'
+                  ? a.index
+                  : extractIndex(aName || '');
+              const bIdx =
+                typeof b === 'object' && typeof b.index === 'number'
+                  ? b.index
+                  : extractIndex(bName || '');
               return aIdx - bIdx;
             });
 

--- a/PuppyFlow/app/components/workflow/blockNode/utils/blockUpdateApplier.ts
+++ b/PuppyFlow/app/components/workflow/blockNode/utils/blockUpdateApplier.ts
@@ -79,8 +79,17 @@ export function applyBlockUpdate(
 
   // Internal: normalize content to string for UI
   const u = update as BlockUpdateInternal;
-  const contentType: ContentType =
+  // Prefer explicit type; fallback to runtime inference to be robust
+  let contentType: ContentType =
     u.type === 'structured' ? 'structured' : 'text';
+  if (!u.type) {
+    const value = u.content;
+    const isStructured =
+      value !== null &&
+      typeof value === 'object' &&
+      !(typeof (value as any).toISOString === 'function');
+    if (isStructured) contentType = 'structured';
+  }
 
   let stringContent: string;
   try {


### PR DESCRIPTION
…#876)

* fix(block-updated): set type for internal updates; FE infers structured when missing

- Backend: EventFactory.create_block_updated_event_internal now emits a semantic type ('structured' for list/dict, otherwise 'text') so the UI can render correctly without guessing, preventing [object Object] in editors.
- Frontend: applyBlockUpdate falls back to inferring 'structured' when type is missing but content is an object/array, making the fix resilient to older backends.

Why: Without type, internal structured content was coerced to string via String(obj) → "[object Object]", which the JSON editor flagged as Invalid JSON. This aligns event semantics and stabilizes rendering.

* style: prettier auto-format

---------