### PR TITLE
Feat(flow-ssr): structured HttpError + propagate upstream status/messages

### DIFF
--- a/PuppyFlow/app/api/workspace/[workspaceId]/rename/route.ts
+++ b/PuppyFlow/app/api/workspace/[workspaceId]/rename/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { getWorkspaceStore } from '@/lib/workspace';
 import { extractAuthHeader } from '@/lib/auth/http';
+import { normalizeError } from '@/lib/http/errors';
 
 export async function PUT(
   request: Request,
@@ -29,9 +30,13 @@ export async function PUT(
       workspace_name: updated.workspace_name,
     });
   } catch (error) {
+    const { status, message, details } = normalizeError(
+      error,
+      'Failed to rename workspace'
+    );
     return NextResponse.json(
-      { error: 'Failed to rename workspace' },
-      { status: 500 }
+      { error: 'Failed to rename workspace', message, details },
+      { status }
     );
   }
 }

--- a/PuppyFlow/app/api/workspace/[workspaceId]/route.ts
+++ b/PuppyFlow/app/api/workspace/[workspaceId]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { getWorkspaceStore } from '@/lib/workspace';
 import { extractAuthHeader } from '@/lib/auth/http';
+import { normalizeError } from '@/lib/http/errors';
 
 // 删除工作区
 export async function DELETE(
@@ -26,9 +27,13 @@ export async function DELETE(
       message: 'Workspace deleted successfully',
     });
   } catch (error) {
+    const { status, message, details } = normalizeError(
+      error,
+      'Failed to delete workspace'
+    );
     return NextResponse.json(
-      { success: false, error: 'Failed to delete workspace' },
-      { status: 500 }
+      { success: false, error: 'Failed to delete workspace', message, details },
+      { status }
     );
   }
 }

--- a/PuppyFlow/app/api/workspace/create/route.ts
+++ b/PuppyFlow/app/api/workspace/create/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { getWorkspaceStore } from '@/lib/workspace';
 import { getCurrentUserId } from '@/lib/auth/serverUser';
 import { extractAuthHeader } from '@/lib/auth/http';
+import { normalizeError } from '@/lib/http/errors';
 
 export async function POST(request: Request) {
   try {
@@ -26,13 +27,13 @@ export async function POST(request: Request) {
     );
     return NextResponse.json(created, { status: 200 });
   } catch (error) {
-    console.error('[API:/api/workspace/create] Failed:', {
-      message: (error as any)?.message,
-      stack: (error as any)?.stack,
-    });
+    const { status, message, details } = normalizeError(
+      error,
+      'Failed to create workspace'
+    );
     return NextResponse.json(
-      { error: 'Failed to create workspace' },
-      { status: 500 }
+      { error: 'Failed to create workspace', message, details },
+      { status }
     );
   }
 }

--- a/PuppyFlow/app/api/workspace/route.ts
+++ b/PuppyFlow/app/api/workspace/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { getWorkspaceStore } from '@/lib/workspace';
 import { extractAuthHeader } from '@/lib/auth/http';
 import { getCurrentUserId } from '@/lib/auth/serverUser';
+import { normalizeError } from '@/lib/http/errors';
 
 export const runtime = 'nodejs';
 
@@ -66,16 +67,13 @@ export async function POST(request: Request) {
     }
     return NextResponse.json({ success: true }, { status: 200 });
   } catch (error) {
-    console.error('[API:/api/workspace] Failed to save:', {
-      message: (error as any)?.message,
-      stack: (error as any)?.stack,
-    });
+    const { status, message, details } = normalizeError(
+      error,
+      'Failed to save workspace'
+    );
     return NextResponse.json(
-      {
-        success: false,
-        error: `Failed to save workspace`,
-      },
-      { status: 500 }
+      { success: false, error: 'Failed to save workspace', message, details },
+      { status }
     );
   }
 }
@@ -98,11 +96,13 @@ export async function GET(request: Request) {
     const data = await store.getLatestHistory(flowId, { authHeader });
     return NextResponse.json({ data });
   } catch (error) {
+    const { status, message, details } = normalizeError(
+      error,
+      'Failed to read workspace'
+    );
     return NextResponse.json(
-      {
-        error: `Failed to read workspace`,
-      },
-      { status: 500 }
+      { error: 'Failed to read workspace', message, details },
+      { status }
     );
   }
 }

--- a/PuppyFlow/lib/http/errors.ts
+++ b/PuppyFlow/lib/http/errors.ts
@@ -1,0 +1,67 @@
+export class HttpError extends Error {
+  status: number;
+  details?: any;
+
+  constructor(status: number, message: string, details?: any) {
+    super(message);
+    this.name = 'HttpError';
+    this.status = status;
+    this.details = details;
+  }
+}
+
+export async function buildHttpErrorFromResponse(
+  res: Response,
+  op: string,
+  url?: string
+): Promise<HttpError> {
+  let text = '';
+  let parsed: any = undefined;
+  try {
+    text = await res.text();
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      // not json
+    }
+  } catch {
+    // ignore
+  }
+
+  const message =
+    (parsed && (parsed.error || parsed.message)) ||
+    (text && text.substring(0, 400)) ||
+    `${op} failed`;
+
+  return new HttpError(res.status, message, {
+    url,
+    body: parsed ?? text ?? null,
+  });
+}
+
+export async function ensureOk(
+  res: Response,
+  ctx: { op: string; url?: string }
+): Promise<void> {
+  if (!res.ok) {
+    throw await buildHttpErrorFromResponse(res, ctx.op, ctx.url);
+  }
+}
+
+export function normalizeError(
+  err: any,
+  defaultMessage?: string
+): { status: number; message: string; details?: any } {
+  if (err && typeof err.status === 'number') {
+    return {
+      status: err.status,
+      message: err.message || defaultMessage || 'error',
+      details: err.details,
+    };
+  }
+  const message = (err && err.message) || defaultMessage || 'error';
+  const m = String(message).match(/\b(\d{3})\b/);
+  const n = m ? parseInt(m[1], 10) : NaN;
+  const status = Number.isInteger(n) && n >= 400 && n < 600 ? n : 500;
+  return { status, message };
+}

--- a/PuppyFlow/lib/workspace/userSystemStore.ts
+++ b/PuppyFlow/lib/workspace/userSystemStore.ts
@@ -1,5 +1,6 @@
 import { IWorkspaceStore, WorkspaceBasic } from './store';
 import { SERVER_ENV } from '@/lib/serverEnv';
+import { ensureOk, HttpError } from '@/lib/http/errors';
 
 function authHeaders(authHeader?: string): HeadersInit {
   const headers: Record<string, string> = {
@@ -23,7 +24,7 @@ export class UserSystemWorkspaceStore implements IWorkspaceStore {
       headers: authHeaders(opts?.authHeader),
       credentials: 'include',
     });
-    if (!res.ok) throw new Error(`listWorkspaces failed: ${res.status}`);
+    await ensureOk(res, { op: 'listWorkspaces', url });
     const json = await res.json();
     return (json.workspaces || []) as WorkspaceBasic[];
   }
@@ -40,7 +41,7 @@ export class UserSystemWorkspaceStore implements IWorkspaceStore {
       credentials: 'include',
       body: JSON.stringify(payload),
     });
-    if (!res.ok) throw new Error(`createWorkspace failed: ${res.status}`);
+    await ensureOk(res, { op: 'createWorkspace', url });
     const json = await res.json();
     return {
       workspace_id: json.workspace_id,
@@ -58,7 +59,7 @@ export class UserSystemWorkspaceStore implements IWorkspaceStore {
       headers: authHeaders(opts?.authHeader),
       credentials: 'include',
     });
-    if (!res.ok) throw new Error(`deleteWorkspace failed: ${res.status}`);
+    await ensureOk(res, { op: 'deleteWorkspace', url });
   }
 
   async renameWorkspace(
@@ -73,7 +74,7 @@ export class UserSystemWorkspaceStore implements IWorkspaceStore {
       credentials: 'include',
       body: JSON.stringify({ new_name: newName }),
     });
-    if (!res.ok) throw new Error(`renameWorkspace failed: ${res.status}`);
+    await ensureOk(res, { op: 'renameWorkspace', url });
     const json = await res.json();
     return {
       workspace_id: json.workspace_id,
@@ -92,7 +93,7 @@ export class UserSystemWorkspaceStore implements IWorkspaceStore {
       credentials: 'include',
     });
     if (res.status === 204) return null;
-    if (!res.ok) throw new Error(`getLatestHistory failed: ${res.status}`);
+    await ensureOk(res, { op: 'getLatestHistory', url });
     const json = await res.json();
     return json.history ?? null;
   }
@@ -112,6 +113,6 @@ export class UserSystemWorkspaceStore implements IWorkspaceStore {
         timestamp: data.timestamp,
       }),
     });
-    if (!res.ok) throw new Error(`addHistory failed: ${res.status}`);
+    await ensureOk(res, { op: 'addHistory', url });
   }
 }


### PR DESCRIPTION
Best-practice error handling for workspace SSR APIs:\n\n- Add HttpError helper (status, details)\n- WorkspaceStore uses ensureOk() to throw structured errors\n- SSR routes (create/delete/rename/save/get) call normalizeError() to return upstream status + message\n- Early validation remains (400 for missing fields)\n- Improves debuggability; no more blanket 500s