### PR TITLE
fix(workspace): force Node runtime, add auth diagnostics, handle 204 list

### DIFF
--- a/PuppyFlow/app/api/workspace/create/route.ts
+++ b/PuppyFlow/app/api/workspace/create/route.ts
@@ -3,6 +3,8 @@ import { getWorkspaceStore } from '@/lib/workspace';
 import { getCurrentUserId } from '@/lib/auth/serverUser';
 import { extractAuthHeader } from '@/lib/auth/http';
 
+export const runtime = 'nodejs';
+
 export async function POST(request: Request) {
   try {
     const userId = await getCurrentUserId(request);

--- a/PuppyFlow/lib/auth/serverUser.ts
+++ b/PuppyFlow/lib/auth/serverUser.ts
@@ -1,5 +1,5 @@
-import { cookies } from 'next/headers';
 import { SERVER_ENV } from '@/lib/serverEnv';
+import { extractAuthHeader } from '@/lib/auth/http';
 
 export async function getCurrentUserId(request: Request): Promise<string> {
   // Non-cloud deployments do not require user verification
@@ -17,23 +17,11 @@ export async function getCurrentUserId(request: Request): Promise<string> {
     );
   }
 
-  let authHeader = request.headers.get('authorization');
+  const authHeader = extractAuthHeader(request);
   if (!authHeader) {
-    try {
-      const token = cookies().get(SERVER_ENV.AUTH_COOKIE_NAME)?.value;
-      if (token) authHeader = `Bearer ${token}`;
-    } catch {
-      const rawCookie = request.headers.get('cookie') || '';
-      const name = SERVER_ENV.AUTH_COOKIE_NAME.replace(
-        /[-[\]{}()*+?.,\\^$|#\s]/g,
-        '\\$&'
-      );
-      const match = rawCookie.match(new RegExp(`(?:^|;\\s*)${name}=([^;]+)`));
-      if (match) authHeader = `Bearer ${decodeURIComponent(match[1])}`;
-    }
+    console.warn('[Auth] getCurrentUserId: no auth header derived');
+    throw new Error('No auth token');
   }
-
-  if (!authHeader) throw new Error('No auth token');
 
   // Cloud mode: Call internal verify endpoint
   const url = new URL('/api/auth/verify', request.url).toString();
@@ -46,14 +34,29 @@ export async function getCurrentUserId(request: Request): Promise<string> {
     verifyHeaders['x-service-key'] = SERVER_ENV.SERVICE_KEY;
   }
 
-  const res = await fetch(url, {
-    method: 'GET',
-    headers: verifyHeaders,
-  });
-  if (!res.ok) throw new Error(`verify failed: ${res.status}`);
+  try {
+    console.info('[Auth] verify start', {
+      url,
+      headerKeys: Object.keys(verifyHeaders),
+      mode: (process.env.DEPLOYMENT_MODE || '').toLowerCase(),
+    });
+    const res = await fetch(url, {
+      method: 'GET',
+      headers: verifyHeaders,
+    });
+    if (!res.ok) throw new Error(`verify failed: ${res.status}`);
 
-  const body = await res.json();
-  const userId = body?.user_id || body?.user?.user_id || body?.userId;
-  if (!userId) throw new Error('user_id not found from verify');
-  return String(userId);
+    const body = await res.json();
+    const userId = body?.user_id || body?.user?.user_id || body?.userId;
+    if (!userId) throw new Error('user_id not found from verify');
+    return String(userId);
+  } catch (err: any) {
+    const code = err?.cause?.code || err?.code;
+    console.error('[Auth] verify failed', {
+      url,
+      code,
+      message: err?.message,
+    });
+    throw err;
+  }
 }


### PR DESCRIPTION
## Issue Summary
Workspace create/list/save failing in cloud due to auth/runtime nuances. Added Node runtime pin for create route, defensive 204 handling for list, and minimal diagnostics for auth verification and createWorkspace fetch to isolate root cause (token extraction, verify call, or network layer).

## Reproduction Steps
- Cloud env (Railway): client POST /api/workspace/create returns 500
- GET /api/workspace/list returned 500 (noise from 204 unhandled)
- POST /api/workspace save with implicit create failed with 500

## Root Cause Analysis
- Multiple suspects: edge runtime differences, missing 204 handling, getCurrentUserId failing to derive token or verify network failing. Diagnostics needed to pinpoint.

## Fix Strategy
- Pin /api/workspace/create to runtime='nodejs' to avoid edge egress variance
- In listWorkspaces, map 204 to []
- Add minimal logs (url, headerKeys, err.cause?.code) in createWorkspace and getCurrentUserId verify path

## Verification
- Lint passes
- Local cloud-sim validates flows; cloud deploy to confirm via new logs

## Risk & Mitigations
- Logs exclude sensitive values; only keys and error codes
- Behavior changes are safe: runtime pin, 204→[]

## Related Issues / Links
- N/A

## Checklist
- [x] Repro covered by manual steps
- [x] Regression: list no longer 500 on 204
- [x] Monitoring: diagnostics logs added
- [x] Rollback safe: revert branch
