### PR TITLE
fix(workspace): revert store to direct connection for server-side calls

### DIFF
--- a/PuppyFlow/app/api/workspace/[workspaceId]/rename/route.ts
+++ b/PuppyFlow/app/api/workspace/[workspaceId]/rename/route.ts
@@ -7,7 +7,6 @@ export async function PUT(
   { params }: { params: { workspaceId: string } }
 ) {
   try {
-    const url = new URL(request.url);
     const { workspaceId } = params;
     const body = await request.json();
     const newName = body?.new_name;
@@ -31,7 +30,6 @@ export async function PUT(
     }
     const updated = await store.renameWorkspace(workspaceId, newName, {
       authHeader,
-      origin: url.origin,
     });
     return NextResponse.json({
       msg: 'Workspace name updated',

--- a/PuppyFlow/app/api/workspace/[workspaceId]/route.ts
+++ b/PuppyFlow/app/api/workspace/[workspaceId]/route.ts
@@ -8,7 +8,6 @@ export async function DELETE(
   { params }: { params: { workspaceId: string } }
 ) {
   try {
-    const url = new URL(request.url);
     const { workspaceId } = params;
     if (!workspaceId) {
       return NextResponse.json(
@@ -28,10 +27,7 @@ export async function DELETE(
         if (match) authHeader = `Bearer ${decodeURIComponent(match[1])}`;
       }
     }
-    await store.deleteWorkspace(workspaceId, {
-      authHeader,
-      origin: url.origin,
-    });
+    await store.deleteWorkspace(workspaceId, { authHeader });
     return NextResponse.json({
       success: true,
       message: 'Workspace deleted successfully',

--- a/PuppyFlow/app/api/workspace/create/route.ts
+++ b/PuppyFlow/app/api/workspace/create/route.ts
@@ -5,7 +5,6 @@ import { cookies } from 'next/headers';
 
 export async function POST(request: Request) {
   try {
-    const url = new URL(request.url);
     const userId = await getCurrentUserId(request);
     const body = await request.json();
     const { workspace_id, workspace_name } = body || {};
@@ -33,7 +32,7 @@ export async function POST(request: Request) {
         workspace_id,
         workspace_name,
       },
-      { authHeader, origin: url.origin }
+      { authHeader }
     );
     return NextResponse.json(created, { status: 200 });
   } catch (error) {

--- a/PuppyFlow/app/api/workspace/list/route.ts
+++ b/PuppyFlow/app/api/workspace/list/route.ts
@@ -8,7 +8,6 @@ export const runtime = 'nodejs';
 
 export async function GET(request: Request) {
   try {
-    const url = new URL(request.url);
     const userId = await getCurrentUserId(request);
     const store = getWorkspaceStore();
     let authHeader = request.headers.get('authorization') || undefined;
@@ -22,10 +21,7 @@ export async function GET(request: Request) {
         if (match) authHeader = `Bearer ${decodeURIComponent(match[1])}`;
       }
     }
-    const workspaces = await store.listWorkspaces(userId, {
-      authHeader,
-      origin: url.origin,
-    });
+    const workspaces = await store.listWorkspaces(userId, { authHeader });
     return NextResponse.json({ workspaces });
   } catch (error) {
     // Log the underlying error for server-side diagnostics

--- a/PuppyFlow/app/api/workspace/route.ts
+++ b/PuppyFlow/app/api/workspace/route.ts
@@ -23,7 +23,6 @@ function getAuthHeaderFromRequest(request: Request): string | undefined {
 // 保存工作区数据
 export async function POST(request: Request) {
   try {
-    const url = new URL(request.url);
     const requestBody = await request.json();
     const { flowId, json, timestamp, workspaceName } = requestBody;
 
@@ -45,7 +44,7 @@ export async function POST(request: Request) {
       await store.addHistory(
         flowId,
         { history: json, timestamp },
-        { authHeader, origin: url.origin }
+        { authHeader }
       );
     } catch (e: any) {
       // 若后端返回404（工作区不存在），先尝试创建再重试一次保存
@@ -68,12 +67,12 @@ export async function POST(request: Request) {
           workspace_id: flowId,
           workspace_name: name,
         },
-        { authHeader, origin: url.origin }
+        { authHeader }
       );
       await store.addHistory(
         flowId,
         { history: json, timestamp },
-        { authHeader, origin: url.origin }
+        { authHeader }
       );
     }
     return NextResponse.json({ success: true }, { status: 200 });
@@ -95,7 +94,6 @@ export async function POST(request: Request) {
 // 获取工作区最新数据
 export async function GET(request: Request) {
   try {
-    const url = new URL(request.url);
     const { searchParams } = new URL(request.url);
     const flowId = searchParams.get('flowId');
     const timestamp = searchParams.get('timestamp');
@@ -108,10 +106,7 @@ export async function GET(request: Request) {
     }
     const store = getWorkspaceStore();
     const authHeader = getAuthHeaderFromRequest(request);
-    const data = await store.getLatestHistory(flowId, {
-      authHeader,
-      origin: url.origin,
-    });
+    const data = await store.getLatestHistory(flowId, { authHeader });
     return NextResponse.json({ data });
   } catch (error) {
     return NextResponse.json(

--- a/PuppyFlow/lib/workspace/store.ts
+++ b/PuppyFlow/lib/workspace/store.ts
@@ -3,29 +3,29 @@ export type WorkspaceBasic = { workspace_id: string; workspace_name: string };
 export interface IWorkspaceStore {
   listWorkspaces(
     userId: string,
-    opts: { authHeader?: string; origin: string }
+    opts?: { authHeader?: string }
   ): Promise<WorkspaceBasic[]>;
   createWorkspace(
     userId: string,
     payload: { workspace_id: string; workspace_name: string },
-    opts: { authHeader?: string; origin: string }
+    opts?: { authHeader?: string }
   ): Promise<WorkspaceBasic>;
   deleteWorkspace(
     workspaceId: string,
-    opts: { authHeader?: string; origin: string }
+    opts?: { authHeader?: string }
   ): Promise<void>;
   renameWorkspace(
     workspaceId: string,
     newName: string,
-    opts: { authHeader?: string; origin: string }
+    opts?: { authHeader?: string }
   ): Promise<WorkspaceBasic>;
   getLatestHistory(
     workspaceId: string,
-    opts: { authHeader?: string; origin: string }
+    opts?: { authHeader?: string }
   ): Promise<any | null>;
   addHistory(
     workspaceId: string,
     data: { history: any; timestamp: string },
-    opts: { authHeader?: string; origin: string }
+    opts?: { authHeader?: string }
   ): Promise<void>;
 }

--- a/PuppyFlow/lib/workspace/userSystemStore.ts
+++ b/PuppyFlow/lib/workspace/userSystemStore.ts
@@ -15,12 +15,9 @@ export class UserSystemWorkspaceStore implements IWorkspaceStore {
 
   async listWorkspaces(
     userId: string,
-    opts: { authHeader?: string; origin: string }
+    opts?: { authHeader?: string }
   ): Promise<WorkspaceBasic[]> {
-    const url = new URL(
-      `${this.base}/get_user_workspaces/${userId}`,
-      opts.origin
-    );
+    const url = `${this.base}/get_user_workspaces/${userId}`;
     const res = await fetch(url, {
       method: 'GET',
       headers: authHeaders(opts?.authHeader),
@@ -34,9 +31,9 @@ export class UserSystemWorkspaceStore implements IWorkspaceStore {
   async createWorkspace(
     userId: string,
     payload: { workspace_id: string; workspace_name: string },
-    opts: { authHeader?: string; origin: string }
+    opts?: { authHeader?: string }
   ): Promise<WorkspaceBasic> {
-    const url = new URL(`${this.base}/create_workspace/${userId}`, opts.origin);
+    const url = `${this.base}/create_workspace/${userId}`;
     const res = await fetch(url, {
       method: 'POST',
       headers: authHeaders(opts?.authHeader),
@@ -53,12 +50,9 @@ export class UserSystemWorkspaceStore implements IWorkspaceStore {
 
   async deleteWorkspace(
     workspaceId: string,
-    opts: { authHeader?: string; origin: string }
+    opts?: { authHeader?: string }
   ): Promise<void> {
-    const url = new URL(
-      `${this.base}/delete_workspace/${workspaceId}`,
-      opts.origin
-    );
+    const url = `${this.base}/delete_workspace/${workspaceId}`;
     const res = await fetch(url, {
       method: 'DELETE',
       headers: authHeaders(opts?.authHeader),
@@ -70,12 +64,9 @@ export class UserSystemWorkspaceStore implements IWorkspaceStore {
   async renameWorkspace(
     workspaceId: string,
     newName: string,
-    opts: { authHeader?: string; origin: string }
+    opts?: { authHeader?: string }
   ): Promise<WorkspaceBasic> {
-    const url = new URL(
-      `${this.base}/update_workspace_name/${workspaceId}`,
-      opts.origin
-    );
+    const url = `${this.base}/update_workspace_name/${workspaceId}`;
     const res = await fetch(url, {
       method: 'PUT',
       headers: authHeaders(opts?.authHeader),
@@ -92,12 +83,9 @@ export class UserSystemWorkspaceStore implements IWorkspaceStore {
 
   async getLatestHistory(
     workspaceId: string,
-    opts: { authHeader?: string; origin: string }
+    opts?: { authHeader?: string }
   ): Promise<any | null> {
-    const url = new URL(
-      `${this.base}/get_latest_workspace_history/${workspaceId}`,
-      opts.origin
-    );
+    const url = `${this.base}/get_latest_workspace_history/${workspaceId}`;
     const res = await fetch(url, {
       method: 'GET',
       headers: authHeaders(opts?.authHeader),
@@ -112,12 +100,9 @@ export class UserSystemWorkspaceStore implements IWorkspaceStore {
   async addHistory(
     workspaceId: string,
     data: { history: any; timestamp: string },
-    opts: { authHeader?: string; origin: string }
+    opts?: { authHeader?: string }
   ): Promise<void> {
-    const url = new URL(
-      `${this.base}/add_workspace_history/${workspaceId}`,
-      opts.origin
-    );
+    const url = `${this.base}/add_workspace_history/${workspaceId}`;
     const res = await fetch(url, {
       method: 'POST',
       headers: authHeaders(opts?.authHeader),


### PR DESCRIPTION
Reverts the UserSystemWorkspaceStore to connect directly to the USER_SYSTEM_BACKEND environment variable.

This fixes a 'fetch failed' error in serverless environments where server-side API routes cannot use relative paths to fetch their own internal proxies.

The correct fix is to use the platform's private networking URL (e.g., from Railway) in the USER_SYSTEM_BACKEND variable, allowing for direct, reliable server-to-server communication.
