### PR TITLE
fix: update file_worker module path in railway.toml

### DIFF
--- a/backend/railway.toml
+++ b/backend/railway.toml
@@ -9,7 +9,7 @@ builder = "NIXPACKS"
 #
 # Environment variables:
 # - SERVICE_ROLE: api | file_worker | mcp_server
-startCommand = "sh -c 'case \"${SERVICE_ROLE:-api}\" in file_worker) arq src.upload.file.jobs.worker.WorkerSettings ;; mcp_server) uvicorn mcp_service.server:app --host 0.0.0.0 --port ${PORT} --no-access-log ;; *) uvicorn src.main:app --host 0.0.0.0 --port ${PORT} --no-access-log ;; esac'"
+startCommand = "sh -c 'case \"${SERVICE_ROLE:-api}\" in file_worker) arq src.ingest.file.jobs.worker.WorkerSettings ;; mcp_server) uvicorn mcp_service.server:app --host 0.0.0.0 --port ${PORT} --no-access-log ;; *) uvicorn src.main:app --host 0.0.0.0 --port ${PORT} --no-access-log ;; esac'"
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 10
 


### PR DESCRIPTION
## Summary
- Fix ARQ file worker crash: `src.upload` → `src.ingest` in `railway.toml` startCommand
- The upload module was renamed to ingest in af40ba1e (2026-03-21) but the Railway start command was never updated

This is the same fix that was supposed to be in PR #1135 but was pushed after the PR was merged.


Made with [Cursor](https://cursor.com)