### PR TITLE
🙈 Hide deep research temporarily

### DIFF
--- a/PuppyFlow/app/components/workflow/edgesNode/edgeNodesNew/edgemenunode/EdgeTypeMenu.tsx
+++ b/PuppyFlow/app/components/workflow/edgesNode/edgeNodesNew/edgemenunode/EdgeTypeMenu.tsx
@@ -113,18 +113,19 @@ const MENU_CONFIG: {
           },
         ],
       },
-      {
-        key: 'deepresearch',
-        label: 'Deep Research',
-        items: [
-          {
-            key: 'deepresearch',
-            label: 'Deep Research',
-            description: 'Plan & research',
-            onPickEdgeType: 'deepresearch',
-          },
-        ],
-      },
+      // Temporarily hidden - Deep Research section
+      // {
+      //   key: 'deepresearch',
+      //   label: 'Deep Research',
+      //   items: [
+      //     {
+      //       key: 'deepresearch',
+      //       label: 'Deep Research',
+      //       description: 'Plan & research',
+      //       onPickEdgeType: 'deepresearch',
+      //     },
+      //   ],
+      // },
       {
         key: 'search',
         label: 'Searching',


### PR DESCRIPTION
## Summary
Temporarily hide the Deep Research menu option from the Edge Type Menu while keeping the implementation intact for future re-enablement.

## Background & Motivation
- The Deep Research feature needs to be temporarily hidden from the user interface while development/testing is ongoing
- Rather than deleting the code, we want to maintain it in a commented state for easy restoration
- This prevents users from accessing an incomplete or under-development feature

## Goals / Non-goals
- Goals:
  - Hide Deep Research menu item from the Edge Type Menu UI
  - Preserve all implementation code for future re-enablement
  - Maintain clean menu structure with other options (Processing, RAG, Searching, Others)
- Non-goals:
  - Removing Deep Research backend functionality
  - Modifying any other menu sections

## Proposed Changes
- Commented out the Deep Research section in the `MENU_CONFIG.default.sections` array (lines 116-128)
- No changes to icon registry or other supporting code
- Menu now displays: Processing, RAG, Searching, and Others sections only

## UX / UI
- **Before**: Menu showed Processing, RAG, Deep Research, Searching, Others
- **After**: Menu shows Processing, RAG, Searching, Others (Deep Research hidden)
- No breaking changes to existing workflows or user interactions
- Users will not see the "Deep Research" option when creating edges

## Breaking Changes
- None. This only affects menu visibility, not functionality of existing features

## Test Plan
- Manual verification:
  - Open Edge Type Menu from any block node
  - Verify Deep Research section is not visible
  - Verify all other menu sections (Processing, RAG, Searching, Others) still work correctly
- Edge cases:
  - Existing workflows with Deep Research edges should continue to function (backend unchanged)

## Rollout Plan
- Direct deployment - no feature flags needed
- To re-enable: simply uncomment lines 116-128 in EdgeTypeMenu.tsx

## Metrics & Monitoring
- No metrics changes needed - this is a simple UI hide

## Related Issues / Links
- N/A

## Checklist
- [x] Tests added/updated - Manual testing sufficient for UI-only change
- [x] Docs updated - Code comments added explaining temporary hide
- [x] Backward compatible - Yes, no breaking changes
- [x] Security/privacy reviewed - Not applicable

---

**File Changed:**
- `PuppyFlow/app/components/workflow/edgesNode/edgeNodesNew/edgemenunode/EdgeTypeMenu.tsx`