### PR TITLE
feat: add table_id filtering to tool retrieval

### DIFF
--- a/backend/openspec/changes/archive/2025-12-29-add-tool-list-by-table-id/proposal.md
+++ b/backend/openspec/changes/archive/2025-12-29-add-tool-list-by-table-id/proposal.md
@@ -1,0 +1,20 @@
+# Change: Tool API 新增按 table_id 查询 Tool 列表路由
+
+## Why
+前端/调用方需要基于某个 `table_id` 快速获取其下所有 `Tool` 实体，用于工具管理与绑定（例如 MCP v2 binding）相关流程。目前仅提供按当前用户列出全部 Tool 的接口，缺少按 table 维度的查询入口。
+
+## What Changes
+- 新增一个只读路由：`GET /tools/by-table/{table_id}`，返回当前用户在该 `table_id` 下的所有 Tool。
+- 保持既有 CRUD 行为不变；新增路由复用现有权限校验逻辑（table 必须属于当前用户）。
+
+## Impact
+- Affected specs: `openspec/specs/mcp-tool-management/spec.md`
+- Affected code:
+  - `src/tool/router.py`
+  - `src/tool/service.py`
+  - `src/tool/repository.py`
+  - `src/supabase/repository.py`
+  - `src/supabase/tools/repository.py`
+  - `tests/`（新增或更新相关 API 测试）
+
+

--- a/backend/openspec/changes/archive/2025-12-29-add-tool-list-by-table-id/specs/mcp-tool-management/spec.md
+++ b/backend/openspec/changes/archive/2025-12-29-add-tool-list-by-table-id/specs/mcp-tool-management/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: 按 table_id 查询 Tool 列表
+系统 SHALL 支持按 `table_id` 查询当前用户在该 table 下的所有 Tool 实体。
+
+#### Scenario: 查询某个 table_id 下的 Tool 列表（成功）
+- **GIVEN** 当前用户有权限访问目标 `table_id`
+- **WHEN** 用户请求 `GET /tools/by-table/{table_id}`
+- **THEN** 系统返回该用户在此 `table_id` 下的 Tool 列表（可能为空）
+
+#### Scenario: 查询某个 table_id 下的 Tool 列表（无权限/不存在）
+- **GIVEN** 目标 `table_id` 不存在或当前用户无权限访问
+- **WHEN** 用户请求 `GET /tools/by-table/{table_id}`
+- **THEN** 系统返回 NOT_FOUND（与 table 权限校验保持一致的错误语义）
+
+

--- a/backend/openspec/changes/archive/2025-12-29-add-tool-list-by-table-id/tasks.md
+++ b/backend/openspec/changes/archive/2025-12-29-add-tool-list-by-table-id/tasks.md
@@ -1,0 +1,7 @@
+## 1. Implementation
+- [ ] 1.1 Supabase Tool 查询支持可选 `table_id` 过滤（repository + facade）
+- [ ] 1.2 Tool 模块新增 Service 方法：按 `table_id` 返回当前用户 Tool 列表（含 table 访问校验）
+- [ ] 1.3 Tool router 新增 `GET /tools/by-table/{table_id}` 路由
+- [ ] 1.4 增加/更新测试覆盖该路由的权限与返回数据
+
+

--- a/backend/openspec/specs/mcp-tool-management/spec.md
+++ b/backend/openspec/specs/mcp-tool-management/spec.md
@@ -91,3 +91,16 @@ TBD - created by archiving change 2025-12-28-refactor-mcp-tools-and-bindings. Up
 - **WHEN** MCP 客户端 call_tool 执行该 Tool
 - **THEN** 系统仅返回指定字段的轻量数据
 
+### Requirement: 按 table_id 查询 Tool 列表
+系统 SHALL 支持按 `table_id` 查询当前用户在该 table 下的所有 Tool 实体。
+
+#### Scenario: 查询某个 table_id 下的 Tool 列表（成功）
+- **GIVEN** 当前用户有权限访问目标 `table_id`
+- **WHEN** 用户请求 `GET /tools/by-table/{table_id}`
+- **THEN** 系统返回该用户在此 `table_id` 下的 Tool 列表（可能为空）
+
+#### Scenario: 查询某个 table_id 下的 Tool 列表（无权限/不存在）
+- **GIVEN** 目标 `table_id` 不存在或当前用户无权限访问
+- **WHEN** 用户请求 `GET /tools/by-table/{table_id}`
+- **THEN** 系统返回 NOT_FOUND（与 table 权限校验保持一致的错误语义）
+

--- a/backend/src/supabase/repository.py
+++ b/backend/src/supabase/repository.py
@@ -370,8 +370,9 @@ class SupabaseRepository:
         skip: int = 0,
         limit: int = 100,
         user_id: Optional[str] = None,
+        table_id: Optional[int] = None,
     ) -> List[ToolResponse]:
-        return self._tool_repo.get_list(skip=skip, limit=limit, user_id=user_id)
+        return self._tool_repo.get_list(skip=skip, limit=limit, user_id=user_id, table_id=table_id)
 
     def update_tool(self, tool_id: int, tool_data: ToolUpdate) -> Optional[ToolResponse]:
         return self._tool_repo.update(tool_id, tool_data)

--- a/backend/src/supabase/tools/repository.py
+++ b/backend/src/supabase/tools/repository.py
@@ -42,10 +42,13 @@ class ToolRepository:
         skip: int = 0,
         limit: int = 100,
         user_id: Optional[str] = None,
+        table_id: Optional[int] = None,
     ) -> List[ToolResponse]:
         query = self._client.table("tool").select("*")
         if user_id is not None:
             query = query.eq("user_id", user_id)
+        if table_id is not None:
+            query = query.eq("table_id", table_id)
         response = query.range(skip, skip + limit - 1).execute()
         return [ToolResponse(**item) for item in response.data]
 

--- a/backend/src/tool/repository.py
+++ b/backend/src/tool/repository.py
@@ -18,7 +18,14 @@ class ToolRepositoryBase(ABC):
         pass
 
     @abstractmethod
-    def get_by_user_id(self, user_id: str, *, skip: int = 0, limit: int = 100) -> List[Tool]:
+    def get_by_user_id(
+        self,
+        user_id: str,
+        *,
+        skip: int = 0,
+        limit: int = 100,
+        table_id: Optional[int] = None,
+    ) -> List[Tool]:
         pass
 
     @abstractmethod
@@ -60,8 +67,15 @@ class ToolRepositorySupabase(ToolRepositoryBase):
             return None
         return self._to_model(resp)
 
-    def get_by_user_id(self, user_id: str, *, skip: int = 0, limit: int = 100) -> List[Tool]:
-        resps = self._repo.get_tools(skip=skip, limit=limit, user_id=user_id)
+    def get_by_user_id(
+        self,
+        user_id: str,
+        *,
+        skip: int = 0,
+        limit: int = 100,
+        table_id: Optional[int] = None,
+    ) -> List[Tool]:
+        resps = self._repo.get_tools(skip=skip, limit=limit, user_id=user_id, table_id=table_id)
         return [self._to_model(r) for r in resps]
 
     def update(self, tool_id: int, tool: SbToolUpdate) -> Optional[Tool]:

--- a/backend/src/tool/router.py
+++ b/backend/src/tool/router.py
@@ -36,6 +36,28 @@ def list_tools(
     return ApiResponse.success(data=tools, message="获取 Tool 列表成功")
 
 
+@router.get(
+    "/by-table/{table_id}",
+    response_model=ApiResponse[List[ToolOut]],
+    summary="获取某个 table_id 下的 Tool 列表",
+    status_code=status.HTTP_200_OK,
+)
+def list_tools_by_table_id(
+    table_id: int,
+    skip: int = Query(default=0, ge=0),
+    limit: int = Query(default=1000, ge=1, le=1000),
+    tool_service: ToolService = Depends(get_tool_service),
+    current_user: CurrentUser = Depends(get_current_user),
+):
+    tools = tool_service.list_user_tools_by_table_id(
+        current_user.user_id,
+        table_id=table_id,
+        skip=skip,
+        limit=limit,
+    )
+    return ApiResponse.success(data=tools, message="获取 Tool 列表成功")
+
+
 @router.post(
     "/",
     response_model=ApiResponse[ToolOut],

--- a/backend/src/tool/service.py
+++ b/backend/src/tool/service.py
@@ -80,6 +80,18 @@ class ToolService:
     def list_user_tools(self, user_id: str, *, skip: int = 0, limit: int = 100) -> List[Tool]:
         return self.repo.get_by_user_id(user_id, skip=skip, limit=limit)
 
+    def list_user_tools_by_table_id(
+        self,
+        user_id: str,
+        *,
+        table_id: int,
+        skip: int = 0,
+        limit: int = 1000,
+    ) -> List[Tool]:
+        # 强校验：table 必须属于当前用户
+        self.table_service.get_by_id_with_access_check(table_id, user_id)
+        return self.repo.get_by_user_id(user_id, skip=skip, limit=limit, table_id=table_id)
+
     def get_by_id(self, tool_id: int) -> Optional[Tool]:
         return self.repo.get_by_id(tool_id)
 

--- a/backend/tests/tool/test_tool_api.py
+++ b/backend/tests/tool/test_tool_api.py
@@ -1,0 +1,136 @@
+"""Tool API 端点测试
+
+覆盖：
+- GET /tools/by-table/{table_id}
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import Mock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from fastapi.exceptions import RequestValidationError
+from starlette.exceptions import HTTPException as StarletteHTTPException
+
+from src.auth.dependencies import get_current_user
+from src.auth.models import CurrentUser
+from src.exception_handler import (
+    app_exception_handler,
+    generic_exception_handler,
+    http_exception_handler,
+    validation_exception_handler,
+)
+from src.exceptions import AppException
+from src.tool.dependencies import get_tool_service
+from src.tool.models import Tool
+from src.tool.router import router
+
+
+@pytest.fixture
+def app():
+    test_app = FastAPI()
+    # 与生产环境对齐：注册全局异常处理器（否则 AppException 会直接冒泡导致测试失败）
+    test_app.add_exception_handler(AppException, app_exception_handler)  # type: ignore
+    test_app.add_exception_handler(StarletteHTTPException, http_exception_handler)  # type: ignore
+    test_app.add_exception_handler(RequestValidationError, validation_exception_handler)  # type: ignore
+    test_app.add_exception_handler(Exception, generic_exception_handler)  # type: ignore
+    test_app.include_router(router)
+    return test_app
+
+
+@pytest.fixture
+def mock_tool_service():
+    service = Mock()
+    service.list_user_tools = Mock()
+    service.list_user_tools_by_table_id = Mock()
+    service.create = Mock()
+    service.get_by_id_with_access_check = Mock()
+    service.update = Mock()
+    service.delete = Mock()
+    return service
+
+
+@pytest.fixture
+def current_user():
+    return CurrentUser(
+        user_id="u_test",
+        email="test@example.com",
+        role="authenticated",
+        is_anonymous=False,
+        app_metadata={},
+        user_metadata={},
+    )
+
+
+@pytest.fixture
+def client(app, mock_tool_service, current_user):
+    app.dependency_overrides[get_tool_service] = lambda: mock_tool_service
+    app.dependency_overrides[get_current_user] = lambda: current_user
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def sample_tools(current_user):
+    return [
+        Tool(
+            id=1,
+            created_at=datetime.now(UTC),
+            user_id=current_user.user_id,
+            table_id=10,
+            json_path="",
+            type="query_data",
+            name="query_1",
+            alias=None,
+            description=None,
+            input_schema=None,
+            output_schema=None,
+            metadata=None,
+        ),
+        Tool(
+            id=2,
+            created_at=datetime.now(UTC),
+            user_id=current_user.user_id,
+            table_id=10,
+            json_path="/a",
+            type="get_all_data",
+            name="get_1",
+            alias="Get",
+            description="desc",
+            input_schema=None,
+            output_schema=None,
+            metadata={"k": "v"},
+        ),
+    ]
+
+
+def test_list_tools_by_table_id_success(client, mock_tool_service, sample_tools, current_user):
+    mock_tool_service.list_user_tools_by_table_id.return_value = sample_tools
+
+    resp = client.get("/tools/by-table/10?skip=0&limit=1000")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["code"] == 0
+    assert body["message"] == "获取 Tool 列表成功"
+    assert len(body["data"]) == 2
+    mock_tool_service.list_user_tools_by_table_id.assert_called_once_with(
+        current_user.user_id,
+        table_id=10,
+        skip=0,
+        limit=1000,
+    )
+
+
+def test_list_tools_by_table_id_not_found(client, mock_tool_service):
+    from src.exceptions import NotFoundException
+
+    mock_tool_service.list_user_tools_by_table_id.side_effect = NotFoundException("Table not found: 999")
+
+    resp = client.get("/tools/by-table/999")
+
+    assert resp.status_code == 404
+
+


### PR DESCRIPTION
- Enhanced the tool retrieval functionality to support filtering by table_id across multiple repository layers.
- Introduced a new API endpoint to list tools by table_id, improving data access for specific user contexts.
- Added unit tests to ensure the correctness of the new functionality and its integration with existing services.