### PR TITLE
fix: replace maybe_single() with limit(1) in get_entry()

### DIFF
--- a/backend/src/mut_engine/server/backends/supabase_history.py
+++ b/backend/src/mut_engine/server/backends/supabase_history.py
@@ -230,10 +230,11 @@ class SupabaseHistoryManager:
             .select("*")
             .eq("project_id", self._project_id)
             .eq("version", version)
-            .maybe_single()
+            .limit(1)
             .execute()
         )
-        entry = _safe_data(resp)
+        rows = resp.data if resp and hasattr(resp, 'data') else None
+        entry = rows[0] if rows else None
         if entry:
             _parse_json_fields(entry)
         return entry


### PR DESCRIPTION
maybe_single() + select("*") on mut_commits fails in production postgrest-py when rows contain complex JSONB data (changes column). The HTTP response is 200 OK but postgrest-py's response parser raises APIError(code=204, "Missing response").

Using .limit(1).execute() + manual extraction avoids this bug. Also removes temporary debug endpoint.