### PR TITLE
🔧 avatar display

### DIFF
--- a/frontend/app/connect/page.tsx
+++ b/frontend/app/connect/page.tsx
@@ -76,6 +76,12 @@ export default function ConnectPage() {
   }, [activeBase])
 
   const userInitial = session?.user?.email?.[0]?.toUpperCase() || 'U'
+  const userMetadata = session?.user?.user_metadata as Record<string, any> | undefined
+  const userAvatarUrl =
+    userMetadata?.avatar_url ||
+    userMetadata?.picture ||
+    userMetadata?.avatarUrl ||
+    null
 
   const pathSegments = useMemo(() => {
     const segments: Array<{ label: string; path: string }> = []
@@ -140,6 +146,7 @@ export default function ConnectPage() {
         utilityNav={utilityNav}
         onUtilityNavClick={handleUtilityNavClick}
         userInitial={userInitial}
+        userAvatarUrl={userAvatarUrl ?? undefined}
         loading={loading}
       />
 

--- a/frontend/app/mcp/page.tsx
+++ b/frontend/app/mcp/page.tsx
@@ -72,6 +72,12 @@ export default function McpPage() {
   }, [activeBase])
 
   const userInitial = session?.user?.email?.[0]?.toUpperCase() || 'U'
+  const userMetadata = session?.user?.user_metadata as Record<string, any> | undefined
+  const userAvatarUrl =
+    userMetadata?.avatar_url ||
+    userMetadata?.picture ||
+    userMetadata?.avatarUrl ||
+    null
 
   const handleProjectSelect = (projectId: string) => {
     setActiveBaseId(projectId)
@@ -114,6 +120,7 @@ export default function McpPage() {
         utilityNav={utilityNav}
         onUtilityNavClick={handleUtilityNavClick}
         userInitial={userInitial}
+        userAvatarUrl={userAvatarUrl ?? undefined}
         loading={loading}
       />
 

--- a/frontend/app/projects/[[...slug]]/page.tsx
+++ b/frontend/app/projects/[[...slug]]/page.tsx
@@ -219,6 +219,12 @@ export default function ProjectsSlugPage({ params }: { params: Promise<{ slug: s
 
   const userInitial =
     (session?.user?.email?.[0] || session?.user?.user_metadata?.name?.[0] || 'U').toUpperCase()
+  const userMetadata = session?.user?.user_metadata as Record<string, any> | undefined
+  const userAvatarUrl =
+    userMetadata?.avatar_url ||
+    userMetadata?.picture ||
+    userMetadata?.avatarUrl ||
+    null
 
   if (showOnboarding) {
     return (
@@ -373,6 +379,7 @@ export default function ProjectsSlugPage({ params }: { params: Promise<{ slug: s
         utilityNav={utilityNav}
         onUtilityNavClick={handleUtilityNavClick}
         userInitial={userInitial}
+        userAvatarUrl={userAvatarUrl ?? undefined}
         loading={loading}
         isCollapsed={isNavCollapsed}
         onCollapsedChange={setIsNavCollapsed}

--- a/frontend/components/ProjectsSidebar.tsx
+++ b/frontend/components/ProjectsSidebar.tsx
@@ -25,6 +25,7 @@ type ProjectsSidebarProps = {
   utilityNav: UtilityNavItem[]
   onUtilityNavClick: (path: string) => void
   userInitial: string
+  userAvatarUrl?: string
   environmentLabel?: string
   onProjectsChange?: (projects: ProjectInfo[]) => void
   loading?: boolean
@@ -51,6 +52,7 @@ export function ProjectsSidebar({
   utilityNav,
   onUtilityNavClick,
   userInitial,
+  userAvatarUrl,
   environmentLabel = 'Local Dev',
   onProjectsChange,
   loading = false,
@@ -1044,6 +1046,15 @@ export function ProjectsSidebar({
           justify-content: center;
           font-size: 12px;
           font-weight: 600;
+          overflow: hidden;
+        }
+
+        .user-avatar img {
+          width: 100%;
+          height: 100%;
+          object-fit: cover;
+          border-radius: inherit;
+          display: block;
         }
 
         .context-menu {
@@ -1436,7 +1447,13 @@ export function ProjectsSidebar({
       {/* Footer */}
       <div className="footer">
         <span className="env-badge">{environmentLabel}</span>
-        <div className="user-avatar">{userInitial}</div>
+        <div className="user-avatar">
+          {userAvatarUrl ? (
+            <img src={userAvatarUrl} alt="User avatar" referrerPolicy="no-referrer" />
+          ) : (
+            userInitial
+          )}
+        </div>
       </div>
 
       {/* Context Menu */}


### PR DESCRIPTION
## Issue Summary
User avatars were not being displayed in the ProjectsSidebar - only user initials were shown, regardless of whether avatar URLs were available in the user metadata.

## Reproduction Steps
- Steps to reproduce: Log in with a user account that has an avatar URL in user_metadata (from OAuth providers like Google, GitHub, etc.)
- Expected vs actual: Expected to see the user's profile image in the sidebar footer, but only the first letter of the email (user initial) was displayed
- Scope: Affects all authenticated users across three main pages (Connect, MCP, and Projects pages)

## Root Cause Analysis
- What caused the issue? The ProjectsSidebar component only received and rendered the `userInitial` prop. The avatar URL from `session.user.user_metadata` was never extracted or passed to the component.
- Why was it not caught earlier? The feature was likely not prioritized, and the fallback to initials was functional but suboptimal.

## Fix Strategy
- What changed and why it fixes the issue:
  1. Extracted `userAvatarUrl` from `session.user.user_metadata` with multiple fallback keys (`avatar_url`, `picture`, `avatarUrl`) to support different OAuth providers
  2. Passed `userAvatarUrl` as a new prop to `ProjectsSidebar` component in all three page components
  3. Updated `ProjectsSidebar` to conditionally render an `<img>` tag when avatar URL is available, with fallback to user initials
  4. Added CSS styling for proper image sizing, object-fit, and border-radius
- Alternatives considered: Could have used a single metadata key, but multiple fallbacks provide better compatibility across OAuth providers

## Verification
- Tests added/updated: N/A (frontend UI change)
- Manual verification steps:
  1. Log in with Google/GitHub OAuth to verify avatar displays correctly
  2. Log in with email provider to verify fallback to initials works
  3. Test on all three affected pages (Connect, MCP, Projects)
- Affected areas to regress: ProjectsSidebar component, authentication flow display

## Risk & Mitigations
- Potential side effects: Minimal - this is additive with a fallback to existing behavior
- Feature flags/guardrails: N/A
- Rollback plan: Simple revert of the commits; the existing initial-based fallback remains intact

## Backporting
- Required? No - this is a UX enhancement, not a critical bug fix

## Related Issues / Links
- N/A

## Checklist
- [ ] Repro added as a test where feasible
- [ ] Regression coverage
- [ ] Monitoring/alerts in place (if relevant)
- [ ] Rollback verified
