### PR TITLE
chore(ci): increase coverage threshold from 59% to 67%

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -91,7 +91,7 @@ jobs:
             --cov-report=term-missing \
             --cov-report=html \
             --cov-report=json \
-            --cov-fail-under=59
+            --cov-fail-under=67
 
       - name: Upload coverage reports
         if: always()
@@ -116,7 +116,7 @@ jobs:
             try {
               const coverage = JSON.parse(fs.readFileSync('PuppyStorage/coverage.json', 'utf8'));
               const total = coverage.totals.percent_covered.toFixed(2);
-              const body = `## Coverage Report\n\n**Total Coverage**: ${total}%\n\n${total >= 59 ? '✅' : '❌'} Coverage threshold: 59% (temporary; target: 70%)`;
+              const body = `## Coverage Report\n\n**Total Coverage**: ${total}%\n\n${total >= 67 ? '✅' : '❌'} Coverage threshold: 67% (target: 70%)`;
               
               github.rest.issues.createComment({
                 issue_number: context.issue.number,


### PR DESCRIPTION
## Summary
Increase coverage threshold to better reflect actual test coverage stability.

## Analysis
- **Current coverage**: Stable at 68.28% (last 10 runs)
- **Previous threshold**: 59% (too low, 9% safety margin)
- **New threshold**: 67% (reasonable 1-2% buffer)
- **Target**: 70% (progressive approach)

## Evidence
Based on analysis of last 10 CI runs:
- All successful runs achieved 68.28-68.29% coverage
- No coverage drops below 68%
- 59% threshold was not providing meaningful quality gate

## Next Steps
- Monitor for 1-2 weeks to ensure stability
- Consider further increase to 70% target if stable

## Checklist
- [x] Analyzed recent CI runs
- [x] Updated pytest --cov-fail-under flag
- [x] Updated PR comment threshold message
- [x] Documented rationale in commit message