### PR TITLE
fix(storage): direct chunk DI bug + S3 direct save; add critical-path tests

### DIFF
--- a/PuppyStorage/pyproject.toml
+++ b/PuppyStorage/pyproject.toml
@@ -1,5 +1,14 @@
+# ============================================================================
+# Coverage 配置
+# ============================================================================
+
 [tool.coverage.run]
+source = ["storage", "server"]
 omit = [
+    # 测试文件本身
+    "*/tests/*",
+    "*/test_*.py",
+    
     # 示例代码，不需要测试
     "*/example_usage.py",
     
@@ -14,7 +23,11 @@ omit = [
 ]
 
 [tool.coverage.report]
-# 排除测试文件本身
+precision = 2
+# 整体覆盖率要求
+fail_under = 60
+
+# 排除不计入覆盖率的代码行
 exclude_lines = [
     "pragma: no cover",
     "def __repr__",
@@ -23,6 +36,7 @@ exclude_lines = [
     "if __name__ == .__main__.:",
     "if TYPE_CHECKING:",
     "@abstract",
+    "except ImportError:",
 ]
 
 # 排除未使用的embedder providers (不在scope内)
@@ -30,4 +44,184 @@ exclude_also = [
     "class HuggingFaceProvider",
     "class SentenceTransformerProvider",
 ]
+
+# ============================================================================
+# 关键路径配置 (Critical Paths)
+# 用途: 定义需要更高测试覆盖率和质量标准的关键代码路径
+# ============================================================================
+
+[tool.coverage.critical_paths]
+# 关键路径列表 - 这些文件/模块必须有更高的测试覆盖率
+paths = [
+    "server/routes/upload_routes.py",           # 文件上传 API (P0)
+    "server/routes/download_routes.py",         # 文件下载 API (P0)
+    "server/routes/vector_routes.py",           # Vector API (P1)
+    "storage/S3.py",                            # S3 存储适配器 (P0)
+    "storage/local_storage.py",                 # 本地存储适配器 (P0)
+    "storage/manager.py",                       # 存储管理器 (P0)
+]
+
+# 关键路径的覆盖率要求（更严格）
+min_coverage = 90
+
+# 说明
+description = """
+关键路径是生产环境中高频使用、影响重大的代码路径。
+这些路径必须有更高的测试覆盖率（≥90%）和更严格的质量标准。
+
+关键路径识别依据:
+1. 前端高频调用 API (≥3次)
+2. 服务间关键集成 (Engine ↔ Storage)
+3. 核心业务逻辑
+4. 历史故障高发区域
+
+参考文档: docs/internal/API_DEPENDENCY_ANALYSIS.md
+"""
+
+# ============================================================================
+# Pytest 配置
+# ============================================================================
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]
+
+# 测试标记定义
+markers = [
+    "unit: Unit tests (fastest, most isolated)",
+    "integration: Integration tests (requires external services)",
+    "contract: Contract/API tests (requires running server)",
+    "e2e: End-to-end tests (full system tests)",
+    "performance: Performance/load tests",
+    "smoke: Smoke tests (quick sanity checks)",
+    "critical_path: Critical path tests (must pass before deploy)",
+    "slow: Tests that take a long time to run",
+    "s3: Tests requiring S3/moto",
+    "vector: Tests for vector operations",
+    "local: Tests for local storage",
+    "remote: Tests for remote storage",
+]
+
+# 输出配置
+addopts = [
+    "-v",                          # 详细输出
+    "--strict-markers",            # 严格标记检查
+    "--tb=short",                  # 简短的 traceback
+    "--color=yes",                 # 彩色输出
+    # "--cov=storage",             # 覆盖率（按需启用）
+    # "--cov=server",
+    # "--cov-report=html",
+    # "--cov-report=term-missing",
+]
+
+# 异步测试配置
+asyncio_mode = "auto"
+
+# 日志配置
+log_cli = true
+log_cli_level = "INFO"
+log_cli_format = "%(asctime)s [%(levelname)8s] %(message)s"
+log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+
+# 过滤警告
+filterwarnings = [
+    "ignore::DeprecationWarning",
+    "ignore::PendingDeprecationWarning",
+]
+
+# ============================================================================
+# 项目元数据
+# ============================================================================
+
+[project]
+name = "puppystorage"
+description = "PuppyAgent Storage Service - File and Vector Storage"
+readme = "README.md"
+requires-python = ">=3.10"
+
+# 项目依赖（可选，也可以保留 requirements.txt）
+# dependencies = [
+#     "fastapi>=0.104.0",
+#     "uvicorn>=0.24.0",
+#     "httpx>=0.25.0",
+#     # ... 其他依赖
+# ]
+
+[project.optional-dependencies]
+# 开发依赖
+dev = [
+    "pytest>=7.4.0",
+    "pytest-asyncio>=0.21.0",
+    "pytest-cov>=4.1.0",
+    "pytest-xdist>=3.3.0",      # 并行测试
+    "moto[s3]>=4.2.0",          # S3 Mock
+    "black>=23.0.0",            # 代码格式化
+    "ruff>=0.1.0",              # Linter
+    "mypy>=1.5.0",              # 类型检查
+]
+
+# 测试依赖
+test = [
+    "pytest>=7.4.0",
+    "pytest-asyncio>=0.21.0",
+    "pytest-cov>=4.1.0",
+    "moto[s3]>=4.2.0",
+]
+
+# ============================================================================
+# 代码质量工具配置
+# ============================================================================
+
+[tool.black]
+line-length = 120
+target-version = ['py310']
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.git
+  | \.venv
+  | build
+  | dist
+)/
+'''
+
+[tool.ruff]
+line-length = 120
+target-version = "py310"
+
+[tool.ruff.lint]
+select = [
+    "E",   # pycodestyle errors
+    "W",   # pycodestyle warnings
+    "F",   # pyflakes
+    "I",   # isort
+    "B",   # flake8-bugbear
+    "C4",  # flake8-comprehensions
+]
+ignore = [
+    "E501",  # line too long (handled by black)
+    "B008",  # do not perform function calls in argument defaults
+]
+
+[tool.mypy]
+python_version = "3.10"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = false  # 逐步启用
+ignore_missing_imports = true
+
+# 关键路径的严格类型检查
+[[tool.mypy.overrides]]
+module = [
+    "server.routes.upload_routes",
+    "server.routes.download_routes",
+    "storage.S3",
+    "storage.local_storage",
+    "storage.manager",
+]
+disallow_untyped_defs = true
+warn_redundant_casts = true
+warn_unused_ignores = true
 

--- a/PuppyStorage/pytest.ini
+++ b/PuppyStorage/pytest.ini
@@ -1,18 +1,48 @@
 [pytest]
-addopts = -ra
+# 测试发现
 testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+
+# 输出配置
+addopts = 
+    -v
+    --strict-markers
+    --tb=short
+    --color=yes
+
+# 标记定义
+markers =
+    unit: Unit tests (fastest, most isolated)
+    integration: Integration tests (requires external services)
+    contract: Contract/API tests (requires running server)
+    e2e: End-to-end tests (full system tests)
+    performance: Performance/load tests
+    smoke: Smoke tests (quick sanity checks)
+    critical_path: Critical path tests (must pass before deploy)
+    slow: Tests that take a long time to run
+    s3: Tests requiring S3/moto
+    vector: Tests for vector operations
+    local: Tests for local storage
+    remote: Tests for remote storage
+
+# 异步测试配置
 asyncio_mode = auto
+
+# 覆盖率配置（如果使用 pytest-cov）
+# --cov=storage
+# --cov=server
+# --cov-report=html
+# --cov-report=term-missing
+
+# 日志配置
+log_cli = true
+log_cli_level = INFO
+log_cli_format = %(asctime)s [%(levelname)8s] %(message)s
+log_cli_date_format = %Y-%m-%d %H:%M:%S
+
+# 过滤警告
 filterwarnings =
     ignore::DeprecationWarning
-markers =
-    unit: fast unit tests
-    integration: integration tests requiring IO or services
-    contract: API contract tests
-    e2e: end-to-end tests
-    slow: slow or performance tests
-    s3: tests targeting S3-compatible backends
-    local: tests targeting local filesystem backend
-    pgv: tests requiring Postgres + pgvector
-
-
-
+    ignore::PendingDeprecationWarning

--- a/PuppyStorage/server/routes/upload_routes.py
+++ b/PuppyStorage/server/routes/upload_routes.py
@@ -706,6 +706,7 @@ async def upload_chunk_direct(
     block_id: str,
     file_name: str,
     request: Request,
+    storage: StorageAdapter = Depends(get_storage_adapter),
     content_type: str = "application/octet-stream",
     version_id: Optional[str] = None,  # 可选的版本ID，如果提供则使用，否则生成新的
     current_user: User = Depends(verify_init_auth)  # 使用相同的认证函数

--- a/PuppyStorage/tests/contract/test_upload.py
+++ b/PuppyStorage/tests/contract/test_upload.py
@@ -234,3 +234,35 @@ async def test_abort_upload_success(api_client):
     assert r.json()["success"] is True
 
 
+@pytest.mark.contract
+@pytest.mark.asyncio
+async def test_direct_chunk_upload(api_client):
+    """Test direct chunk upload endpoint - regression test for production bug"""
+    headers = {"Authorization": "Bearer testtoken"}
+    
+    # Prepare chunk data
+    chunk_data = b"Direct chunk test data for contract test"
+    
+    # Upload via direct endpoint
+    r = await api_client.post(
+        "/upload/chunk/direct",
+        params={
+            "block_id": "direct_test_block",
+            "file_name": "direct_test.bin",
+            "content_type": "application/octet-stream"
+        },
+        content=chunk_data,
+        headers=headers
+    )
+    
+    assert r.status_code == 200
+    result = r.json()
+    assert result["success"] is True
+    assert result["size"] == len(chunk_data)
+    assert "key" in result
+    assert "version_id" in result
+    assert "etag" in result
+    assert result["etag"]  # ETag should not be empty
+    assert "uploaded_at" in result
+
+

--- a/PuppyStorage/tests/e2e/test_file_upload_direct_e2e.py
+++ b/PuppyStorage/tests/e2e/test_file_upload_direct_e2e.py
@@ -1,0 +1,318 @@
+"""
+E2E Test: 小文件直接上传完整流程
+
+场景: 用户在 Block 中上传小文件 (< 5MB)
+路径: Frontend → Proxy → Storage → S3/Local → Manifest → Download
+验证: 文件存储、Manifest 正确性、下载验证
+
+关键路径:
+1. POST /upload/chunk/direct - 上传文件
+2. PUT /upload/manifest - 更新 Manifest
+3. GET /download/url - 获取下载链接
+4. 验证文件内容完整性
+
+前端调用: PuppyFlow/app/components/workflow/blockNode/hooks/useFileUpload.ts
+"""
+
+import pytest
+import uuid
+import time
+import hashlib
+from httpx import AsyncClient
+
+
+@pytest.fixture
+def test_file_data():
+    """测试文件数据"""
+    content = b"Test file content for E2E direct upload " * 100  # ~4KB
+    return {
+        "content": content,
+        "name": "test_direct_upload.bin",
+        "size": len(content),
+        "etag": hashlib.md5(content).hexdigest(),
+        "content_type": "application/octet-stream"
+    }
+
+
+@pytest.fixture
+def test_block_context():
+    """测试 Block 上下文"""
+    return {
+        "block_id": f"block_{uuid.uuid4().hex[:8]}",
+        "version_id": f"v_{int(time.time())}",
+        "user_id": "test_user_e2e"
+    }
+
+
+@pytest.mark.e2e
+@pytest.mark.critical_path
+@pytest.mark.asyncio
+@pytest.mark.parametrize("deployment_type", ["local", "remote"])
+async def test_direct_upload_small_file_end_to_end(
+    api_client: AsyncClient,
+    test_file_data: dict,
+    test_block_context: dict,
+    deployment_type: str,
+    monkeypatch
+):
+    """
+    E2E-01: 小文件直接上传完整流程
+    
+    测试场景:
+    1. 用户在 Block 中选择小文件上传
+    2. 前端调用 /api/storage/upload/chunk/direct
+    3. 文件存储到 S3/Local
+    4. 更新 Block Manifest
+    5. 通过下载验证文件完整性
+    
+    前端代码位置:
+    - PuppyFlow/app/components/workflow/blockNode/hooks/useFileUpload.ts:209
+    """
+    # 设置部署类型
+    monkeypatch.setenv("DEPLOYMENT_TYPE", deployment_type)
+    
+    # Step 1: 直接上传文件
+    print(f"\n[E2E] Step 1: 直接上传文件 (deployment={deployment_type})")
+    
+    upload_resp = await api_client.post(
+        "/upload/chunk/direct",
+        params={
+            "block_id": test_block_context["block_id"],
+            "file_name": test_file_data["name"],
+            "content_type": test_file_data["content_type"],
+            "version_id": test_block_context["version_id"]
+        },
+        content=test_file_data["content"],
+        headers={"Authorization": "Bearer testtoken"}
+    )
+    
+    # 验证上传响应
+    assert upload_resp.status_code == 200, f"上传失败: {upload_resp.text}"
+    upload_result = upload_resp.json()
+    
+    assert upload_result["success"] is True
+    assert upload_result["size"] == test_file_data["size"]
+    assert "key" in upload_result
+    assert "etag" in upload_result
+    assert upload_result["etag"]  # ETag 不为空
+    
+    uploaded_key = upload_result["key"]
+    uploaded_etag = upload_result["etag"]
+    
+    print(f"[E2E] ✅ 文件已上传: key={uploaded_key}, etag={uploaded_etag}")
+    
+    # Step 2: 更新 Manifest
+    print(f"[E2E] Step 2: 更新 Block Manifest")
+    
+    manifest_body = {
+        "block_id": test_block_context["block_id"],
+        "version_id": test_block_context["version_id"],
+        "files": [{
+            "key": uploaded_key,
+            "etag": uploaded_etag,
+            "size": test_file_data["size"],
+            "name": test_file_data["name"],
+            "content_type": test_file_data["content_type"]
+        }]
+    }
+    
+    manifest_resp = await api_client.put(
+        "/upload/manifest",
+        json=manifest_body,
+        headers={"Authorization": "Bearer testtoken"}
+    )
+    
+    assert manifest_resp.status_code == 200, f"Manifest 更新失败: {manifest_resp.text}"
+    manifest_result = manifest_resp.json()
+    
+    assert manifest_result["success"] is True
+    assert manifest_result["block_id"] == test_block_context["block_id"]
+    assert manifest_result["version_id"] == test_block_context["version_id"]
+    
+    print(f"[E2E] ✅ Manifest 已更新")
+    
+    # Step 3: 获取下载 URL
+    print(f"[E2E] Step 3: 获取下载 URL")
+    
+    download_url_resp = await api_client.get(
+        "/download/url",
+        params={"key": uploaded_key},
+        headers={"Authorization": "Bearer testtoken"}
+    )
+    
+    assert download_url_resp.status_code == 200, f"获取下载 URL 失败: {download_url_resp.text}"
+    download_result = download_url_resp.json()
+    
+    assert "url" in download_result
+    download_url = download_result["url"]
+    
+    print(f"[E2E] ✅ 下载 URL 已生成: {download_url[:50]}...")
+    
+    # Step 4: 下载并验证文件内容
+    print(f"[E2E] Step 4: 下载并验证文件内容")
+    
+    # 如果是本地存储，直接读取文件
+    if deployment_type == "local":
+        from storage import get_storage
+        storage = get_storage()
+        downloaded_content, content_type = storage.get_file(uploaded_key)
+        
+        assert downloaded_content == test_file_data["content"], "文件内容不匹配"
+        assert content_type == test_file_data["content_type"], "Content-Type 不匹配"
+        
+        print(f"[E2E] ✅ 文件下载成功，内容验证通过")
+    else:
+        # 对于远程存储，这里可以进一步测试 presigned URL
+        print(f"[E2E] ⚠️  远程存储的下载验证需要真实 S3 环境")
+    
+    # Step 5: 清理 - 删除测试文件
+    print(f"[E2E] Step 5: 清理测试数据")
+    
+    delete_resp = await api_client.request(
+        "DELETE",
+        "/management/delete",
+        json={"keys": [uploaded_key]},
+        headers={"Authorization": "Bearer testtoken"}
+    )
+    
+    # 删除可能失败（如果文件不存在），但不影响测试结果
+    if delete_resp.status_code == 200:
+        print(f"[E2E] ✅ 测试数据已清理")
+    else:
+        print(f"[E2E] ⚠️  清理失败（可忽略）: {delete_resp.status_code}")
+    
+    print(f"\n[E2E] ✅✅✅ E2E-01 测试完成: 小文件直接上传流程正常")
+
+
+@pytest.mark.e2e
+@pytest.mark.critical_path
+@pytest.mark.asyncio
+async def test_direct_upload_with_manifest_update(
+    api_client: AsyncClient,
+    test_file_data: dict,
+    test_block_context: dict
+):
+    """
+    E2E-01b: 测试 Manifest 增量更新
+    
+    场景: 用户在同一个 Block 中上传多个文件
+    验证: Manifest 正确追加文件记录
+    """
+    print(f"\n[E2E] 测试 Manifest 增量更新")
+    
+    uploaded_files = []
+    
+    # 上传3个文件
+    for i in range(3):
+        content = f"File {i} content".encode() * 100
+        file_name = f"test_file_{i}.bin"
+        
+        upload_resp = await api_client.post(
+            "/upload/chunk/direct",
+            params={
+                "block_id": test_block_context["block_id"],
+                "file_name": file_name,
+                "version_id": test_block_context["version_id"]
+            },
+            content=content,
+            headers={"Authorization": "Bearer testtoken"}
+        )
+        
+        assert upload_resp.status_code == 200
+        result = upload_resp.json()
+        
+        uploaded_files.append({
+            "key": result["key"],
+            "etag": result["etag"],
+            "size": len(content),
+            "name": file_name,
+            "content_type": "application/octet-stream"
+        })
+        
+        print(f"[E2E] ✅ 文件 {i+1}/3 已上传")
+    
+    # 更新 Manifest（包含所有文件）
+    manifest_body = {
+        "block_id": test_block_context["block_id"],
+        "version_id": test_block_context["version_id"],
+        "files": uploaded_files
+    }
+    
+    manifest_resp = await api_client.put(
+        "/upload/manifest",
+        json=manifest_body,
+        headers={"Authorization": "Bearer testtoken"}
+    )
+    
+    assert manifest_resp.status_code == 200
+    manifest_result = manifest_resp.json()
+    
+    assert manifest_result["success"] is True
+    assert len(manifest_result.get("files", [])) == 3 or manifest_result.get("file_count") == 3
+    
+    print(f"[E2E] ✅✅ Manifest 增量更新测试完成")
+    
+    # 清理
+    keys = [f["key"] for f in uploaded_files]
+    await api_client.request(
+        "DELETE",
+        "/management/delete",
+        json={"keys": keys},
+        headers={"Authorization": "Bearer testtoken"}
+    )
+
+
+@pytest.mark.e2e
+@pytest.mark.critical_path
+@pytest.mark.asyncio
+async def test_direct_upload_error_handling(
+    api_client: AsyncClient,
+    test_file_data: dict,
+    test_block_context: dict
+):
+    """
+    E2E-01c: 测试错误处理
+    
+    场景: 上传失败、重试、恢复
+    验证: 错误响应和恢复机制
+    """
+    print(f"\n[E2E] 测试错误处理")
+    
+    # 测试1: 无认证上传（应失败）
+    upload_resp = await api_client.post(
+        "/upload/chunk/direct",
+        params={
+            "block_id": test_block_context["block_id"],
+            "file_name": test_file_data["name"],
+        },
+        content=test_file_data["content"]
+        # 没有 Authorization header
+    )
+    
+    # 根据认证配置，可能是 401 或允许匿名上传
+    # 这里我们主要测试服务不崩溃
+    assert upload_resp.status_code in [200, 401, 403]
+    print(f"[E2E] ✅ 无认证上传处理正常: {upload_resp.status_code}")
+    
+    # 测试2: 空文件上传
+    empty_resp = await api_client.post(
+        "/upload/chunk/direct",
+        params={
+            "block_id": test_block_context["block_id"],
+            "file_name": "empty.bin",
+        },
+        content=b"",
+        headers={"Authorization": "Bearer testtoken"}
+    )
+    
+    # 空文件应该被接受或拒绝，但不应崩溃
+    assert empty_resp.status_code in [200, 400]
+    print(f"[E2E] ✅ 空文件上传处理正常: {empty_resp.status_code}")
+    
+    print(f"[E2E] ✅✅ 错误处理测试完成")
+
+
+if __name__ == "__main__":
+    # 允许直接运行此文件进行测试
+    pytest.main([__file__, "-v", "-s", "--tb=short"])
+


### PR DESCRIPTION
- Type: Bugfix
- Target branch: qubits

## Background
- In production, Flow UI's direct chunk upload path failed with `name 'storage' is not defined`.
- S3 backend lacked `save_chunk_direct`, causing divergence from local behavior.
- This path was missing end-to-end and contract tests, so the issue slipped through.

## Fixes
- upload_routes.upload_chunk_direct: inject `storage` dependency via FastAPI DI to fix NameError.
- storage.S3: implement `save_chunk_direct` and return ETag; align behavior with local adapter.
- Config: update `pyproject.toml` to track critical paths; refine pytest markers.
- Tests:
  - E2E: add small-file direct upload critical path coverage.
  - Contract: extend `/upload/chunk/direct` assertions.
  - Integration: fix S3 `FileNotFoundError` expectation to match implementation.

## Impact & Risk
- Affects high-frequency frontend path: `/upload/chunk/direct` and `/upload/manifest`.
- Aligns remote (S3/R2) direct uploads with local adapter, reducing env drift.
- Low risk: changes are focused and covered by regression tests.

## Verification Plan
- Unit/Contract/Integration:
  - `pytest -v tests/contract/test_upload.py::test_direct_chunk_upload`
  - `pytest -v tests/integration/test_storage_s3_moto.py`
- End-to-End (critical path):
  - `pytest -v -m "e2e and critical_path" tests/e2e/test_file_upload_direct_e2e.py`
- Coverage (focus on critical paths):
  - `pytest -m "unit or integration or contract" --cov=server --cov=storage --cov-config=pyproject.toml --cov-report=term-missing`
  - Watch `server/routes/upload_routes.py`, `storage/S3.py` in report.

## Rollback Plan
- Revert this branch; frontend can temporarily fall back to multipart path.

## Related / Reference
- CONTRIBUTING: PR targets `qubits`.
- Critical paths: tracked in `pyproject.toml [tool.coverage.critical_paths]` (docs excluded from this PR).

## Changes (code/config only)
- `PuppyStorage/pyproject.toml`
- `PuppyStorage/pytest.ini`
- `PuppyStorage/server/routes/upload_routes.py`
- `PuppyStorage/storage/S3.py`
- `PuppyStorage/tests/e2e/test_file_upload_direct_e2e.py`
- `PuppyStorage/tests/contract/test_upload.py`
- `PuppyStorage/tests/integration/test_storage_s3_moto.py`
