### PR TITLE
💡 Feat: Implement smart type degradation for Edit Structured node

### DIFF
--- a/PuppyEngine/Server/EventFactory.py
+++ b/PuppyEngine/Server/EventFactory.py
@@ -103,18 +103,20 @@ class EventFactory:
         }
     
     @staticmethod
-    def create_block_updated_event_internal(block_id: str, content: Any) -> Dict[str, Any]:
+    def create_block_updated_event_internal(block_id: str, content: Any, semantic_type: str = None) -> Dict[str, Any]:
         """Create BLOCK_UPDATED event for internal storage"""
-        # Determine semantic content type for clients to render correctly
-        # - list/dict => structured
-        # - others (str/number/bool/None) => text
-        try:
-            if isinstance(content, (list, dict)):
-                content_type = "structured"
-            else:
+        # Use explicit semantic type if provided, otherwise infer from content
+        if semantic_type:
+            content_type = semantic_type
+        else:
+            # Fallback to runtime inference for backward compatibility
+            try:
+                if isinstance(content, (list, dict)):
+                    content_type = "structured"
+                else:
+                    content_type = "text"
+            except Exception:
                 content_type = "text"
-        except Exception:
-            content_type = "text"
 
         return {
             "event_type": "BLOCK_UPDATED",


### PR DESCRIPTION
## Issue Summary
The PR template enforcer created duplicate reviews on PR #911 due to concurrent runs.

## Reproduction Steps
- Create or edit a PR to quickly trigger multiple `pull_request_target` events (opened/edited/synchronize)
- Observe two bot reviews created within seconds

## Root Cause Analysis
- Workflow allowed concurrent runs for the same PR; both runs passed the "no existing review yet" check and each created a `CHANGES_REQUESTED` review.

## Fix Strategy
- Add a top-level `concurrency` group keyed by PR number, with `cancel-in-progress: true`, to serialize runs per PR.

## Verification
- Triggered the workflow after merging the fix; only one run executes at a time and no duplicate reviews are created.

## Risk & Mitigations
- Low risk; change only affects workflow scheduling.

## Backporting
- Not required.

## Related Issues / Links
- Follow-up PR #912 implements the concurrency guard.

## Checklist
- [x] Repro added in description
- [x] Regression coverage via concurrency guard
- [x] Rollback plan: remove the `concurrency` block if needed
- [x] Verified no duplicate reviews after fix

<!-- noop: trigger edited -->