### PR TITLE
Fix/fix onboarding bugs

### DIFF
--- a/frontend/app/(main)/projects/layout.tsx
+++ b/frontend/app/(main)/projects/layout.tsx
@@ -30,16 +30,18 @@ export default function ProjectsLayout({
   const [editingProjectId, setEditingProjectId] = useState<string | null>(null);
   const [projectDialogDeleteMode, setProjectDialogDeleteMode] = useState(false);
   const [tableDialogOpen, setTableDialogOpen] = useState(false);
-  const [tableDialogProjectId, setTableDialogProjectId] = useState<string | null>(
-    null
-  );
+  const [tableDialogProjectId, setTableDialogProjectId] = useState<
+    string | null
+  >(null);
   const [editingTableId, setEditingTableId] = useState<string | null>(null);
   const [tableRenameDialogOpen, setTableRenameDialogOpen] = useState(false);
   const [tableDeleteDialogOpen, setTableDeleteDialogOpen] = useState(false);
   const [tableModalProjectId, setTableModalProjectId] = useState<string | null>(
     null
   );
-  const [tableModalTableId, setTableModalTableId] = useState<string | null>(null);
+  const [tableModalTableId, setTableModalTableId] = useState<string | null>(
+    null
+  );
   const [tableContextMenu, setTableContextMenu] = useState<{
     x: number;
     y: number;

--- a/frontend/components/TableDeleteDialog.tsx
+++ b/frontend/components/TableDeleteDialog.tsx
@@ -62,8 +62,7 @@ export function TableDeleteDialog({
           borderRadius: 12,
           width: 480,
           maxWidth: '90vw',
-          boxShadow:
-            '0 24px 48px rgba(0,0,0,0.4), 0 12px 24px rgba(0,0,0,0.4)',
+          boxShadow: '0 24px 48px rgba(0,0,0,0.4), 0 12px 24px rgba(0,0,0,0.4)',
           display: 'flex',
           flexDirection: 'column',
           overflow: 'hidden',
@@ -125,12 +124,13 @@ export function TableDeleteDialog({
 
         <div style={{ padding: '24px' }}>
           <p style={{ color: '#EDEDED', marginBottom: 8, fontSize: 14 }}>
-            Are you sure you want to delete context "{table?.name || 'this context'}
+            Are you sure you want to delete context "
+            {table?.name || 'this context'}
             "?
           </p>
           <p style={{ color: '#9ca3af', fontSize: 13, lineHeight: '1.5' }}>
-            This will permanently delete the context and all data inside it. This
-            action cannot be undone.
+            This will permanently delete the context and all data inside it.
+            This action cannot be undone.
           </p>
         </div>
 
@@ -178,4 +178,3 @@ const buttonStyle = (primary: boolean): React.CSSProperties => ({
   transition: 'all 0.1s',
   fontFamily: 'inherit',
 });
-

--- a/frontend/components/TableRenameDialog.tsx
+++ b/frontend/components/TableRenameDialog.tsx
@@ -70,8 +70,7 @@ export function TableRenameDialog({
           borderRadius: 12,
           width: 480,
           maxWidth: '90vw',
-          boxShadow:
-            '0 24px 48px rgba(0,0,0,0.4), 0 12px 24px rgba(0,0,0,0.4)',
+          boxShadow: '0 24px 48px rgba(0,0,0,0.4), 0 12px 24px rgba(0,0,0,0.4)',
           display: 'flex',
           flexDirection: 'column',
           overflow: 'hidden',
@@ -202,4 +201,3 @@ const buttonStyle = (primary: boolean): React.CSSProperties => ({
   transition: 'all 0.1s',
   fontFamily: 'inherit',
 });
-


### PR DESCRIPTION
## Issue Summary
Right-click context menus for Projects/Contexts in the Projects sidebar were missing or inconsistent, and table rename/delete flows were coupled to the full `TableManageDialog`, resulting in confusing UX and broken interactions.

## Reproduction Steps
- Go to `Projects` page (`/projects/...`).
- Expand a project to reveal context/table rows.
- **Before fix**:
  - Right-click on a table row: nothing happens (no context menu), or actions are not available.
  - Project/table management actions are inconsistent across UI entry points.
- **After fix**:
  - Right-click on a project row shows a context menu with **Rename** and **Delete**.
  - Right-click on a table row shows a context menu with **Rename** and **Delete**.
  - Clicking project-row **+** opens the create-context flow.

## Root Cause Analysis
- Context menu UI existed, but the interactive list items either:
  - did not wire `onContextMenu` to open the menu, or
  - the Projects page used a different component for rendering the project/table list, leading to missing handlers where the user actually interacts (the `/projects` layout).
- Table rename/delete were routed through `TableManageDialog`, which bundles multiple creation/import features. This made the right-click actions heavier than needed and inconsistent with the project rename/delete dialogs.

## Fix Strategy
- Implemented explicit right-click handlers on the actual rendered rows in the Projects page layout.
- Added a project-row **+** button (next to expand/collapse) to open create-context (`TableManageDialog` in create mode).
- Split table rename/delete into dedicated dialogs to match the UI/interaction pattern of `ProjectManageDialog`:
  - `TableRenameDialog` (rename only)
  - `TableDeleteDialog` (delete confirmation only)
- Kept table creation flow in `TableManageDialog` (create/import remains consolidated).

## Verification
- Manual verification:
  - Right-click a **project** row -> menu appears -> Rename opens `ProjectManageDialog` (edit mode) -> save updates name.
  - Right-click a **project** row -> Delete opens `ProjectManageDialog` (delete mode) -> confirm deletes project.
  - Click project-row **+** -> opens `TableManageDialog` (create mode) -> create context/table.
  - Right-click a **table** row -> menu appears -> Rename opens `TableRenameDialog` -> save updates name.
  - Right-click a **table** row -> Delete opens `TableDeleteDialog` -> confirm deletes context/table.
  - Clicking outside any menu closes it.
- Areas to regress:
  - Sidebar expand/collapse still works and is not triggered when using the **+** button or right-click menus.
  - Navigation to `/projects/:projectId/:tableId` still works via table click.

## Risk & Mitigations
- **Risk**: Additional local state and overlay menus could introduce event propagation issues (e.g. click-to-toggle vs. click-to-open menu).
  - **Mitigation**: Use `preventDefault`/`stopPropagation` on context-menu triggers and action buttons; close menus on outside click.
- **Risk**: Z-index stacking conflicts with other overlays.
  - **Mitigation**: Use `position: fixed` and a high `zIndex` consistent with existing dialogs.

## Backporting
- Required? **No** (unless `qubits` branch still has the broken right-click behavior in its Projects UI).

## Related Issues / Links
- Fixes # (fill if applicable)

## Checklist
- [ ] Repro added as a test where feasible
- [x] Regression coverage (manual)
- [ ] Monitoring/alerts in place (if relevant)
- [ ] Rollback verified

