### PR TITLE
fix(workspace): forward auth header, fix timestamp key, add logging

### DIFF
--- a/PuppyFlow/app/api/workspace/create/route.ts
+++ b/PuppyFlow/app/api/workspace/create/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { getWorkspaceStore } from '@/lib/workspace';
 import { getCurrentUserId } from '@/lib/auth/serverUser';
+import { cookies } from 'next/headers';
 
 export async function POST(request: Request) {
   try {
@@ -14,12 +15,31 @@ export async function POST(request: Request) {
       );
     }
     const store = getWorkspaceStore();
-    const created = await store.createWorkspace(userId, {
-      workspace_id,
-      workspace_name,
-    });
+    let authHeader = request.headers.get('authorization') || undefined;
+    if (!authHeader) {
+      try {
+        const token = cookies().get('access_token')?.value;
+        if (token) authHeader = `Bearer ${token}`;
+      } catch {
+        const rawCookie = request.headers.get('cookie') || '';
+        const match = rawCookie.match(/(?:^|;\s*)access_token=([^;]+)/);
+        if (match) authHeader = `Bearer ${decodeURIComponent(match[1])}`;
+      }
+    }
+    const created = await store.createWorkspace(
+      userId,
+      {
+        workspace_id,
+        workspace_name,
+      },
+      authHeader ? { authHeader } : undefined
+    );
     return NextResponse.json(created, { status: 200 });
   } catch (error) {
+    console.error('[API:/api/workspace/create] Failed:', {
+      message: (error as any)?.message,
+      stack: (error as any)?.stack,
+    });
     return NextResponse.json(
       { error: 'Failed to create workspace' },
       { status: 500 }

--- a/PuppyFlow/app/api/workspace/list/route.ts
+++ b/PuppyFlow/app/api/workspace/list/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { getWorkspaceStore } from '@/lib/workspace';
 import { getCurrentUserId } from '@/lib/auth/serverUser';
+import { cookies } from 'next/headers';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -9,7 +10,21 @@ export async function GET(request: Request) {
   try {
     const userId = await getCurrentUserId(request);
     const store = getWorkspaceStore();
-    const workspaces = await store.listWorkspaces(userId);
+    let authHeader = request.headers.get('authorization') || undefined;
+    if (!authHeader) {
+      try {
+        const token = cookies().get('access_token')?.value;
+        if (token) authHeader = `Bearer ${token}`;
+      } catch {
+        const rawCookie = request.headers.get('cookie') || '';
+        const match = rawCookie.match(/(?:^|;\s*)access_token=([^;]+)/);
+        if (match) authHeader = `Bearer ${decodeURIComponent(match[1])}`;
+      }
+    }
+    const workspaces = await store.listWorkspaces(
+      userId,
+      authHeader ? { authHeader } : undefined
+    );
     return NextResponse.json({ workspaces });
   } catch (error) {
     // Log the underlying error for server-side diagnostics

--- a/PuppyFlow/app/api/workspace/route.ts
+++ b/PuppyFlow/app/api/workspace/route.ts
@@ -1,6 +1,23 @@
 import { NextResponse } from 'next/server';
 import { getWorkspaceStore } from '@/lib/workspace';
-import { getCurrentUserId } from '@/lib/auth/serverUser';
+import { cookies } from 'next/headers';
+
+export const runtime = 'nodejs';
+
+function getAuthHeaderFromRequest(request: Request): string | undefined {
+  let authHeader = request.headers.get('authorization') || undefined;
+  if (!authHeader) {
+    try {
+      const token = cookies().get('access_token')?.value;
+      if (token) authHeader = `Bearer ${token}`;
+    } catch {
+      const rawCookie = request.headers.get('cookie') || '';
+      const match = rawCookie.match(/(?:^|;\s*)access_token=([^;]+)/);
+      if (match) authHeader = `Bearer ${decodeURIComponent(match[1])}`;
+    }
+  }
+  return authHeader;
+}
 
 // 保存工作区数据
 export async function POST(request: Request) {
@@ -19,9 +36,18 @@ export async function POST(request: Request) {
       );
     }
     const store = getWorkspaceStore();
-    await store.addHistory(flowId, { history: json, timestamp });
+    const authHeader = getAuthHeaderFromRequest(request);
+    await store.addHistory(
+      flowId,
+      { history: json, timestamp },
+      authHeader ? { authHeader } : undefined
+    );
     return NextResponse.json({ success: true }, { status: 200 });
   } catch (error) {
+    console.error('[API:/api/workspace] Failed to save:', {
+      message: (error as any)?.message,
+      stack: (error as any)?.stack,
+    });
     return NextResponse.json(
       {
         success: false,
@@ -46,7 +72,11 @@ export async function GET(request: Request) {
       );
     }
     const store = getWorkspaceStore();
-    const data = await store.getLatestHistory(flowId);
+    const authHeader = getAuthHeaderFromRequest(request);
+    const data = await store.getLatestHistory(
+      flowId,
+      authHeader ? { authHeader } : undefined
+    );
     return NextResponse.json({ data });
   } catch (error) {
     return NextResponse.json(

--- a/PuppyFlow/lib/workspace/userSystemStore.ts
+++ b/PuppyFlow/lib/workspace/userSystemStore.ts
@@ -111,7 +111,7 @@ export class UserSystemWorkspaceStore implements IWorkspaceStore {
         credentials: 'include',
         body: JSON.stringify({
           history: data.history,
-          timestep: data.timestamp,
+          timestamp: data.timestamp,
         }),
       }
     );


### PR DESCRIPTION
## Summary
- Forward Authorization (from access_token cookie when needed) in all /api/workspace* routes
- Cloud store: fix addHistory payload key from 'timestep' to 'timestamp'
- Add server-side error logging and ensure node runtime where needed
- Keeps local (file) store behavior unchanged; only cloud path forwards auth

## Context
- Fixes 500 on POST /api/workspace in cloud mode when cookie is valid but upstream requires Authorization
- Aligns payload key with backend expectation (timestamp)

## Test plan
- Local mode (DEPLOYMENT_MODE!=cloud):
  - Create/rename/delete workspace; save and fetch content (writes to workspace_data)
- Cloud mode (DEPLOYMENT_MODE=cloud):
  - With valid access_token cookie, create/rename/delete works; save/fetch content works
  - Confirm /api/workspace/list hits backend with Authorization header
  - Verify logs show detailed error if upstream returns non-2xx

## Notes
- No client changes required; internal server routes handle token injection