### PR TITLE
fix: fall back to root scope hash for sub-scope tree navigation

### DIFF
--- a/backend/src/mut_engine/server/server_repo.py
+++ b/backend/src/mut_engine/server/server_repo.py
@@ -176,8 +176,8 @@ class PuppyOneServerRepo:
         if scope_hash and self.store.exists(scope_hash):
             return self._files_from_tree(scope_hash, scope_path, scope)
 
-        # Fallback: global root_hash + tree navigation
-        root_hash = self.get_root_hash()
+        # Fallback: navigate from root scope hash into sub-scope
+        root_hash = self.get_scope_hash("") or self.get_root_hash()
         if not root_hash:
             return {}
 
@@ -231,7 +231,7 @@ class PuppyOneServerRepo:
         if scope_hash and self.store.exists(scope_hash):
             return scope_hash
 
-        root_hash = self.get_root_hash()
+        root_hash = self.get_scope_hash("") or self.get_root_hash()
         if not root_hash:
             return self.store.put(json.dumps({}, sort_keys=True).encode())
 


### PR DESCRIPTION
When a sub-scope (e.g. /docs/) has never pushed independently, it has no scope_hash. The fallback was using projects.mut_root_hash which is stale (never updated by scope-based pushes). Now falls back to get_scope_hash("") which is the root scope's current tree hash.