### PR TITLE
hotfix: fix Optional NameError + add cachetools dependency

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.12"
 dependencies = [
     "beautifulsoup4>=4.12.0",
     "boto3>=1.41.5",
+    "cachetools>=5.0.0",
     "cashews>=7.4.4",
     "cryptography>=46.0.3",
     "fastapi>=0.121.1",

--- a/backend/src/platform/project/models.py
+++ b/backend/src/platform/project/models.py
@@ -19,6 +19,6 @@ class Project(BaseModel):
     visibility: str = Field(default="org", description="Visibility: org (visible within organization) / private (authorized members only)")
     created_by: str | None = Field(None, description="Creator user ID")
     created_at: datetime = Field(..., description="Creation time")
-    updated_at: Optional[datetime] = Field(None, description="Last update time")
+    updated_at: datetime | None = Field(None, description="Last update time")
 
     model_config = ConfigDict(from_attributes=True)

--- a/backend/src/platform/project/supabase_schemas.py
+++ b/backend/src/platform/project/supabase_schemas.py
@@ -38,6 +38,6 @@ class ProjectResponse(ProjectBase):
 
     id: str
     created_at: datetime
-    updated_at: Optional[datetime] = None
+    updated_at: datetime | None = None
 
     model_config = ConfigDict(from_attributes=True)


### PR DESCRIPTION
## Summary

Fixes startup crash introduced by PR #1130 merge (refactor/mut-engine-quality → qubits).

**Root cause:** Git auto-merge silently created a semantic conflict — the refactor branch removed `from typing import Optional` imports while the qubits branch added new `Optional[datetime]` fields. No line-level conflict was detected, but the merged result crashes with `NameError: name 'Optional' is not defined`.

### Changes
- `backend/src/platform/project/supabase_schemas.py` — `Optional[datetime]` → `datetime | None`
- `backend/src/platform/project/models.py` — `Optional[datetime]` → `datetime | None`
- `backend/pyproject.toml` — add `cachetools` as explicit dependency (used by `CachedStorageBackend`)

## Test plan
- [x] All 11 affected modules import successfully (smoke tested locally)
- [x] Verified no other `Optional`/`List`/`Dict` usage without imports across entire `backend/src/`


Made with [Cursor](https://cursor.com)