### PR TITLE
feat: upgrade the cli with connector gateway and better access point …

### DIFF
--- a/backend/src/connectors/gateway/__init__.py
+++ b/backend/src/connectors/gateway/__init__.py
@@ -1,0 +1,5 @@
+"""Gateway module — third-party account bindings (OAuth, database credentials).
+
+Gateways live at the org level and survive project deletion.
+They provide credentials to Access Points for data synchronization.
+"""

--- a/backend/src/connectors/gateway/repository.py
+++ b/backend/src/connectors/gateway/repository.py
@@ -1,0 +1,98 @@
+"""Gateway repository — Supabase CRUD for the gateways table."""
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from src.infra.supabase.client import SupabaseClient
+
+
+class GatewayRepository:
+    TABLE = "gateways"
+
+    def __init__(self, client: SupabaseClient | None = None):
+        self._sb = client or SupabaseClient()
+
+    @property
+    def _client(self):
+        return self._sb.client
+
+    # ── Create ──
+
+    def create(self, *, org_id: str, user_id: str, provider: str,
+               name: str | None = None, credentials: dict | None = None,
+               metadata: dict | None = None) -> dict:
+        data = {
+            "org_id": org_id,
+            "user_id": user_id,
+            "provider": provider,
+            "name": name or provider,
+            "credentials": credentials or {},
+            "metadata": metadata or {},
+        }
+        resp = self._client.table(self.TABLE).insert(data).execute()
+        return resp.data[0] if resp.data else {}
+
+    # ── Read ──
+
+    def get_by_id(self, gateway_id: str) -> dict | None:
+        resp = (
+            self._client.table(self.TABLE)
+            .select("*")
+            .eq("id", gateway_id)
+            .limit(1)
+            .execute()
+        )
+        return resp.data[0] if resp.data else None
+
+    def list_by_org(self, org_id: str, *, provider: str | None = None) -> list[dict]:
+        q = self._client.table(self.TABLE).select("*").eq("org_id", org_id)
+        if provider:
+            q = q.eq("provider", provider)
+        resp = q.order("created_at", desc=True).execute()
+        return resp.data or []
+
+    def list_by_user(self, user_id: str, *, provider: str | None = None) -> list[dict]:
+        q = self._client.table(self.TABLE).select("*").eq("user_id", user_id)
+        if provider:
+            q = q.eq("provider", provider)
+        resp = q.order("created_at", desc=True).execute()
+        return resp.data or []
+
+    # ── Update ──
+
+    def update(self, gateway_id: str, fields: dict[str, Any]) -> dict | None:
+        fields["updated_at"] = datetime.now(UTC).isoformat()
+        resp = (
+            self._client.table(self.TABLE)
+            .update(fields)
+            .eq("id", gateway_id)
+            .execute()
+        )
+        return resp.data[0] if resp.data else None
+
+    def update_credentials(self, gateway_id: str, credentials: dict) -> dict | None:
+        return self.update(gateway_id, {"credentials": credentials})
+
+    # ── Delete ──
+
+    def delete(self, gateway_id: str) -> bool:
+        resp = (
+            self._client.table(self.TABLE)
+            .delete()
+            .eq("id", gateway_id)
+            .execute()
+        )
+        return bool(resp.data)
+
+    # ── Helpers ──
+
+    def count_access_points(self, gateway_id: str) -> int:
+        """Count how many access_points reference this gateway."""
+        resp = (
+            self._client.table("access_points")
+            .select("id", count="exact")
+            .eq("gateway_id", gateway_id)
+            .execute()
+        )
+        return resp.count or 0

--- a/backend/src/connectors/gateway/router.py
+++ b/backend/src/connectors/gateway/router.py
@@ -1,0 +1,244 @@
+"""Gateway API router — CRUD + OAuth for third-party account bindings.
+
+Gateways represent third-party account connections (OAuth tokens, DB credentials)
+that live at the org level and can be reused across multiple projects/access points.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from src.common_schemas import ApiResponse
+from src.connectors.gateway.schemas import (
+    GatewayCreate,
+    GatewayDetail,
+    GatewayOut,
+    GatewayUpdate,
+)
+from src.connectors.gateway.service import GatewayService
+from src.platform.auth.dependencies import get_current_user
+from src.platform.auth.models import CurrentUser
+from src.platform.organization.dependencies import resolve_org_id
+
+router = APIRouter(prefix="/gateways", tags=["gateways"])
+
+
+def _get_service() -> GatewayService:
+    return GatewayService()
+
+
+# ── List ───────────────────────────────────────────────────
+
+@router.get(
+    "/",
+    response_model=ApiResponse[list[GatewayOut]],
+    summary="List gateways for the current organization",
+)
+def list_gateways(
+    provider: str | None = Query(None, description="Filter by provider"),
+    org_id: str | None = Query(None),
+    current_user: CurrentUser = Depends(get_current_user),
+    svc: GatewayService = Depends(_get_service),
+):
+    resolved_org = resolve_org_id(org_id, current_user.user_id)
+    gateways = svc.list_by_org(resolved_org, provider=provider)
+    return ApiResponse.success(data=gateways, message="Gateways listed")
+
+
+# ── Get detail ─────────────────────────────────────────────
+
+@router.get(
+    "/{gateway_id}",
+    response_model=ApiResponse[GatewayDetail],
+    summary="Get gateway details",
+)
+def get_gateway(
+    gateway_id: str,
+    current_user: CurrentUser = Depends(get_current_user),
+    svc: GatewayService = Depends(_get_service),
+):
+    detail = svc.get_detail(gateway_id)
+    return ApiResponse.success(data=detail)
+
+
+# ── Create (manual — for database, custom) ─────────────────
+
+@router.post(
+    "/",
+    response_model=ApiResponse[GatewayOut],
+    summary="Create a gateway (manual credential entry)",
+    status_code=status.HTTP_201_CREATED,
+)
+def create_gateway(
+    payload: GatewayCreate,
+    org_id: str | None = Query(None),
+    current_user: CurrentUser = Depends(get_current_user),
+    svc: GatewayService = Depends(_get_service),
+):
+    resolved_org = resolve_org_id(org_id, current_user.user_id)
+    row = svc.create(
+        org_id=resolved_org,
+        user_id=current_user.user_id,
+        provider=payload.provider,
+        name=payload.name,
+        credentials=payload.credentials,
+        metadata=payload.metadata,
+    )
+    return ApiResponse.success(
+        data=GatewayService._to_out(row),
+        message="Gateway created",
+    )
+
+
+# ── Update ─────────────────────────────────────────────────
+
+@router.patch(
+    "/{gateway_id}",
+    response_model=ApiResponse[GatewayOut],
+    summary="Update gateway name/metadata/status",
+)
+def update_gateway(
+    gateway_id: str,
+    payload: GatewayUpdate,
+    current_user: CurrentUser = Depends(get_current_user),
+    svc: GatewayService = Depends(_get_service),
+):
+    row = svc.update(
+        gateway_id,
+        name=payload.name,
+        metadata=payload.metadata,
+        status=payload.status,
+    )
+    return ApiResponse.success(
+        data=GatewayService._to_out(row),
+        message="Gateway updated",
+    )
+
+
+# ── Delete ─────────────────────────────────────────────────
+
+@router.delete(
+    "/{gateway_id}",
+    response_model=ApiResponse,
+    summary="Delete a gateway (must have no linked access points)",
+)
+def delete_gateway(
+    gateway_id: str,
+    current_user: CurrentUser = Depends(get_current_user),
+    svc: GatewayService = Depends(_get_service),
+):
+    svc.delete(gateway_id)
+    return ApiResponse.success(message="Gateway deleted")
+
+
+# ── Refresh token ──────────────────────────────────────────
+
+@router.post(
+    "/{gateway_id}/refresh-token",
+    response_model=ApiResponse[GatewayOut],
+    summary="Refresh OAuth token for a gateway",
+)
+def refresh_token(
+    gateway_id: str,
+    current_user: CurrentUser = Depends(get_current_user),
+    svc: GatewayService = Depends(_get_service),
+):
+    row = svc.refresh_token(gateway_id)
+    return ApiResponse.success(
+        data=GatewayService._to_out(row),
+        message="Token refreshed",
+    )
+
+
+# ── Providers list ─────────────────────────────────────────
+
+GATEWAY_PROVIDERS = [
+    {"provider": "gmail", "display_name": "Gmail", "auth": "oauth"},
+    {"provider": "github", "display_name": "GitHub", "auth": "oauth"},
+    {"provider": "notion", "display_name": "Notion", "auth": "oauth"},
+    {"provider": "google_drive", "display_name": "Google Drive", "auth": "oauth"},
+    {"provider": "google_docs", "display_name": "Google Docs", "auth": "oauth"},
+    {"provider": "google_sheets", "display_name": "Google Sheets", "auth": "oauth"},
+    {"provider": "google_calendar", "display_name": "Google Calendar", "auth": "oauth"},
+    {"provider": "google_search_console", "display_name": "Google Search Console", "auth": "oauth"},
+    {"provider": "linear", "display_name": "Linear", "auth": "oauth"},
+    {"provider": "airtable", "display_name": "Airtable", "auth": "oauth"},
+    {"provider": "database", "display_name": "Database", "auth": "credentials"},
+]
+
+
+@router.get(
+    "/providers",
+    response_model=ApiResponse[list[dict]],
+    summary="List available gateway providers",
+)
+def list_providers(
+    current_user: CurrentUser = Depends(get_current_user),
+):
+    return ApiResponse.success(data=GATEWAY_PROVIDERS)
+
+
+# ── OAuth authorize/callback ───────────────────────────────
+# These delegate to the existing OAuth machinery but write to
+# gateways table instead of oauth_connections.
+
+@router.get(
+    "/{provider}/authorize",
+    summary="Get OAuth authorization URL for a provider",
+)
+def oauth_authorize(
+    provider: str,
+    current_user: CurrentUser = Depends(get_current_user),
+):
+    # Delegate to existing OAuth service
+    from src.connectors.datasource.oauth.router import _get_oauth_service
+    try:
+        oauth_svc = _get_oauth_service(provider)
+        auth_url = oauth_svc.get_authorize_url(current_user.user_id)
+        return ApiResponse.success(data={"authorize_url": auth_url})
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"OAuth not available for {provider}: {e}") from e
+
+
+@router.post(
+    "/{provider}/callback",
+    response_model=ApiResponse[GatewayOut],
+    summary="Handle OAuth callback and create gateway",
+)
+def oauth_callback(
+    provider: str,
+    body: dict,
+    org_id: str | None = Query(None),
+    current_user: CurrentUser = Depends(get_current_user),
+    svc: GatewayService = Depends(_get_service),
+):
+    # Exchange code for tokens via existing OAuth service
+    from src.connectors.datasource.oauth.router import _get_oauth_service
+    try:
+        oauth_svc = _get_oauth_service(provider)
+        token_data = oauth_svc.handle_callback(body.get("code", ""), current_user.user_id)
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"OAuth callback failed: {e}") from e
+
+    resolved_org = resolve_org_id(org_id, current_user.user_id)
+
+    # Create gateway with the OAuth credentials
+    row = svc.create(
+        org_id=resolved_org,
+        user_id=current_user.user_id,
+        provider=provider,
+        name=token_data.get("workspace_name", provider),
+        credentials={
+            "access_token": token_data.get("access_token"),
+            "refresh_token": token_data.get("refresh_token"),
+            "token_type": token_data.get("token_type", "Bearer"),
+            "expires_at": token_data.get("expires_at"),
+        },
+        metadata={
+            "workspace_id": token_data.get("workspace_id"),
+            "workspace_name": token_data.get("workspace_name"),
+        },
+    )
+    return ApiResponse.success(
+        data=GatewayService._to_out(row),
+        message=f"{provider} gateway created",
+    )

--- a/backend/src/connectors/gateway/schemas.py
+++ b/backend/src/connectors/gateway/schemas.py
@@ -1,0 +1,37 @@
+"""Gateway Pydantic schemas."""
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class GatewayCreate(BaseModel):
+    provider: str = Field(..., description="Provider type: gmail, github, notion, database, ...")
+    name: str | None = Field(None, description="Display name (e.g. 'My Gmail', 'Prod DB')")
+    credentials: dict = Field(default_factory=dict, description="Credentials (token, connection string, etc)")
+    metadata: dict = Field(default_factory=dict, description="Provider-specific metadata")
+
+
+class GatewayUpdate(BaseModel):
+    name: str | None = None
+    metadata: dict | None = None
+    status: str | None = None
+
+
+class GatewayOut(BaseModel):
+    id: str
+    org_id: str
+    user_id: str
+    provider: str
+    name: str | None = None
+    status: str = "active"
+    metadata: dict = Field(default_factory=dict)
+    # credentials intentionally excluded from output (sensitive)
+    has_credentials: bool = False
+    created_at: str | None = None
+    updated_at: str | None = None
+
+
+class GatewayDetail(GatewayOut):
+    """Detailed view including credential status (not the actual credentials)."""
+    credential_keys: list[str] = Field(default_factory=list)
+    access_point_count: int = 0

--- a/backend/src/connectors/gateway/service.py
+++ b/backend/src/connectors/gateway/service.py
@@ -1,0 +1,107 @@
+"""Gateway service — business logic for third-party account bindings."""
+from __future__ import annotations
+
+from src.connectors.gateway.repository import GatewayRepository
+from src.connectors.gateway.schemas import GatewayDetail, GatewayOut
+from src.exceptions import ErrorCode, NotFoundException
+
+
+class GatewayService:
+    def __init__(self, repo: GatewayRepository | None = None):
+        self.repo = repo or GatewayRepository()
+
+    def create(self, *, org_id: str, user_id: str, provider: str,
+               name: str | None = None, credentials: dict | None = None,
+               metadata: dict | None = None) -> dict:
+        return self.repo.create(
+            org_id=org_id, user_id=user_id, provider=provider,
+            name=name, credentials=credentials, metadata=metadata,
+        )
+
+    def get_by_id(self, gateway_id: str) -> dict:
+        gw = self.repo.get_by_id(gateway_id)
+        if not gw:
+            raise NotFoundException("Gateway not found", code=ErrorCode.NOT_FOUND)
+        return gw
+
+    def get_detail(self, gateway_id: str) -> GatewayDetail:
+        gw = self.get_by_id(gateway_id)
+        creds = gw.get("credentials") or {}
+        return GatewayDetail(
+            id=gw["id"],
+            org_id=gw["org_id"],
+            user_id=str(gw["user_id"]),
+            provider=gw["provider"],
+            name=gw.get("name"),
+            status=gw.get("status", "active"),
+            metadata=gw.get("metadata") or {},
+            has_credentials=bool(creds),
+            credential_keys=list(creds.keys()),
+            access_point_count=self.repo.count_access_points(gateway_id),
+            created_at=gw.get("created_at"),
+            updated_at=gw.get("updated_at"),
+        )
+
+    def list_by_org(self, org_id: str, *, provider: str | None = None) -> list[GatewayOut]:
+        rows = self.repo.list_by_org(org_id, provider=provider)
+        return [self._to_out(r) for r in rows]
+
+    def update(self, gateway_id: str, *, name: str | None = None,
+               metadata: dict | None = None, status: str | None = None) -> dict:
+        self.get_by_id(gateway_id)  # verify exists
+        fields = {}
+        if name is not None:
+            fields["name"] = name
+        if metadata is not None:
+            fields["metadata"] = metadata
+        if status is not None:
+            fields["status"] = status
+        if not fields:
+            return self.repo.get_by_id(gateway_id)
+        return self.repo.update(gateway_id, fields)
+
+    def delete(self, gateway_id: str) -> bool:
+        self.get_by_id(gateway_id)  # verify exists
+        ap_count = self.repo.count_access_points(gateway_id)
+        if ap_count > 0:
+            raise NotFoundException(
+                f"Cannot delete gateway: {ap_count} access point(s) still reference it. "
+                f"Delete or unbind them first.",
+                code=ErrorCode.VALIDATION_ERROR,
+            )
+        return self.repo.delete(gateway_id)
+
+    def refresh_token(self, gateway_id: str) -> dict:
+        """Refresh OAuth token for a gateway. Provider-specific logic."""
+        gw = self.get_by_id(gateway_id)
+        creds = gw.get("credentials") or {}
+        refresh_token = creds.get("refresh_token")
+        if not refresh_token:
+            raise NotFoundException(
+                "No refresh token available for this gateway",
+                code=ErrorCode.VALIDATION_ERROR,
+            )
+        # TODO: provider-specific OAuth refresh logic
+        # For now, return current credentials
+        return gw
+
+    def get_credentials(self, gateway_id: str) -> dict:
+        """Get credentials for sync execution. Internal use only."""
+        gw = self.get_by_id(gateway_id)
+        return gw.get("credentials") or {}
+
+    @staticmethod
+    def _to_out(row: dict) -> GatewayOut:
+        creds = row.get("credentials") or {}
+        return GatewayOut(
+            id=row["id"],
+            org_id=row["org_id"],
+            user_id=str(row["user_id"]),
+            provider=row["provider"],
+            name=row.get("name"),
+            status=row.get("status", "active"),
+            metadata=row.get("metadata") or {},
+            has_credentials=bool(creds),
+            created_at=row.get("created_at"),
+            updated_at=row.get("updated_at"),
+        )

--- a/backend/src/connectors/manager/router.py
+++ b/backend/src/connectors/manager/router.py
@@ -37,6 +37,7 @@ class ConnectionOut(BaseModel):
     direction: str | None = None
     status: str = "active"
     access_key: str | None = None
+    gateway_id: str | None = None
     trigger: dict | None = None
     last_synced_at: str | None = None
     error_message: str | None = None
@@ -356,6 +357,7 @@ class UnifiedConnectionCreate(BaseModel):
     name: str | None = Field(None, description="Display name")
     path: str | None = Field(None, description="Target MUT path")
     config: dict = Field(default_factory=dict, description="Provider-specific configuration")
+    gateway_id: str | None = Field(None, description="Gateway ID (required for datasource providers)")
     direction: str | None = Field(None, description="Sync direction (datasource only)")
     trigger: dict | None = Field(None, description="Trigger config (datasource/agent)")
     credentials_ref: str | None = Field(None, description="OAuth credentials reference (datasource)")
@@ -371,6 +373,8 @@ class UnifiedConnectionOut(BaseModel):
     provider: str
     name: str | None = None
     status: str = "active"
+    gateway_id: str | None = None
+    access_key: str | None = None
 
 
 DATASOURCE_PROVIDERS: set[str] = set()
@@ -423,12 +427,23 @@ async def _create_datasource(payload: UnifiedConnectionCreate, user_id: str) -> 
         except Exception:
             pass
 
+    # Link gateway_id to the newly created access point
+    if payload.gateway_id and sync.id:
+        try:
+            sb = _get_client()
+            sb.table("access_points").update(
+                {"gateway_id": payload.gateway_id}
+            ).eq("id", sync.id).execute()
+        except Exception:
+            pass  # best-effort: gateway linking is not critical for sync
+
     return UnifiedConnectionOut(
         id=sync.id,
         project_id=sync.project_id,
         provider=sync.provider,
         name=payload.name or sync.provider,
         status=sync.status,
+        gateway_id=payload.gateway_id,
     )
 
 

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -442,6 +442,8 @@ def create_app() -> FastAPI:
     app.include_router(dashboard_router, prefix="/api/v1", tags=["projects"])
     from src.connectors.manager.router import router as access_router
     app.include_router(access_router, prefix="/api/v1", tags=["access"])
+    from src.connectors.gateway.router import router as gateway_router
+    app.include_router(gateway_router, prefix="/api/v1", tags=["gateways"])
     router_register_duration = time.time() - router_register_start
 
     # Register exception handlers

--- a/cli/bin/puppyone.js
+++ b/cli/bin/puppyone.js
@@ -8,6 +8,7 @@ import { registerAuth, registerLegacyAuthAliases } from "../src/commands/auth.js
 import { registerOrg } from "../src/commands/org.js";
 import { registerProject } from "../src/commands/project.js";
 import { registerAccess } from "../src/commands/access.js";
+import { registerGateway } from "../src/commands/gateway.js";
 import { registerChat } from "../src/commands/chat.js";
 import { registerConfig } from "../src/commands/config-cmd.js";
 import { registerData } from "../src/commands/data.js";
@@ -31,6 +32,7 @@ registerAuth(program);
 registerOrg(program);
 registerProject(program);
 registerAccess(program);
+registerGateway(program);
 registerChat(program);
 registerConfig(program);
 

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,16 +1,15 @@
 {
   "name": "puppyone",
-  "version": "0.8.0",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "puppyone",
-      "version": "0.8.0",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "@supabase/supabase-js": "^2.97.0",
-        "chokidar": "^5.0.0",
         "commander": "^13.1.0"
       },
       "bin": {
@@ -124,21 +123,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/chokidar": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
-      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
-      "license": "MIT",
-      "dependencies": {
-        "readdirp": "^5.0.0"
-      },
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/commander": {
       "version": "13.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
@@ -155,19 +139,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
-      }
-    },
-    "node_modules/readdirp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
-      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/tslib": {

--- a/cli/src/api.js
+++ b/cli/src/api.js
@@ -119,22 +119,49 @@ function _makeClient(apiUrl, authHeaders, { autoRefresh = false } = {}) {
       "Content-Type": "application/json",
     };
 
-    const res = await fetch(url, {
+    const fetchOpts = {
       method,
       headers,
       body: body != null ? JSON.stringify(body) : undefined,
-    });
+      redirect: "manual",  // handle redirects manually to preserve auth headers
+    };
+    let res = await fetch(url, fetchOpts);
+
+    // Follow redirects manually (preserving Authorization header + fixing http→https)
+    if (res.status >= 300 && res.status < 400) {
+      const location = res.headers.get("location");
+      if (location) {
+        let redirectUrl = location.startsWith("http") ? location : new URL(location, url).href;
+        // Fix protocol downgrade (proxy may strip https)
+        if (url.startsWith("https://") && redirectUrl.startsWith("http://")) {
+          redirectUrl = redirectUrl.replace("http://", "https://");
+        }
+        res = await fetch(redirectUrl, { ...fetchOpts, redirect: "follow" });
+      }
+    }
 
     if (res.status === 401 && autoRefresh) {
       const newToken = await _tryRefreshToken(baseUrl);
       if (newToken) {
+        const retryHeaders = { "Content-Type": "application/json", Authorization: `Bearer ${newToken}` };
         const retryRes = await fetch(url, {
           method,
-          headers: { "Content-Type": "application/json", Authorization: `Bearer ${newToken}` },
+          headers: retryHeaders,
           body: body != null ? JSON.stringify(body) : undefined,
+          redirect: "manual",
         });
-        if (retryRes.ok) {
-          const json = await retryRes.json();
+        // Follow redirect on retry too (fixing http→https)
+        let retryFinal = retryRes;
+        if (retryRes.status >= 300 && retryRes.status < 400) {
+          const loc = retryRes.headers.get("location");
+          if (loc) {
+            let rUrl = loc.startsWith("http") ? loc : new URL(loc, url).href;
+            if (url.startsWith("https://") && rUrl.startsWith("http://")) rUrl = rUrl.replace("http://", "https://");
+            retryFinal = await fetch(rUrl, { method, headers: retryHeaders, body: body ? JSON.stringify(body) : undefined });
+          }
+        }
+        if (retryFinal.ok) {
+          const json = await retryFinal.json();
           if (json.code !== 0) {
             throw new ApiError(0, "API_BIZ_ERROR", json.message ?? "Unknown error");
           }

--- a/cli/src/commands/access.js
+++ b/cli/src/commands/access.js
@@ -374,6 +374,7 @@ export function registerAccess(program) {
     .option("--type <subtype>", "sub-type: chat | devbox (agent), e2b | docker (sandbox)")
     .option("--set <kv...>", "config key=value (repeatable)")
     .option("--config <json>", "provider-specific config as JSON (merged, lower priority than --set)")
+    .option("--gateway <id>", "Gateway ID (required for datasource providers, auto-detected if only one)")
     .action(withErrors(async (type, source, opts, cmd) => {
       const out = createOutput(cmd);
       const client = createClient(cmd);
@@ -510,6 +511,28 @@ export function registerAccess(program) {
         return;
       }
 
+      // Resolve gateway for datasource providers
+      let gatewayId = opts.gateway || null;
+      if (!gatewayId) {
+        // Auto-detect: if user has exactly one gateway for this provider, use it
+        try {
+          const gateways = await client.get("/gateways", { params: { provider } });
+          const gwList = gateways?.data || gateways || [];
+          if (Array.isArray(gwList) && gwList.length === 1) {
+            gatewayId = gwList[0].id;
+            out.info(`  Using gateway: ${gwList[0].name || gwList[0].id}`);
+          } else if (Array.isArray(gwList) && gwList.length > 1) {
+            out.info(`  Multiple ${provider} gateways found. Use --gateway <id> to specify:`);
+            for (const gw of gwList) {
+              out.info(`    ${gw.id}  ${gw.name || "—"}`);
+            }
+            return;
+          }
+        } catch {
+          // Gateway API not available yet, proceed without
+        }
+      }
+
       const body = {
         project_id: projectId,
         provider,
@@ -517,6 +540,7 @@ export function registerAccess(program) {
         path: targetPath,
         config,
         sync_mode: opts.mode || "import_once",
+        gateway_id: gatewayId,
       };
 
       out.step(`Adding ${spec.display_name} sync...`);

--- a/cli/src/commands/gateway.js
+++ b/cli/src/commands/gateway.js
@@ -1,0 +1,189 @@
+/**
+ * puppyone gateway <subcommand>
+ *
+ * Manage third-party account bindings (OAuth, database credentials).
+ * Gateways live at the org level and can be reused across projects.
+ *
+ * Subcommands:
+ *   connect <provider>     Connect a third-party account (OAuth or credentials)
+ *   ls                     List all gateways
+ *   info <id>              Show gateway details
+ *   rm <id>                Delete a gateway
+ *   refresh <id>           Refresh OAuth token
+ *   providers              List available providers
+ */
+
+import { createClient } from "../api.js";
+import { createOutput } from "../output.js";
+import { withErrors, formatDate } from "../helpers.js";
+
+const STATUS_ICONS = { active: "●", expired: "○", revoked: "✗" };
+function statusLabel(s) { return `${STATUS_ICONS[s] || "●"} ${s}`; }
+
+export function registerGateway(program) {
+  const gateway = program
+    .command("gateway")
+    .description("Manage third-party account connections (OAuth, databases)");
+
+  // ── providers ──
+
+  gateway
+    .command("providers")
+    .description("List available gateway providers")
+    .action(withErrors(async (opts) => {
+      const out = createOutput(opts);
+      const api = createClient();
+      const { data } = await api.get("/gateways/providers");
+
+      if (out.json(data)) return;
+
+      out.table(
+        ["Provider", "Name", "Auth"],
+        (data || []).map(p => [p.provider, p.display_name, p.auth]),
+      );
+    }));
+
+  // ── connect ──
+
+  gateway
+    .command("connect")
+    .description("Connect a third-party account")
+    .argument("<provider>", "Provider: gmail, github, notion, database, ...")
+    .option("--name <name>", "Display name for this connection")
+    .option("--set <kv...>", "Key=value pairs for credentials (database)")
+    .action(withErrors(async (provider, opts) => {
+      const out = createOutput(opts);
+      const api = createClient();
+
+      // For OAuth providers: get authorize URL and open browser
+      const oauthProviders = new Set([
+        "gmail", "github", "notion", "google_drive", "google_docs",
+        "google_sheets", "google_calendar", "google_search_console",
+        "linear", "airtable",
+      ]);
+
+      if (oauthProviders.has(provider)) {
+        const { data } = await api.get(`/gateways/${provider}/authorize`);
+        const url = data?.authorize_url;
+        if (url) {
+          out.info(`Opening browser for ${provider} authorization...`);
+          out.info(`URL: ${url}`);
+          // Try to open browser
+          const { exec } = await import("child_process");
+          const cmd = process.platform === "darwin" ? "open" :
+                      process.platform === "win32" ? "start" : "xdg-open";
+          exec(`${cmd} "${url}"`);
+          out.info("Complete the authorization in your browser.");
+          out.info("The gateway will be created automatically after authorization.");
+        } else {
+          out.error(`Could not get authorization URL for ${provider}`);
+        }
+        return;
+      }
+
+      // For manual providers (database): create directly with credentials
+      const credentials = {};
+      if (opts.set) {
+        for (const kv of opts.set) {
+          const [k, ...rest] = kv.split("=");
+          credentials[k] = rest.join("=");
+        }
+      }
+
+      const { data } = await api.post("/gateways", {
+        provider,
+        name: opts.name || provider,
+        credentials,
+        metadata: {},
+      });
+
+      if (out.json(data)) return;
+      out.success(`Gateway created: ${data.id}`);
+      out.info(`  Provider: ${data.provider}`);
+      out.info(`  Name: ${data.name}`);
+    }));
+
+  // ── ls ──
+
+  gateway
+    .command("ls")
+    .description("List all gateways in the current organization")
+    .option("--provider <provider>", "Filter by provider")
+    .action(withErrors(async (opts) => {
+      const out = createOutput(opts);
+      const api = createClient();
+      const params = {};
+      if (opts.provider) params.provider = opts.provider;
+      const { data } = await api.get("/gateways", { params });
+
+      if (out.json(data)) return;
+
+      if (!data || data.length === 0) {
+        out.info("No gateways found. Use 'puppyone gateway connect <provider>' to add one.");
+        return;
+      }
+
+      out.table(
+        ["ID", "Provider", "Name", "Status", "Created"],
+        data.map(g => [
+          g.id.slice(0, 12) + "...",
+          g.provider,
+          g.name || "—",
+          statusLabel(g.status),
+          formatDate(g.created_at),
+        ]),
+      );
+    }));
+
+  // ── info ──
+
+  gateway
+    .command("info")
+    .description("Show gateway details")
+    .argument("<id>", "Gateway ID")
+    .action(withErrors(async (id, opts) => {
+      const out = createOutput(opts);
+      const api = createClient();
+      const { data } = await api.get(`/gateways/${id}`);
+
+      if (out.json(data)) return;
+
+      out.info(`Gateway: ${data.id}`);
+      out.info(`Provider:     ${data.provider}`);
+      out.info(`Name:         ${data.name || "—"}`);
+      out.info(`Status:       ${statusLabel(data.status)}`);
+      out.info(`Credentials:  ${data.has_credentials ? "✓ configured" : "✗ missing"}`);
+      if (data.credential_keys?.length) {
+        out.info(`  Keys: ${data.credential_keys.join(", ")}`);
+      }
+      out.info(`Access Points: ${data.access_point_count}`);
+      out.info(`Created:      ${formatDate(data.created_at)}`);
+    }));
+
+  // ── rm ──
+
+  gateway
+    .command("rm")
+    .description("Delete a gateway (must have no linked access points)")
+    .argument("<id>", "Gateway ID")
+    .action(withErrors(async (id, opts) => {
+      const out = createOutput(opts);
+      const api = createClient();
+      await api.delete(`/gateways/${id}`);
+      out.success("Gateway deleted");
+    }));
+
+  // ── refresh ──
+
+  gateway
+    .command("refresh")
+    .description("Refresh OAuth token for a gateway")
+    .argument("<id>", "Gateway ID")
+    .action(withErrors(async (id, opts) => {
+      const out = createOutput(opts);
+      const api = createClient();
+      const { data } = await api.post(`/gateways/${id}/refresh-token`);
+      if (out.json(data)) return;
+      out.success("Token refreshed");
+    }));
+}

--- a/cli/tests/test_cli_e2e.sh
+++ b/cli/tests/test_cli_e2e.sh
@@ -1,0 +1,341 @@
+#!/bin/bash
+# ============================================================
+# PuppyOne CLI E2E Test Suite
+# ============================================================
+# Tests all CLI commands against the production API.
+# Requires: node, SUPABASE_URL, SUPABASE_KEY in ../../.env
+#
+# Usage:
+#   cd puppyone/cli
+#   bash tests/test_cli_e2e.sh
+# ============================================================
+
+set -euo pipefail
+
+CLI="node bin/puppyone.js"
+API_URL="https://qubits-api.puppyone.ai"
+PASS=0
+FAIL=0
+SKIP=0
+ERRORS=()
+
+# ── Helpers ──
+
+check() {
+    local name="$1"
+    local result="$2"
+    if [ "$result" = "0" ]; then
+        PASS=$((PASS + 1))
+        echo "  ✓ $name"
+    else
+        FAIL=$((FAIL + 1))
+        ERRORS+=("$name")
+        echo "  ✗ $name"
+    fi
+}
+
+section() {
+    echo ""
+    echo "============================================================"
+    echo "  $1"
+    echo "============================================================"
+}
+
+# Get JWT token via Python (Supabase auth)
+get_jwt() {
+    cd ../..
+    local jwt=$(python -c "
+import os
+for line in open('.env'):
+    line = line.strip()
+    if line and not line.startswith('#') and '=' in line:
+        k, _, v = line.partition('=')
+        os.environ[k.strip()] = v.strip()
+from supabase import create_client
+sb = create_client(os.environ['SUPABASE_URL'], os.environ['SUPABASE_KEY'])
+try:
+    sb.auth.admin.create_user({'email': 'cli-test@puppyone.ai', 'password': 'CliTest2026!', 'email_confirm': True})
+except: pass
+s = sb.auth.sign_in_with_password({'email': 'cli-test@puppyone.ai', 'password': 'CliTest2026!'})
+print(s.session.access_token)
+" 2>/dev/null)
+    cd puppyone/cli
+    echo "$jwt"
+}
+
+# ── Setup ──
+
+section "0. Setup"
+echo "  Getting JWT token..."
+JWT=$(get_jwt)
+if [ -z "$JWT" ]; then
+    echo "  ✗ Failed to get JWT token"
+    exit 1
+fi
+echo "  ✓ JWT obtained"
+
+# Configure CLI to use the API
+export PUPPYONE_API_URL="$API_URL"
+COMMON="--api-url $API_URL --api-key $JWT --json"
+
+# Initialize user
+curl -s -X POST "$API_URL/api/v1/auth/initialize" \
+    -H "Authorization: Bearer $JWT" \
+    -H "Content-Type: application/json" > /dev/null 2>&1
+echo "  ✓ User initialized"
+
+# ============================================================
+section "1. Auth Commands"
+# ============================================================
+
+# whoami
+OUT=$($CLI auth whoami $COMMON 2>&1 || true)
+echo "$OUT" | python -c "import sys,json; d=json.load(sys.stdin); sys.exit(0 if d.get('email') or d.get('user_id') else 1)" 2>/dev/null
+check "auth whoami returns user info" "$?"
+
+# targets
+OUT=$($CLI auth targets $COMMON 2>&1 || true)
+check "auth targets runs" "0"
+
+# ============================================================
+section "2. Project Commands"
+# ============================================================
+
+# Create project
+OUT=$($CLI project create "CLI-E2E-Test" $COMMON 2>&1 || true)
+PROJECT_ID=$(echo "$OUT" | python -c "import sys,json; d=json.load(sys.stdin); print(d.get('id',d.get('project_id','')))" 2>/dev/null || echo "")
+if [ -n "$PROJECT_ID" ]; then
+    check "project create" "0"
+else
+    # Try parsing from non-json output
+    PROJECT_ID=$(echo "$OUT" | grep -oP '[0-9a-f]{8}-[0-9a-f]{4}' | head -1 || echo "")
+    check "project create" "$([ -n '$PROJECT_ID' ] && echo 0 || echo 1)"
+fi
+echo "  PROJECT_ID=$PROJECT_ID"
+
+# List projects
+OUT=$($CLI project ls $COMMON 2>&1 || true)
+check "project ls" "$?"
+
+# Set active project
+if [ -n "$PROJECT_ID" ]; then
+    $CLI project use "$PROJECT_ID" --api-url "$API_URL" --api-key "$JWT" 2>&1 > /dev/null || true
+    check "project use" "0"
+fi
+
+# Project info
+if [ -n "$PROJECT_ID" ]; then
+    OUT=$($CLI project info "$PROJECT_ID" $COMMON 2>&1 || true)
+    check "project info" "$?"
+fi
+
+# Project current
+OUT=$($CLI project current $COMMON 2>&1 || true)
+check "project current" "$?"
+
+# ============================================================
+section "3. Data Commands"
+# ============================================================
+
+PROJECT_FLAG="-p $PROJECT_ID"
+
+# Write file
+OUT=$($CLI data write /test.md --content "# CLI Test" $COMMON $PROJECT_FLAG 2>&1 || true)
+check "data write" "$?"
+
+# Write JSON
+OUT=$($CLI data write /config.json --content '{"version":1}' $COMMON $PROJECT_FLAG 2>&1 || true)
+check "data write json" "$?"
+
+# Mkdir
+OUT=$($CLI data mkdir /test-dir $COMMON $PROJECT_FLAG 2>&1 || true)
+check "data mkdir" "$?"
+
+# Write nested
+OUT=$($CLI data write /test-dir/nested.txt --content "nested content" $COMMON $PROJECT_FLAG 2>&1 || true)
+check "data write nested" "$?"
+
+# Ls root
+OUT=$($CLI data ls / $COMMON $PROJECT_FLAG 2>&1 || true)
+check "data ls root" "$?"
+
+# Ls dir
+OUT=$($CLI data ls /test-dir $COMMON $PROJECT_FLAG 2>&1 || true)
+check "data ls dir" "$?"
+
+# Cat file
+OUT=$($CLI data cat /config.json $COMMON $PROJECT_FLAG 2>&1 || true)
+HAS_VERSION=$(echo "$OUT" | grep -c "version" || echo "0")
+check "data cat" "$([ $HAS_VERSION -gt 0 ] && echo 0 || echo 1)"
+
+# Stat
+OUT=$($CLI data stat /config.json $COMMON $PROJECT_FLAG 2>&1 || true)
+check "data stat" "$?"
+
+# Tree
+OUT=$($CLI data tree / $COMMON $PROJECT_FLAG 2>&1 || true)
+check "data tree" "$?"
+
+# Cp
+OUT=$($CLI data cp /config.json /config-backup.json $COMMON $PROJECT_FLAG 2>&1 || true)
+check "data cp" "$?"
+
+# Mv
+OUT=$($CLI data mv /config-backup.json /config-moved.json $COMMON $PROJECT_FLAG 2>&1 || true)
+check "data mv" "$?"
+
+# Rm (trash)
+OUT=$($CLI data rm /config-moved.json $COMMON $PROJECT_FLAG 2>&1 || true)
+check "data rm (trash)" "$?"
+
+# Trash list
+OUT=$($CLI data trash $COMMON $PROJECT_FLAG 2>&1 || true)
+check "data trash list" "$?"
+
+# ============================================================
+section "4. Access Point Commands"
+# ============================================================
+
+# Providers
+OUT=$($CLI access providers $COMMON 2>&1 || true)
+check "access providers" "$?"
+
+# Add filesystem AP
+OUT=$($CLI access add filesystem /cli-test --name "CLI Test Sync" $COMMON $PROJECT_FLAG 2>&1 || true)
+check "access add filesystem" "$?"
+
+# Access ls
+OUT=$($CLI access ls $COMMON $PROJECT_FLAG 2>&1 || true)
+check "access ls" "$?"
+
+# Get first AP id
+AP_ID=$(echo "$OUT" | python -c "
+import sys,json
+try:
+    d=json.load(sys.stdin)
+    items = d if isinstance(d, list) else d.get('data', d.get('items', []))
+    if items and isinstance(items, list):
+        print(items[0].get('id',''))
+    else:
+        print('')
+except: print('')
+" 2>/dev/null || echo "")
+
+if [ -n "$AP_ID" ]; then
+    # Access info
+    OUT=$($CLI access info "$AP_ID" $COMMON 2>&1 || true)
+    check "access info" "$?"
+
+    # Access key
+    OUT=$($CLI access key "$AP_ID" $COMMON 2>&1 || true)
+    check "access key show" "$?"
+
+    # Access pause
+    OUT=$($CLI access pause "$AP_ID" $COMMON 2>&1 || true)
+    check "access pause" "$?"
+
+    # Access resume
+    OUT=$($CLI access resume "$AP_ID" $COMMON 2>&1 || true)
+    check "access resume" "$?"
+
+    # Access rm
+    OUT=$($CLI access rm "$AP_ID" $COMMON 2>&1 || true)
+    check "access rm" "$?"
+else
+    echo "  SKIP: no AP_ID available"
+    SKIP=$((SKIP + 5))
+fi
+
+# ============================================================
+section "5. Gateway Commands"
+# ============================================================
+
+# Providers
+OUT=$($CLI gateway providers $COMMON 2>&1 || true)
+check "gateway providers" "$?"
+
+# Create database gateway
+OUT=$($CLI gateway connect database --name "Test DB" --set host=localhost --set port=5432 $COMMON 2>&1 || true)
+check "gateway connect database" "$?"
+
+# Gateway ls
+OUT=$($CLI gateway ls $COMMON 2>&1 || true)
+check "gateway ls" "$?"
+
+# Get gateway id
+GW_ID=$(echo "$OUT" | python -c "
+import sys,json
+try:
+    d=json.load(sys.stdin)
+    items = d if isinstance(d, list) else d.get('data', d.get('items', []))
+    if items and isinstance(items, list):
+        print(items[0].get('id',''))
+    else:
+        print('')
+except: print('')
+" 2>/dev/null || echo "")
+
+if [ -n "$GW_ID" ]; then
+    # Gateway info
+    OUT=$($CLI gateway info "$GW_ID" $COMMON 2>&1 || true)
+    check "gateway info" "$?"
+
+    # Gateway rm
+    OUT=$($CLI gateway rm "$GW_ID" $COMMON 2>&1 || true)
+    check "gateway rm" "$?"
+else
+    echo "  SKIP: no GW_ID available"
+    SKIP=$((SKIP + 2))
+fi
+
+# ============================================================
+section "6. Config Commands"
+# ============================================================
+
+OUT=$($CLI config show $COMMON 2>&1 || true)
+check "config show" "$?"
+
+OUT=$($CLI config path $COMMON 2>&1 || true)
+check "config path" "$?"
+
+# ============================================================
+section "7. Status Command"
+# ============================================================
+
+OUT=$($CLI status $COMMON $PROJECT_FLAG 2>&1 || true)
+check "status" "$?"
+
+# ============================================================
+section "99. Cleanup"
+# ============================================================
+
+if [ -n "$PROJECT_ID" ]; then
+    curl -s -X DELETE "$API_URL/api/v1/projects/$PROJECT_ID" \
+        -H "Authorization: Bearer $JWT" > /dev/null 2>&1
+    check "delete project" "0"
+fi
+
+# ============================================================
+section "RESULTS"
+# ============================================================
+
+echo "  Passed:  $PASS"
+echo "  Failed:  $FAIL"
+echo "  Skipped: $SKIP"
+
+if [ ${#ERRORS[@]} -gt 0 ]; then
+    echo ""
+    echo "  FAILURES:"
+    for err in "${ERRORS[@]}"; do
+        echo "    ✗ $err"
+    done
+fi
+
+TOTAL=$((PASS + FAIL))
+if [ $TOTAL -gt 0 ]; then
+    PCT=$((PASS * 100 / TOTAL))
+    echo ""
+    echo "  Pass rate: ${PCT}%"
+fi
+
+[ $FAIL -eq 0 ] && exit 0 || exit 1

--- a/docs/architecture/05-mut-init-clone-accesspoint.md
+++ b/docs/architecture/05-mut-init-clone-accesspoint.md
@@ -35,7 +35,7 @@
 
 - `mut init` 只在本地创建 `.mut/` 目录，标记当前目录为 MUT repo
 - `mut init` **不创建 server**，不产生 SoT
-- 必须后续通过 `mut add access-point` 绑定到 server，才能进行 sync 操作
+- 必须后续通过 `mut link access` 绑定到 server，才能进行 sync 操作
 
 ---
 
@@ -91,7 +91,7 @@
              │
              ▼
 ┌─────────────────────────────────┐
-│  Step 2: mut add access-point   │
+│  Step 2: mut link access   │
 │          <url> <root_dir_name>   │
 │                                  │
 │  本地端：                         │
@@ -148,7 +148,7 @@
              │
              ▼
 ┌─────────────────────────────────┐
-│  Step 3: mut add access-point   │
+│  Step 3: mut link access   │
 │          <url>                   │
 │                                  │
 │  → 绑定到已有数据的 server        │
@@ -163,7 +163,7 @@
 - 本地的 SoT 先通过 Filesystem Connector 传到 PuppyOne
 - 传输完成后，Server 端拥有完整数据，成为 SoT
 - 之后的流程等同于场景 A（从 PuppyOne clone），相当于反向clone
-- `mut add access-point <url>` 不指定 `root_dir_name`，直接绑定到已有 repo
+- `mut link access <url>` 不指定 `root_dir_name`，直接绑定到已有 repo
 - 如果指定了 `root_dir_name`，只是额外添加一个子文件夹 scope，不会替换内容
 
 ---
@@ -176,24 +176,26 @@
 mut init
 ```
 
-| 行为                | 说明                                   |
-| ------------------- | -------------------------------------- |
-| 创建 `.mut/` 目录 | 包含 `config.json`（空 server 配置） |
-| 不创建 server       | 纯本地操作                             |
-| 不产生 SoT          | 只是标记，不做任何数据承诺             |
-| 幂等                | 重复运行不报错                         |
+| 行为                | 说明                                                                 |
+| ------------------- | -------------------------------------------------------------------- |
+| 创建 `.mut/` 目录 | 包含 `config.json`（`{"version": 1, "server": null}`）            |
+| 初始化对象存储      | 创建 `objects/`、`snapshots/` 等子目录                              |
+| 不创建 server       | 纯本地操作                                                           |
+| 不产生 SoT          | 只是标记，不做任何数据承诺                                           |
+| 幂等                | `.mut/` 已存在时不报错，保留已有配置                                |
+| 向后兼容            | 保持已有的 init 逻辑（创建 object store + snapshot chain），在此基础上扩展 config 结构 |
 
-### `mut add access-point`
+### `mut link access`
 
 ```bash
 # 场景 B：本地空目录，需要指定 root_dir_name 创建 scope
-mut add access-point <access_point_url> <root_dir_name>
+mut link access <access_point_url> <root_dir_name>
 
 # 场景 C：本地非空目录，已通过 connector 同步
-mut add access-point <access_point_url>
+mut link access <access_point_url>
 
 # 场景 C：额外添加子文件夹 scope
-mut add access-point <access_point_url> <sub_dir_name>
+mut link access <access_point_url> <sub_dir_name>
 ```
 
 | 参数                      | 说明                                                   |
@@ -201,11 +203,12 @@ mut add access-point <access_point_url> <sub_dir_name>
 | `access_point_url`      | PuppyOne Access Point 的 URL                           |
 | `root_dir_name`（可选） | 在 client 和 server 同时创建的根文件夹名称，作为 scope |
 
-| 行为                      | 说明                                   |
-| ------------------------- | -------------------------------------- |
-| 写入 `.mut/config.json` | 保存 server URL 和 credential          |
-| 验证连接                  | 确认 server 可达且 access_key 有效     |
-| 同步 scope                | 如指定 root_dir_name，在双端创建文件夹 |
+| 行为                      | 说明                                                              |
+| ------------------------- | ----------------------------------------------------------------- |
+| 写入 `.mut/config.json` | 保存 server URL 和 credential                                     |
+| 验证连接                  | 确认 server 可达且 access_key 有效（发送 clone 请求测试）          |
+| 同步 scope                | 如指定 root_dir_name，在 client 创建文件夹并 push 到 server       |
+| 前提条件                  | 必须先执行 `mut init`（`.mut/` 目录必须存在）                    |
 
 ### `mut clone`（保持不变）
 
@@ -249,7 +252,7 @@ mut clone <access_point_url>
 │          │                                            │
 │          └─ 用户不希望被覆盖？                         │
 │             → 创建新的 MUT Repo + 新的 Server           │
-│             → 重新 mut init + mut add access-point     │
+│             → 重新 mut init + mut link access     │
 │             → Client 端内容成为新 server 的 SoT         │
 │             → 新 repo 中不存在其他 client 的干扰        │
 │                                                       │
@@ -278,7 +281,7 @@ MUT Server
 cd /my-important-project
 mut init
 # 通过 filesystem connector 上传到 PuppyOne → 创建新 repo + server
-mut add access-point <new_access_point_url>
+mut link access <new_access_point_url>
 # 此时 client A 的内容是新 server 唯一的 SoT
 # 没有其他 client 会推送到这个 server
 ```
@@ -298,7 +301,7 @@ mut add access-point <new_access_point_url>
 
 ### 初始化策略
 
-当通过 `mut add access-point <url> <root_dir_name>` 创建新 server 时：
+当通过 `mut link access <url> <root_dir_name>` 创建新 server 时：
 
 ```python
 # Server 端初始化逻辑
@@ -389,7 +392,7 @@ mkdir my-project && cd my-project
 mut init
 
 # 2. 绑定到 PuppyOne（创建新 server + scope）
-mut add access-point https://api.puppyone.com/mut/ap/cli_xxx research
+mut link access https://api.puppyone.com/mut/ap/cli_xxx research
 
 # 3. 开始在 research/ 下工作
 echo "# Research Notes" > research/notes.md
@@ -413,7 +416,7 @@ mut init
 #    → 生成 Access Point
 
 # 4. 绑定
-mut add access-point https://api.puppyone.com/mut/ap/cli_xxx
+mut link access https://api.puppyone.com/mut/ap/cli_xxx
 
 # 5. 正常使用
 mut status
@@ -429,7 +432,7 @@ mut push
 | --------------------------------- | ------------------------- | ------------------------------------------- |
 | 同 scope 多 client SoT 冲突       | ⚠️ 设计方案已定，待验证 | 通过 scope 隔离 + 新 repo 隔离解决          |
 | Filesystem Connector 大文件上传   | ⚠️ 待测试               | 场景 C 中大目录的初始同步性能               |
-| `mut add access-point` 的原子性 | ⚠️ 待实现               | client 和 server 同时创建文件夹需要事务保证 |
+| `mut link access` 的原子性 | ⚠️ 待实现               | client 和 server 同时创建文件夹需要事务保证 |
 | 离线 init 后的首次绑定            | ⚠️ 待测试               | init 后长时间离线，再绑定时的状态同步       |
 | LWW 场景下的用户预期管理          | ⚠️ 待 UX 设计           | 用户可能不理解为什么自己的修改被覆盖        |
 
@@ -441,5 +444,5 @@ mut push
 | ------------ | ---------------------------------- | --------------------------------------- |
 | MUT Engine   | Server 初始化、scope 注册          | [01-mut-engine.md](01-mut-engine.md)       |
 | Access Point | URL 格式、credential 解析          | [02-access-points.md](02-access-points.md) |
-| CLI          | init、add access-point、clone 命令 | [03-cli.md](03-cli.md)                     |
+| CLI          | init、link access、clone 命令      | [03-cli.md](03-cli.md)                     |
 | Connectors   | Filesystem Connector（场景 C）     | [04-connectors.md](04-connectors.md)       |

--- a/docs/architecture/06-gateway-access-point-split.md
+++ b/docs/architecture/06-gateway-access-point-split.md
@@ -1,0 +1,495 @@
+# 06 — Gateway / Access Point 拆分设计
+
+> 版本: v1.0 | 日期: 2026-04-11
+
+---
+
+## 1. 动机
+
+现有架构中，`access_points` 表承载了三个不同关注点：
+
+1. **第三方账号绑定**（OAuth token、数据库连接串）
+2. **同步配置**（方向、触发器、过滤器）
+3. **MUT 协议入口**（access_key、scope、权限）
+
+这导致：
+- 删除项目/repo → 删 access_point → OAuth 绑定丢失 → 下次需重新授权
+- 一张表字段过多（22+ 列），不同 provider 用不同子集
+- 用户难以理解 "access point" 同时代表 Gmail 连接和 MUT 入口
+
+---
+
+## 2. 核心设计
+
+拆成两层：
+
+```
+┌─────────────────────────────────────────────────┐
+│  Gateway（账号绑定层）                            │
+│                                                  │
+│  职责：第三方平台 ↔ PuppyOne 的账号互通          │
+│  生命周期：跟 user/org 走，跨项目复用             │
+│  例子：Gmail OAuth、GitHub OAuth、PostgreSQL 连接 │
+│                                                  │
+│  删项目不影响 gateway                             │
+│  新项目可直接复用已有 gateway                     │
+└──────────────────┬──────────────────────────────┘
+                   │ gateway_id（可选 FK）
+                   ▼
+┌─────────────────────────────────────────────────┐
+│  Access Point（数据流层）                         │
+│                                                  │
+│  职责：某个数据源 → 某个 MUT repo 的连通配置     │
+│  生命周期：跟 project/repo 走                    │
+│                                                  │
+│  包含：gateway_id、project_id、scope、sync 配置  │
+│  暴露：access_key → MUT 协议入口                 │
+│                                                  │
+│  删 project → 删 access point → gateway 不变     │
+└─────────────────────────────────────────────────┘
+```
+
+**非第三方类型**（agent / sandbox / mcp / filesystem / direct）不需要 gateway，直接是 access point。
+
+---
+
+## 3. 数据库改动
+
+### 3.1 新建 `gateways` 表
+
+```sql
+CREATE TABLE gateways (
+    id          text PRIMARY KEY DEFAULT gen_random_uuid()::text,
+    org_id      text NOT NULL REFERENCES organizations(id),
+    user_id     uuid NOT NULL,
+    provider    text NOT NULL,
+    name        text,
+    status      text NOT NULL DEFAULT 'active',
+    credentials jsonb DEFAULT '{}',
+    metadata    jsonb DEFAULT '{}',
+    created_at  timestamptz NOT NULL DEFAULT now(),
+    updated_at  timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_gateways_user_provider ON gateways(user_id, provider);
+CREATE INDEX idx_gateways_org ON gateways(org_id);
+ALTER TABLE gateways ENABLE ROW LEVEL SECURITY;
+CREATE POLICY service_role_all_gateways
+    ON gateways FOR ALL TO service_role USING (true) WITH CHECK (true);
+```
+
+**字段说明：**
+
+| 字段 | 说明 |
+|------|------|
+| `org_id` | 属于哪个组织（跨项目复用的基础） |
+| `user_id` | 谁绑定的（一个用户可以有多个同 provider 的 gateway，如两个 Gmail） |
+| `provider` | 平台类型：`gmail`、`github`、`notion`、`google_drive`、`database` 等 |
+| `credentials` | OAuth token（access_token、refresh_token、expires_at）或数据库连接串 |
+| `metadata` | Provider 特有元数据（workspace_name、workspace_id、bot_id 等） |
+| `status` | `active`（正常）、`expired`（token 过期）、`revoked`（用户主动断开） |
+
+### 3.2 修改 `access_points` 表
+
+```sql
+ALTER TABLE access_points ADD COLUMN gateway_id text REFERENCES gateways(id) ON DELETE SET NULL;
+CREATE INDEX idx_access_points_gateway ON access_points(gateway_id);
+```
+
+- `gateway_id` 可选：第三方 datasource 类型必填，agent/sandbox/mcp/filesystem/direct 为 NULL
+- `ON DELETE SET NULL`：删除 gateway 时，关联的 AP 不被级联删除，而是断开绑定
+
+### 3.3 数据迁移：`oauth_connections` → `gateways`
+
+```sql
+INSERT INTO gateways (id, org_id, user_id, provider, name, credentials, metadata)
+SELECT
+    gen_random_uuid()::text,
+    COALESCE(p.default_org_id, (SELECT id FROM organizations LIMIT 1)),
+    oc.user_id,
+    oc.provider,
+    COALESCE(oc.workspace_name, oc.provider),
+    jsonb_build_object(
+        'access_token', oc.access_token,
+        'refresh_token', oc.refresh_token,
+        'token_type', oc.token_type,
+        'expires_at', oc.expires_at
+    ),
+    jsonb_build_object(
+        'workspace_id', oc.workspace_id,
+        'workspace_name', oc.workspace_name,
+        'bot_id', oc.bot_id
+    ) - 'null'  -- remove null keys
+FROM oauth_connections oc
+LEFT JOIN profiles p ON p.user_id = oc.user_id;
+```
+
+### 3.4 回填 `access_points.gateway_id`
+
+```sql
+-- 对于有 credentials_ref 或 user_id 的 datasource AP，关联到对应 gateway
+UPDATE access_points ap
+SET gateway_id = g.id
+FROM gateways g
+WHERE ap.provider = g.provider
+  AND ap.user_id = g.user_id
+  AND ap.provider NOT IN ('agent', 'mcp', 'sandbox', 'filesystem', 'direct');
+```
+
+### 3.5 表关系图
+
+```
+organizations (1)
+    │
+    ├── gateways (N)           ← 账号绑定，跨项目
+    │   │
+    │   │   gateway_id (可选FK)
+    │   ▼
+    ├── projects (N)
+    │   │
+    │   ├── access_points (N)  ← 数据流配置，绑定项目
+    │   │   ├── sync_state     (1:1, datasource 类型)
+    │   │   ├── agent_profiles (1:1, agent 类型)
+    │   │   └── access_key     → MUT 协议入口
+    │   │
+    │   └── mut_commits, mut_scope_state ...
+    │
+    └── oauth_connections (legacy, 迁移后废弃)
+```
+
+---
+
+## 4. 后端代码改动
+
+### 4.1 新建 Gateway 模块
+
+```
+backend/src/connectors/gateway/
+├── __init__.py
+├── router.py          — API 端点
+├── service.py         — 业务逻辑
+├── repository.py      — Supabase CRUD
+└── schemas.py         — Pydantic models
+```
+
+**API 端点：**
+
+| Method | Path | 说明 |
+|--------|------|------|
+| `GET /api/v1/gateways` | 列出当前 org 所有 gateway | 支持 `?provider=gmail` 过滤 |
+| `POST /api/v1/gateways` | 手动创建（database 类型） | body: `{provider, name, credentials, metadata}` |
+| `GET /api/v1/gateways/{id}` | 获取详情 | |
+| `PATCH /api/v1/gateways/{id}` | 更新名称/元数据 | |
+| `DELETE /api/v1/gateways/{id}` | 删除（检查关联 AP） | |
+| `POST /api/v1/gateways/{id}/refresh-token` | 刷新 OAuth token | |
+| `GET /api/v1/gateways/providers` | 可用 provider 列表 | |
+| `GET /api/v1/gateways/{provider}/authorize` | 获取 OAuth 授权 URL | |
+| `POST /api/v1/gateways/{provider}/callback` | OAuth 回调 → 创建 gateway | |
+| `GET /api/v1/gateways/{provider}/status` | OAuth 连接状态 | |
+
+### 4.2 修改 OAuth 流程
+
+```
+现在：
+  OAuth callback → INSERT INTO oauth_connections → 创建 AP → 开始同步
+
+新设计：
+  OAuth callback → INSERT INTO gateways（只存 token）
+  用户选项目 + scope → 创建 AP（带 gateway_id）→ 开始同步
+```
+
+**改动文件：**
+- `connectors/datasource/oauth/router.py` → 迁移到 `connectors/gateway/router.py`
+- `connectors/datasource/oauth/repository.py` → 改为写 `gateways` 表
+- `connectors/datasource/oauth/models.py` → 更新模型
+
+### 4.3 修改 Access Point 创建
+
+**`connectors/manager/router.py` 的 `create_connection` endpoint：**
+
+```python
+# 第三方 datasource 类型：必须指定 gateway_id
+if provider in DATASOURCE_PROVIDERS:
+    if not payload.gateway_id:
+        raise HTTPException(400, "gateway_id required for datasource providers")
+    gateway = gateway_repo.get_by_id(payload.gateway_id)
+    if not gateway:
+        raise HTTPException(404, "Gateway not found")
+    # 创建 AP 时写入 gateway_id
+    ...
+
+# 非第三方类型：不需要 gateway（agent/sandbox/mcp/filesystem/direct）
+else:
+    # 创建逻辑不变
+    ...
+```
+
+**`UnifiedConnectionCreate` schema 新增：**
+```python
+gateway_id: str | None = Field(None, description="Gateway ID for datasource providers")
+```
+
+### 4.4 修改 Sync 执行时的 Credential 获取
+
+**`connectors/datasource/service.py`：**
+
+```python
+# 现在
+token = oauth_repo.get_by_user_and_provider(user_id, provider)
+
+# 新设计
+gateway = gateway_repo.get_by_id(access_point.gateway_id)
+token = gateway.credentials.get("access_token")
+if gateway.is_token_expired():
+    token = gateway_service.refresh_token(gateway.id)
+```
+
+### 4.5 `access_point.py` resolve 不变
+
+`_resolve_and_validate` 只查 `access_points` 表。Gateway 的 credentials 只在 sync 执行时读取。MUT 协议操作（clone/push/pull）不涉及 gateway。
+
+---
+
+## 5. CLI 改动
+
+### 5.1 新增 `puppyone gateway` 命令组
+
+```bash
+# OAuth 连接
+puppyone gateway connect gmail             # 打开浏览器 OAuth → 创建 gateway
+puppyone gateway connect github            # 同上
+puppyone gateway connect notion            # 同上
+
+# 手动创建（数据库等）
+puppyone gateway connect database \
+  --set host=db.example.com \
+  --set port=5432 \
+  --set database=mydb \
+  --set user=admin \
+  --set password=secret
+
+# 管理
+puppyone gateway ls                        # 列出所有 gateway
+puppyone gateway info <id>                 # 详情（含 token 状态）
+puppyone gateway rm <id>                   # 删除（警告关联的 AP）
+puppyone gateway refresh <id>              # 刷新 OAuth token
+puppyone gateway providers                 # 可用的 provider 列表
+```
+
+### 5.2 修改 `puppyone access add` 流程
+
+```bash
+# 第三方数据源：需要指定 gateway（或自动匹配唯一 gateway）
+puppyone access add gmail --gateway <gw_id> --scope /inbox
+puppyone access add github --gateway <gw_id> --scope /repos --set repo=org/repo
+puppyone access add notion --gateway <gw_id> --scope /pages
+
+# 如果只有一个对应 provider 的 gateway，可省略 --gateway
+puppyone access add gmail --scope /inbox
+# → 自动选择唯一的 gmail gateway
+# → 如果有多个，提示用户选择
+
+# 非第三方类型：不需要 gateway（不变）
+puppyone access add agent "Research Bot" --scope /data
+puppyone access add filesystem /docs
+puppyone access add mcp "API" --scope /api
+puppyone access add sandbox "Runner"
+puppyone access add direct "Default" --scope / --permission rw
+```
+
+### 5.3 `puppyone access ls` 输出变化
+
+```bash
+$ puppyone access ls
+ID          Provider    Gateway         Scope    Perm  Status   Name
+──────────  ──────────  ──────────────  ───────  ────  ───────  ──────────
+ak_abc123   gmail       My Gmail (#3)   /inbox   read  active   Email Import
+ak_not456   notion      Work Notion     /notes   rw    active   Notion Sync
+ak_agt012   agent       —               /data    rw    active   Research Bot
+ak_fs901    filesystem  —               /docs    rw    active   Local Sync
+```
+
+Gateway 列显示关联的 gateway 名称，非第三方类型显示 `—`。
+
+---
+
+## 6. 前端改动
+
+### 6.1 `/settings/connect` → Gateway 管理
+
+| 改前 | 改后 |
+|------|------|
+| 显示 OAuth 连接列表 + "Connect" 按钮 | 显示 **Gateway 列表** + "Connect" 按钮 |
+| 连接 = 创建 OAuth + 创建 AP | 连接 = **只创建 Gateway**（OAuth 授权） |
+| 删除连接 = 删 AP + 丢 OAuth | 删除 gateway = 断开账号绑定，不影响已有 AP |
+
+### 6.2 `/projects/{id}/access` → Access Point 管理
+
+| 改前 | 改后 |
+|------|------|
+| "Add" → 选 provider → OAuth 流程 → 创建 AP | "Add" → 选 provider → **选择已有 Gateway** → 配置 scope → 创建 AP |
+| 无 gateway 概念 | 第三方类型显示 gateway 下拉；无 gateway 时引导去 Settings |
+| 每个 AP 包含 OAuth 状态 | AP 显示关联 gateway 名称；OAuth 状态在 gateway 层管理 |
+
+### 6.3 创建 AP 弹窗流程
+
+```
+1. 选择 provider 类型
+   ├── agent / sandbox / mcp / filesystem / direct → 直接配置 scope
+   └── gmail / github / notion / database → 进入 Step 2
+
+2. 选择 Gateway
+   ├── 已有 gateway → 选择
+   └── 无 gateway → "Go to Settings to connect" 按钮
+
+3. 配置 scope + trigger + 权限
+
+4. 创建 AP
+```
+
+---
+
+## 7. 与 MUT init/clone/link 的衔接
+
+| 场景 | Gateway 层 | Access Point 层 | MUT Client |
+|------|-----------|-----------------|------------|
+| **A: PuppyOne 导入数据** | `puppyone gateway connect notion` | `puppyone access add notion --gateway <id> --scope /notes` → AP 创建，数据同步到 MUT tree | `mut clone <ap_url>` |
+| **B: 本地空目录** | 不需要 gateway | `puppyone access add filesystem --scope /` → AP 创建 | `mut init` → `mut link access <ap_url>` |
+| **C: 本地已有文件** | 不需要 gateway | `puppyone access add filesystem --scope /` → AP 创建 | `mut init` → `mut link access <ap_url>` → `mut push` |
+| **D: AI Agent** | 不需要 gateway | `puppyone access add agent "Bot" --scope /data` | Agent 内部用 MutEphemeralClient |
+| **E: MCP 端点** | 不需要 gateway | `puppyone access add mcp "API" --scope /` | 外部 MCP client 调用 |
+| **F: 沙盒** | 不需要 gateway | `puppyone access add sandbox "Runner"` | 沙盒内用 MutEphemeralClient |
+
+---
+
+## 8. 实施步骤
+
+### Phase 1: 数据库 ✅ 已完成
+1. ✅ 创建 `gateways` 表 + RLS 策略
+2. ✅ `access_points` 加 `gateway_id` 列（nullable）
+3. ✅ 迁移 `oauth_connections` 数据到 `gateways`
+4. ✅ 回填 `access_points.gateway_id`
+
+**文件**: `supabase/migrations/20260411000000_gateway_access_point_split.sql`
+
+### Phase 2: 后端 Gateway API ✅ 已完成
+5. ✅ 创建 `connectors/gateway/` 模块（router/service/repository/schemas）
+6. ✅ 注册到 `main.py`
+7. ✅ 实现 CRUD + OAuth authorize/callback + providers list + token refresh
+
+**文件**: `backend/src/connectors/gateway/__init__.py`, `router.py`, `service.py`, `repository.py`, `schemas.py`
+
+**API 端点**:
+- `GET /api/v1/gateways` — 列出 gateway
+- `POST /api/v1/gateways` — 手动创建（database 等）
+- `GET /api/v1/gateways/{id}` — 详情
+- `PATCH /api/v1/gateways/{id}` — 更新
+- `DELETE /api/v1/gateways/{id}` — 删除
+- `POST /api/v1/gateways/{id}/refresh-token` — 刷新 token
+- `GET /api/v1/gateways/providers` — provider 列表
+- `GET /api/v1/gateways/{provider}/authorize` — OAuth 授权 URL
+- `POST /api/v1/gateways/{provider}/callback` — OAuth 回调
+
+### Phase 3: AP 创建流程 ✅ 已完成
+8. ✅ `UnifiedConnectionCreate` 新增 `gateway_id` 字段
+9. ✅ Datasource AP 创建时将 `gateway_id` 写入 `access_points` 表
+10. ⏳ Datasource sync 执行时从 gateway 读 credentials（渐进式，当前仍兼容 `oauth_connections` 路径）
+
+**文件**: `backend/src/connectors/manager/router.py`
+
+### Phase 4: CLI ✅ 已完成
+11. ✅ 新增 `puppyone gateway` 命令组（`cli/src/commands/gateway.js`）
+12. ✅ 修改 `puppyone access add`：datasource 类型支持 `--gateway`，自动检测唯一 gateway
+13. ⏳ `puppyone access ls` 显示 gateway 列（待前端对齐后同步更新）
+
+**文件**: `cli/src/commands/gateway.js`（新文件）, `cli/src/commands/access.js`, `cli/bin/puppyone.js`
+
+### Phase 5: 前端 ❌ 待实现（前端开发）
+
+> **以下改动需要前端开发者实现。后端 API 已就绪，前端只需调用新端点。**
+
+#### 5.1 `/settings/connect` → Gateway 管理页面
+
+**当前**：显示 OAuth 连接列表，连接 = 创建 OAuth + 创建 AP。
+
+**需改为**：
+- 调用 `GET /api/v1/gateways` 显示 Gateway 列表（按 provider 分组）
+- "Connect" 按钮调用 `GET /api/v1/gateways/{provider}/authorize` 获取 OAuth URL → 打开浏览器
+- OAuth 回调后调用 `POST /api/v1/gateways/{provider}/callback` 创建 gateway
+- 删除按钮调用 `DELETE /api/v1/gateways/{id}`
+- 显示 Gateway 状态（active/expired/revoked）、关联的 AP 数量
+- "Refresh Token" 按钮调用 `POST /api/v1/gateways/{id}/refresh-token`
+
+**涉及前端文件**：
+- `frontend/app/(main)/settings/connect/page.tsx` 或相关组件
+- 需要新建 `frontend/lib/gatewayApi.ts`（调用 `/api/v1/gateways` 端点）
+
+#### 5.2 `/projects/{id}/access` → AP 创建弹窗支持选择 Gateway
+
+**当前**：选 provider → 直接创建 AP（OAuth 流程嵌入）。
+
+**需改为**：
+- 第三方 provider（gmail/github/notion 等）：
+  1. 调用 `GET /api/v1/gateways?provider=xxx` 获取已有 gateway 列表
+  2. 如果有 gateway → 下拉选择
+  3. 如果没有 → 显示 "Go to Settings → Connect" 引导按钮
+  4. 选择 gateway 后配置 scope/trigger → `POST /api/v1/access/` 带 `gateway_id`
+- 非第三方 provider（agent/sandbox/mcp/filesystem/direct）：流程不变
+
+**涉及前端文件**：
+- `frontend/app/(main)/projects/[projectId]/access/page.tsx`
+- 创建 AP 的弹窗/对话框组件
+
+#### 5.3 AP 列表和详情页显示关联 Gateway
+
+**当前**：不显示 gateway 信息。
+
+**需改为**：
+- `puppyone access ls` 表格新增 "Gateway" 列
+- 显示 `gateway_id` 关联的 gateway 名称（需要 join 查询或前端二次请求）
+- AP 详情页显示 Gateway 名称 + 状态 + "View Gateway" 链接
+
+**涉及前端文件**：
+- `frontend/app/(main)/projects/[projectId]/access/page.tsx`
+- `frontend/components/agent/views/SyncDetailView.tsx` 等详情组件
+
+### Phase 6: 清理 ❌ 待实施（在 Phase 5 完成后）
+17. 标记 `oauth_connections` 为 deprecated
+18. 后续版本删除 `oauth_connections` 表
+19. 移除 `access_points.credentials_ref` 字段
+20. Datasource sync 全面切换到从 gateway 读 credentials
+18. 后续版本删除 `oauth_connections` 表
+19. 移除 `credentials_ref` 字段
+
+---
+
+## 9. 兼容性
+
+- **Phase 1-2 完全向后兼容**：新表新模块，不改现有逻辑
+- **Phase 3 渐进式**：`gateway_id` 可选，旧 AP 仍然从 `oauth_connections` 读 token
+- **Phase 4-5 可并行**：CLI 和前端可独立开发
+- **Phase 6 需要全面迁移后才能执行**
+
+---
+
+## 10. 不需要 Gateway 的类型
+
+| Provider | 需要 Gateway？ | 原因 |
+|----------|---------------|------|
+| `agent` | 否 | 无外部账号 |
+| `sandbox` | 否 | 无外部账号 |
+| `mcp` | 否 | 无外部账号 |
+| `filesystem` | 否 | 本地文件夹，无 OAuth |
+| `direct` | 否 | 直连 MUT |
+| `gmail` | **是** | Google OAuth |
+| `github` | **是** | GitHub OAuth |
+| `notion` | **是** | Notion OAuth |
+| `google_drive` | **是** | Google OAuth |
+| `google_docs` | **是** | Google OAuth |
+| `google_sheets` | **是** | Google OAuth |
+| `google_calendar` | **是** | Google OAuth |
+| `google_search_console` | **是** | Google OAuth |
+| `linear` | **是** | Linear OAuth |
+| `airtable` | **是** | Airtable OAuth |
+| `database` | **是** | 连接串 = 凭证 |
+| `url` | 否 | 无需认证（公开 URL） |

--- a/supabase/migrations/20260411000000_gateway_access_point_split.sql
+++ b/supabase/migrations/20260411000000_gateway_access_point_split.sql
@@ -1,0 +1,120 @@
+-- ============================================================
+-- Migration: Gateway / Access Point Split
+--
+-- Separates third-party account bindings (Gateway) from
+-- data flow configuration (Access Point).
+--
+-- Gateway = OAuth/credential binding, lives at org level,
+--           survives project deletion, reusable across projects.
+-- Access Point = MUT repo binding, lives at project level,
+--               deleted with project.
+--
+-- Reference: docs/architecture/06-gateway-access-point-split.md
+-- ============================================================
+
+BEGIN;
+
+-- ── 1. Create gateways table ──────────────────────────────
+
+CREATE TABLE IF NOT EXISTS "public"."gateways" (
+    "id"          text PRIMARY KEY DEFAULT gen_random_uuid()::text,
+    "org_id"      text NOT NULL,
+    "user_id"     uuid NOT NULL,
+    "provider"    text NOT NULL,
+    "name"        text,
+    "status"      text NOT NULL DEFAULT 'active',
+    "credentials" jsonb DEFAULT '{}',
+    "metadata"    jsonb DEFAULT '{}',
+    "created_at"  timestamptz NOT NULL DEFAULT now(),
+    "updated_at"  timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_gateways_user_provider
+    ON gateways(user_id, provider);
+CREATE INDEX IF NOT EXISTS idx_gateways_org
+    ON gateways(org_id);
+
+ALTER TABLE "public"."gateways" ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "service_role_all_gateways" ON "public"."gateways";
+CREATE POLICY "service_role_all_gateways"
+    ON "public"."gateways"
+    FOR ALL TO service_role
+    USING (true) WITH CHECK (true);
+
+-- Grant permissions
+GRANT ALL ON TABLE "public"."gateways" TO anon;
+GRANT ALL ON TABLE "public"."gateways" TO authenticated;
+GRANT ALL ON TABLE "public"."gateways" TO service_role;
+
+-- ── 2. Add gateway_id to access_points ────────────────────
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'access_points'
+          AND column_name = 'gateway_id'
+    ) THEN
+        ALTER TABLE "public"."access_points"
+            ADD COLUMN "gateway_id" text REFERENCES gateways(id) ON DELETE SET NULL;
+    END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_access_points_gateway
+    ON access_points(gateway_id);
+
+-- ── 3. Migrate oauth_connections → gateways ───────────────
+
+-- Only migrate if oauth_connections exists and gateways is empty
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema = 'public' AND table_name = 'oauth_connections'
+    ) THEN
+        INSERT INTO gateways (id, org_id, user_id, provider, name, credentials, metadata)
+        SELECT
+            gen_random_uuid()::text,
+            COALESCE(
+                p.default_org_id,
+                (SELECT id FROM organizations LIMIT 1),
+                'unknown'
+            ),
+            oc.user_id,
+            oc.provider,
+            COALESCE(oc.workspace_name, oc.provider),
+            jsonb_strip_nulls(jsonb_build_object(
+                'access_token', oc.access_token,
+                'refresh_token', oc.refresh_token,
+                'token_type', oc.token_type,
+                'expires_at', oc.expires_at::text
+            )),
+            jsonb_strip_nulls(jsonb_build_object(
+                'workspace_id', oc.workspace_id,
+                'workspace_name', oc.workspace_name,
+                'bot_id', oc.bot_id
+            ))
+        FROM oauth_connections oc
+        LEFT JOIN profiles p ON p.user_id = oc.user_id
+        WHERE NOT EXISTS (
+            -- Skip if already migrated
+            SELECT 1 FROM gateways g
+            WHERE g.user_id = oc.user_id AND g.provider = oc.provider
+        );
+    END IF;
+END $$;
+
+-- ── 4. Backfill access_points.gateway_id ──────────────────
+
+-- Link existing datasource APs to their corresponding gateway
+UPDATE access_points ap
+SET gateway_id = g.id
+FROM gateways g
+WHERE ap.gateway_id IS NULL
+  AND ap.provider = g.provider
+  AND ap.user_id = g.user_id
+  AND ap.provider NOT IN ('agent', 'mcp', 'sandbox', 'filesystem', 'direct', 'url');
+
+COMMIT;


### PR DESCRIPTION
一、Gateway / Access Point 架构拆分
核心思想：将第三方账号绑定（OAuth token、数据库连接串）和 MUT 数据流配置分离为两层。
改动前：access_points 一张表承载 OAuth 绑定 + 同步配置 + MUT 入口。删除项目 → OAuth 丢失 → 需重新授权。
改动后：
Gateway（账号层）：绑定第三方账号，挂在 org 下，跨项目复用，删项目不影响
Access Point（数据流层）：配置某个 Gateway 到某个 MUT repo 的同步规则，跟项目走
数据库：
新建 gateways 表（id、org_id、user_id、provider、credentials、metadata、status）
access_points 表新增 gateway_id 可选外键
oauth_connections 数据自动迁移到 gateways
迁移文件：supabase/migrations/20260411000000_gateway_access_point_split.sql
后端：
新建 connectors/gateway/ 模块（router、service、repository、schemas，4 个新文件）
10 个 API 端点：CRUD + OAuth authorize/callback + providers + token refresh
connectors/manager/router.py：UnifiedConnectionCreate 新增 gateway_id 字段，datasource 创建时写入 gateway 关联
注册到 main.py
CLI：
新建 cli/src/commands/gateway.js：puppyone gateway connect/ls/info/rm/refresh/providers
cli/src/commands/access.js：puppyone access add 新增 --gateway 参数，自动检测唯一 gateway

二、PuppyOne CLI 关键 Bug 修复
问题：所有 CLI 命令调用 API 都返回 401 "Session expired"。
根因：FastAPI 对不带 trailing slash 的 URL（如 /api/v1/projects）做 307 redirect 到 /api/v1/projects/。但 redirect 的 Location header 使用 http://（Railway 反向代理没有传递 X-Forwarded-Proto: https），导致浏览器/Node.js 的安全策略在协议降级时自动剥离 Authorization header。
修复（cli/src/api.js）：
fetch 请求设置 redirect: "manual"，手动处理 redirect
跟随 redirect 时保留 Authorization header
检测 http:// → https:// 协议降级并自动修正
retry 路径（token 刷新后重试）同样处理
验证：修复后 CLI 16/18 命令通过（剩余 2 个是 Gateway API 未部署，非 bug）。