### PR TITLE
🐛 Fix: JSON block node becomes undraggable after syntax error.

### DIFF
--- a/PuppyFlow/app/components/tableComponent/JSONForm.tsx
+++ b/PuppyFlow/app/components/tableComponent/JSONForm.tsx
@@ -132,13 +132,15 @@ const JSONForm = ({
   // 添加清理 useEffect
   useEffect(() => {
     return () => {
+      // 确保在组件卸载时恢复拖拽功能
+      allowParentDrag();
       // 清理 Monaco Editor 监听器
       editorDisposablesRef.current.forEach(disposable => {
         disposable.dispose();
       });
       editorDisposablesRef.current = [];
     };
-  }, []);
+  }, [allowParentDrag]);
 
   // 计算实际的宽高样式
   const actualWidth = widthStyle === 0 ? '100%' : widthStyle;


### PR DESCRIPTION
## Issue Summary
The JSON Block node permanently loses its drag functionality after entering syntactically incorrect JSON content. Even if the syntax error is subsequently fixed, the node remains undraggable.

## Reproduction Steps
- **Steps to Reproduce**:
  1. Create a JSON Block node.
  2. Edit the JSON content and introduce a syntax error (e.g., missing a closing brace).
  3. Click outside the node to make the editor lose focus.
  4. Attempt to drag the node.
- **Expected Behavior**: The node should be draggable normally.
- **Actual Behavior**: The node is completely undraggable; there is no drag cursor when hovering over it.
- **Scope of Impact**: All JSON Block nodes that utilize the Monaco Editor.

## Root Cause Analysis
- **Root Cause**: When the React component re-renders, the Monaco Editor's focus event adds a `nodrag` CSS class to disable dragging. However, during the component re-rendering process, this CSS class is not correctly cleaned up, leading to the new component instance "inheriting" the disabled drag state.
- **Why it wasn't discovered before**:
  - The issue only occurs under a specific sequence of user interactions (syntax error + loss of focus).
  - There's a subtle interaction between Monaco Editor's event handling mechanism and React's re-rendering timing.
  - Lack of test coverage specifically for drag functionality in error states.

## Fix Strategy
- **Fix Proposal**: Add an `allowParentDrag()` call within the `useEffect` cleanup function to ensure the drag state is reset every time the component re-renders.
- **Reasoning for Choice**: Utilizes React's lifecycle mechanism to forcefully clear the drag-disabled state before the component re-renders.
- **Alternative Solutions Considered**:
  - ❌ Listening to various Monaco Editor events (complex and unreliable).
  - ❌ Adding a periodic check mechanism (performance overhead and not a fundamental fix).
  - ❌ Modifying Monaco Editor's event handling logic (too intrusive).

## Verification
- **Manual Verification Steps**:
  1. Create a JSON Block and input syntactically incorrect JSON.
  2. Make the editor lose focus.
  3. Verify that the node is still draggable.
  4. Fix the JSON syntax error and verify the drag functionality again.
- **Regression Test Areas**:
  - Drag functionality of all types of Block nodes.
  - Monaco Editor's focus/blur behavior.
  - JSON syntax validation functionality.

## Risk & Mitigations
- **Potential Side Effects**:
  - Theoretically, dragging might be enabled prematurely in some extreme cases.
  - Changes in `useEffect` dependency array might lead to unnecessary re-renders.
- **Mitigation Measures**:
  - Fix scope is limited to the `JSONForm` component.
  - Keep the existing focus/blur event handling logic unchanged.
- **Rollback Plan**: Removing the `allowParentDrag()` call from the `useEffect` cleanup function allows for a quick rollback.

## Backporting
- **Not Required**: This is a bug fix for a new feature and does not involve backward compatibility.

## Related Issues / Links
- Affected files:
  - `PuppyFlow/app/components/tableComponent/JSONForm.tsx`
  - `PuppyFlow/app/components/workflow/blockNode/JsonNodeNew.tsx`

## Checklist
- [x] Confirmed minimal fix (adding only one line of code).
- [x] Verified fix does not affect existing functionality.
- [x] Manually tested various edge cases.
- [x] Confirmed rollback path is simple and clear.
- [ ] Added automated test coverage for this scenario (recommended for future).
