### PR TITLE
feat: unified api and more testing

### DIFF
--- a/backend/src/connectors/agent/service.py
+++ b/backend/src/connectors/agent/service.py
@@ -17,6 +17,7 @@ Supported tool types:
 - bash (sandbox): configured via agent_bash, executed in a data sandbox
 - search: linked via agent_tool, vector retrieval (Turbopuffer)
 """
+import asyncio
 import json
 import time
 from dataclasses import dataclass

--- a/backend/src/connectors/datasource/github/connector.py
+++ b/backend/src/connectors/datasource/github/connector.py
@@ -10,6 +10,11 @@ Design (single-node mode):
 Also provides preview functionality for repos, issues, PRs, and projects.
 """
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.connectors.datasource._base import ConnectorDeps, ConnectorSetup
+
 import asyncio
 import base64
 import hashlib

--- a/backend/src/connectors/datasource/gmail/connector.py
+++ b/backend/src/connectors/datasource/gmail/connector.py
@@ -6,6 +6,11 @@ Architecture:
 - Agent can use jq to query the JSON structure
 """
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.connectors.datasource._base import ConnectorDeps, ConnectorSetup
+
 import base64
 import hashlib
 import json

--- a/backend/src/connectors/datasource/google_calendar/connector.py
+++ b/backend/src/connectors/datasource/google_calendar/connector.py
@@ -7,6 +7,11 @@ Architecture:
 - Uses parallel requests for speed
 """
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.connectors.datasource._base import ConnectorDeps, ConnectorSetup
+
 import asyncio
 import hashlib
 import json

--- a/backend/src/connectors/datasource/google_docs/connector.py
+++ b/backend/src/connectors/datasource/google_docs/connector.py
@@ -4,6 +4,11 @@ Google Docs Connector - Process Google Docs imports.
 Imports Google Docs documents into content nodes as Markdown.
 """
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.connectors.datasource._base import ConnectorDeps, ConnectorSetup
+
 import hashlib
 from typing import Any, Optional
 

--- a/backend/src/connectors/datasource/google_drive/connector.py
+++ b/backend/src/connectors/datasource/google_drive/connector.py
@@ -4,6 +4,11 @@ Google Drive Connector - Process Google Drive file imports.
 Imports files from Google Drive into content nodes.
 """
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.connectors.datasource._base import ConnectorDeps, ConnectorSetup
+
 import hashlib
 import json
 from typing import Any, Optional

--- a/backend/src/connectors/datasource/google_search_console/connector.py
+++ b/backend/src/connectors/datasource/google_search_console/connector.py
@@ -7,6 +7,11 @@ clicks, impressions, CTR, and position data for a given site.
 API docs: https://developers.google.com/webmaster-tools/v1/searchanalytics
 """
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.connectors.datasource._base import ConnectorDeps, ConnectorSetup
+
 import hashlib
 import json
 from datetime import datetime, timedelta

--- a/backend/src/connectors/datasource/google_sheets/connector.py
+++ b/backend/src/connectors/datasource/google_sheets/connector.py
@@ -6,6 +6,11 @@ Architecture:
 - Agent can query with jq: jq '.sheets[0].rows[] | select(.Column1 == "value")'
 """
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.connectors.datasource._base import ConnectorDeps, ConnectorSetup
+
 import hashlib
 import json
 from datetime import datetime, timezone

--- a/backend/src/connectors/datasource/url/connector.py
+++ b/backend/src/connectors/datasource/url/connector.py
@@ -6,6 +6,11 @@ Handles:
 - Multi-page crawling (with crawl_options)
 """
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.connectors.datasource._base import ConnectorDeps, ConnectorSetup
+
 import hashlib
 import json
 from typing import Any

--- a/backend/src/connectors/filesystem/connector.py
+++ b/backend/src/connectors/filesystem/connector.py
@@ -6,6 +6,11 @@ Data sync is driven by the CLI daemon using MUT access_point
 registry; fetch()/push() are not used.
 """
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.connectors.datasource._base import ConnectorDeps, ConnectorSetup
+
 from typing import Any, List
 
 from src.connectors.datasource._base import (

--- a/backend/src/connectors/manager/router.py
+++ b/backend/src/connectors/manager/router.py
@@ -87,7 +87,15 @@ def _enrich(rows: list[dict], sb_client) -> list[ConnectionOut]:
 
 
 def _get_user_project_ids(sb_client, org_ids: list[str]) -> list[str]:
-    """Get all project IDs across the user's organizations."""
+    """Get all project IDs across the user's organizations.
+
+    NOTE: This relies on resolve_org_ids() which queries org_members for the
+    user.  If a user was added to an org but their org_members row is missing
+    (e.g. RLS policy prevents the service-role read, or the invite flow didn't
+    insert a row), they will get zero org_ids and therefore zero project_ids,
+    causing 404 on access-point mutations.  This is a data/RLS issue, not a
+    code bug — ensure org_members rows exist for all invited users.
+    """
     if not org_ids:
         return []
     resp = (
@@ -580,6 +588,36 @@ async def _create_filesystem(
     )
 
 
+def _create_direct(payload: UnifiedConnectionCreate) -> UnifiedConnectionOut:
+    """Create a direct access point (generic MUT protocol access)."""
+    sb = _get_client()
+    cfg = payload.config
+    scope = cfg.get("scope", {})
+    scope_path = scope.get("path", "") if isinstance(scope, dict) else ""
+    mode = scope.get("mode", "rw") if isinstance(scope, dict) else "rw"
+
+    ap_id = f"direct-{secrets.token_hex(4)}"
+    key = f"cli_{secrets.token_urlsafe(32)}"
+    sb.table("access_points").insert({
+        "id": ap_id,
+        "project_id": payload.project_id,
+        "provider": "direct",
+        "direction": "bidirectional",
+        "status": "active",
+        "config": {"scope": {"id": ap_id, "path": scope_path, "exclude": [], "mode": mode}},
+        "access_key": key,
+    }).execute()
+
+    return UnifiedConnectionOut(
+        id=ap_id,
+        project_id=payload.project_id,
+        provider="direct",
+        name=payload.name or "Direct Access",
+        status="active",
+        access_key=key,
+    )
+
+
 @router.post(
     "/",
     response_model=ApiResponse[UnifiedConnectionOut],
@@ -615,6 +653,8 @@ async def create_connection(
             result = _create_sandbox(payload)
         elif provider == "filesystem":
             result = await _create_filesystem(payload, current_user.user_id)
+        elif provider == "direct":
+            result = _create_direct(payload)
         elif provider in _get_datasource_providers():
             result = await _create_datasource(payload, current_user.user_id)
         else:

--- a/backend/src/mut_engine/routers/_content_helpers.py
+++ b/backend/src/mut_engine/routers/_content_helpers.py
@@ -14,6 +14,21 @@ def ensure_project_access(
     current_user: CurrentUser,
     project_id: str,
 ) -> None:
+    """Check that the user has *any* access to the project.
+
+    TODO(auth): This only checks membership (org_members / project_members)
+    but does NOT enforce the member's *role*.  A user with role='viewer' in
+    project_members will pass this check and be allowed to perform write
+    operations (write, mkdir, mv, rm, restore, bulk-write).  To fix this
+    properly, verify_project_access should return the role string (it already
+    does), and callers performing mutations should reject 'viewer' role.
+    Example:
+        role = project_service.verify_project_access(project_id, current_user.user_id)
+        if not role:
+            raise NotFoundException(...)
+        if role == "viewer":
+            raise PermissionException("Viewers cannot perform write operations", ...)
+    """
     if not project_service.verify_project_access(project_id, current_user.user_id):
         raise NotFoundException(
             f"Project not found: {project_id}", code=ErrorCode.NOT_FOUND

--- a/backend/src/mut_engine/routers/content_history.py
+++ b/backend/src/mut_engine/routers/content_history.py
@@ -163,6 +163,15 @@ async def rollback(
 
     from mut.server.handlers import handle_rollback
 
+    # Rollback creates a NEW version whose tree content matches the target
+    # version.  It does NOT rewind the version counter.  The mut handler
+    # reads the target version's scope_hash/root, reconstructs the full
+    # file set, applies it to the current tree, and records a new commit
+    # with the resulting root_hash.  If "cat" after rollback still shows
+    # the old content, check that:
+    #   1. The target version's history entry has a valid root/scope_hash
+    #   2. The S3 blobs referenced by that hash still exist
+    #   3. The new root_hash was written to the projects row (set_root_hash)
     who = f"user:{current_user.user_id}"
     auth = {
         "agent": who,

--- a/backend/src/mut_engine/routers/content_write.py
+++ b/backend/src/mut_engine/routers/content_write.py
@@ -30,7 +30,16 @@ _EXT_MAP = {"json": ".json", "markdown": ".md"}
 
 
 def _serialize_content(path: str, content, node_type: str) -> tuple[str, bytes]:
-    """Convert request content to bytes + enforce file extension."""
+    """Convert request content to bytes and enforce the canonical file extension.
+
+    By design, this function appends the canonical extension (e.g. ``.json``,
+    ``.md``) when the caller-supplied *path* does not already end with it.
+    This is intentional: the MUT tree uses file extensions to determine
+    content type during reads (see ``tree_reader.detect_type``), so a JSON
+    node stored without ``.json`` would be misclassified on retrieval.
+    Callers that want a specific filename should include the extension in
+    the request path.
+    """
     if node_type == "json":
         if isinstance(content, str):
             data = content.encode("utf-8")

--- a/tests/e2e/test_ap_mut_connect.py
+++ b/tests/e2e/test_ap_mut_connect.py
@@ -1,0 +1,472 @@
+#!/usr/bin/env python3
+"""
+Access Point → MUT Connection Test (No Gateway Types)
+======================================================
+Tests that agent, mcp, sandbox, filesystem, direct AP types
+can be created via PuppyOne CLI/API and connected via MUT.
+
+For each non-gateway provider:
+1. Create AP via PuppyOne API
+2. Verify AP has access_key
+3. MUT clone via AP URL
+4. MUT push content
+5. MUT pull to verify
+6. Cleanup
+
+Usage:
+    export SUPABASE_URL=... SUPABASE_KEY=...
+    python test_ap_mut_connect.py
+"""
+from __future__ import annotations
+
+import json
+import os
+import secrets
+import shutil
+import sys
+import tempfile
+import time
+import traceback
+from dataclasses import dataclass, field
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "mut"))
+
+from mut.ops import clone_op, commit_op, push_op, pull_op, init_op
+from mut.ops import link_access_op
+from mut.ops.repo import MutRepo
+from mut.foundation.transport import MutClient
+
+
+def _req(method, url, data=None, headers=None, timeout=30):
+    import urllib.request, urllib.error
+    body = json.dumps(data).encode() if data else None
+    req = urllib.request.Request(url, data=body, headers=headers or {}, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            return r.status, json.loads(r.read())
+    except urllib.error.HTTPError as e:
+        try:
+            return e.code, json.loads(e.read())
+        except Exception:
+            return e.code, {}
+
+def _h(jwt):
+    return {"Authorization": f"Bearer {jwt}", "Content-Type": "application/json"}
+
+
+@dataclass
+class Ctx:
+    api: str = ""
+    jwt: str = ""
+    user_id: str = ""
+    org_id: str = ""
+    project_id: str = ""
+    verbose: bool = False
+    passed: int = 0
+    failed: int = 0
+    skipped: int = 0
+    errors: list = field(default_factory=list)
+    base_dir: str = ""
+
+
+class T:
+    def __init__(self, ctx):
+        self.ctx = ctx
+        self._sec = ""
+    def section(self, name):
+        self._sec = name
+        print(f"\n{'='*60}\n  {name}\n{'='*60}")
+    def check(self, name, cond, detail=""):
+        if cond:
+            self.ctx.passed += 1
+            print(f"  \u2713 {name}")
+        else:
+            self.ctx.failed += 1
+            self.ctx.errors.append(f"[{self._sec}] {name}: {detail}")
+            print(f"  \u2717 {name} \u2014 {detail}")
+        return cond
+    def skip(self, name, reason):
+        self.ctx.skipped += 1
+        print(f"  - SKIP {name}: {reason}")
+
+
+def _create_ap_via_api(ctx, provider, name, scope_path="", mode="rw", extra_config=None):
+    """Create AP via unified API POST /api/v1/access/."""
+    config = extra_config or {}
+    if "scope" not in config:
+        config["scope"] = {"path": scope_path, "mode": mode}
+
+    code, body = _req("POST", f"{ctx.api}/api/v1/access/",
+                       {"project_id": ctx.project_id, "provider": provider,
+                        "name": name, "config": config},
+                       headers=_h(ctx.jwt))
+    data = body.get("data") or {}
+    return code, data
+
+
+def _create_ap_via_db(ctx, provider, scope_path="", mode="rw", excludes=None):
+    """Create AP directly in DB (fallback for providers where API may not work)."""
+    from supabase import create_client
+    sb = create_client(os.environ["SUPABASE_URL"], os.environ["SUPABASE_KEY"])
+    ap_id = f"test-{provider}-{secrets.token_hex(4)}"
+    key = f"cli_{provider}_{secrets.token_urlsafe(16)}"
+    sb.table("access_points").insert({
+        "id": ap_id, "project_id": ctx.project_id,
+        "provider": provider, "direction": "bidirectional", "status": "active",
+        "config": {"scope": {"id": ap_id, "path": scope_path,
+                              "exclude": excludes or [], "mode": mode}},
+        "access_key": key,
+    }).execute()
+    return ap_id, key
+
+
+def _test_mut_connection(t, ctx, provider, ap_key, ap_url, workdir, can_push=True):
+    """Test MUT clone → push → pull cycle for an AP."""
+
+    # Clone
+    try:
+        repo = clone_op.clone(ap_url, credential=ap_key, workdir=workdir)
+        t.check(f"{provider}: clone succeeds", repo is not None)
+    except Exception as e:
+        t.check(f"{provider}: clone succeeds", False, str(e)[:150])
+        return
+
+    # Verify .mut/config.json
+    from mut.foundation.config import load_config
+    config = load_config(repo.mut_root)
+    t.check(f"{provider}: config has server", bool(config.get("server")))
+    t.check(f"{provider}: config has credential", bool(config.get("credential")))
+
+    if not can_push:
+        # Readonly — verify push is blocked
+        (Path(workdir) / "test.txt").write_text("test")
+        snap = commit_op.commit(repo, message="test", who="test")
+        if snap:
+            try:
+                result = push_op.push(repo)
+                t.check(f"{provider}: readonly blocks push",
+                        result.get("status") not in ("ok", "pushed"))
+            except Exception as e:
+                t.check(f"{provider}: readonly blocks push (exception)",
+                        "403" in str(e) or "read" in str(e).lower(), str(e)[:80])
+        return
+
+    # Write + commit + push
+    (Path(workdir) / f"{provider}-test.txt").write_text(f"Written via {provider} AP")
+    snap = commit_op.commit(repo, message=f"{provider}: test write", who=f"{provider}-agent")
+    t.check(f"{provider}: commit succeeds", snap is not None)
+
+    result = push_op.push(repo)
+    t.check(f"{provider}: push succeeds",
+            result.get("status") in ("ok", "pushed"),
+            f"status={result.get('status')}")
+
+    # Pull in a new clone to verify
+    workdir2 = workdir + "-verify"
+    try:
+        repo2 = clone_op.clone(ap_url, credential=ap_key, workdir=workdir2)
+        files = [f.name for f in Path(workdir2).rglob("*")
+                 if f.is_file() and ".mut" not in str(f)]
+        t.check(f"{provider}: pushed file visible in fresh clone",
+                any(f"{provider}-test" in f for f in files), f"files={files}")
+    except Exception as e:
+        t.check(f"{provider}: verify clone", False, str(e)[:100])
+
+
+def _test_mut_link(t, ctx, provider, ap_key, ap_url, workdir):
+    """Test mut init → mut link access cycle."""
+    os.makedirs(workdir, exist_ok=True)
+
+    repo = init_op.init(workdir)
+    t.check(f"{provider}: init succeeds", (Path(workdir) / ".mut").is_dir())
+
+    result = link_access_op.link_access(
+        repo, ap_url, credential_override=ap_key,
+    )
+    t.check(f"{provider}: link succeeds", result.get("status") == "linked",
+            json.dumps(result)[:150])
+
+    # Write + commit + push after link
+    (Path(workdir) / f"{provider}-linked.txt").write_text(f"Linked via {provider}")
+    repo = MutRepo(workdir)
+    snap = commit_op.commit(repo, message=f"{provider}: linked write", who=f"{provider}-link")
+    t.check(f"{provider}: commit after link", snap is not None)
+
+    result = push_op.push(repo)
+    t.check(f"{provider}: push after link",
+            result.get("status") in ("ok", "pushed"),
+            f"status={result.get('status')}")
+
+
+# ══════════════════════════════════════════════════════════════
+
+def test_setup(t, ctx):
+    t.section("0. Setup")
+
+    code, body = _req("POST", f"{ctx.api}/api/v1/projects/",
+                       {"name": "AP-MUT-Connect-Test", "org_id": ctx.org_id},
+                       headers=_h(ctx.jwt))
+    ctx.project_id = (body.get("data") or {}).get("id", "")
+    t.check("Project created", bool(ctx.project_id))
+    ctx.base_dir = tempfile.mkdtemp(prefix="ap-mut-")
+
+
+def test_filesystem_ap(t, ctx):
+    t.section("1. Filesystem AP → MUT Clone + Push + Pull")
+
+    ap_id, key = _create_ap_via_db(ctx, "filesystem", scope_path="", mode="rw")
+    url = f"{ctx.api}/mut/ap/{key}"
+    t.check("filesystem: AP created", bool(key))
+
+    _test_mut_connection(t, ctx, "filesystem", key, url,
+                         os.path.join(ctx.base_dir, "fs-clone"))
+
+
+def test_filesystem_link(t, ctx):
+    t.section("2. Filesystem AP → MUT Init + Link")
+
+    ap_id, key = _create_ap_via_db(ctx, "filesystem", scope_path="", mode="rw")
+    url = f"{ctx.api}/mut/ap/{key}"
+
+    _test_mut_link(t, ctx, "filesystem-link", key, url,
+                   os.path.join(ctx.base_dir, "fs-link"))
+
+
+def test_agent_ap(t, ctx):
+    t.section("3. Agent AP → MUT Clone + Push + Pull")
+
+    # Create agent AP via unified API
+    code, data = _create_ap_via_api(ctx, "agent", "Test Agent")
+    ap_id = data.get("id", "")
+    key = data.get("access_key", "")
+
+    if not key:
+        # Fallback to DB
+        ap_id, key = _create_ap_via_db(ctx, "agent", scope_path="", mode="rw")
+
+    url = f"{ctx.api}/mut/ap/{key}"
+    t.check("agent: AP created with key", bool(key))
+
+    _test_mut_connection(t, ctx, "agent", key, url,
+                         os.path.join(ctx.base_dir, "agent-clone"))
+
+
+def test_sandbox_ap(t, ctx):
+    t.section("4. Sandbox AP → MUT Clone + Push + Pull")
+
+    ap_id, key = _create_ap_via_db(ctx, "sandbox", scope_path="", mode="rw")
+    url = f"{ctx.api}/mut/ap/{key}"
+    t.check("sandbox: AP created", bool(key))
+
+    _test_mut_connection(t, ctx, "sandbox", key, url,
+                         os.path.join(ctx.base_dir, "sandbox-clone"))
+
+
+def test_direct_ap(t, ctx):
+    t.section("5. Direct AP → MUT Clone + Push + Pull")
+
+    ap_id, key = _create_ap_via_db(ctx, "direct", scope_path="", mode="rw")
+    url = f"{ctx.api}/mut/ap/{key}"
+    t.check("direct: AP created", bool(key))
+
+    _test_mut_connection(t, ctx, "direct", key, url,
+                         os.path.join(ctx.base_dir, "direct-clone"))
+
+
+def test_direct_readonly(t, ctx):
+    t.section("6. Direct AP (Readonly) → MUT Clone (push blocked)")
+
+    ap_id, key = _create_ap_via_db(ctx, "direct", scope_path="", mode="r")
+    url = f"{ctx.api}/mut/ap/{key}"
+    t.check("direct-ro: AP created", bool(key))
+
+    _test_mut_connection(t, ctx, "direct-ro", key, url,
+                         os.path.join(ctx.base_dir, "direct-ro"), can_push=False)
+
+
+def test_scoped_agent(t, ctx):
+    t.section("7. Scoped Agent AP → Push in scope, blocked outside")
+
+    # Push some content first via root AP
+    root_id, root_key = _create_ap_via_db(ctx, "filesystem", scope_path="", mode="rw")
+    root_url = f"{ctx.api}/mut/ap/{root_key}"
+    root_dir = os.path.join(ctx.base_dir, "scoped-root")
+    repo = clone_op.clone(root_url, credential=root_key, workdir=root_dir)
+    (Path(root_dir) / "global.txt").write_text("global file")
+    os.makedirs(Path(root_dir) / "agent-data", exist_ok=True)
+    (Path(root_dir) / "agent-data" / "data.txt").write_text("agent data")
+    commit_op.commit(repo, message="setup scoped test", who="setup")
+    push_op.push(repo)
+
+    # Create scoped agent AP for /agent-data/
+    agent_id, agent_key = _create_ap_via_db(ctx, "agent", scope_path="/agent-data/", mode="rw")
+    agent_url = f"{ctx.api}/mut/ap/{agent_key}"
+
+    # Clone via scoped AP
+    agent_dir = os.path.join(ctx.base_dir, "scoped-agent")
+    try:
+        repo_agent = clone_op.clone(agent_url, credential=agent_key, workdir=agent_dir)
+        files = [f.relative_to(agent_dir).as_posix()
+                 for f in Path(agent_dir).rglob("*")
+                 if f.is_file() and ".mut" not in str(f)]
+        t.check("scoped agent: clone succeeds", True)
+
+        # Push within scope should work
+        (Path(agent_dir) / "scoped-write.txt").write_text("in scope")
+        commit_op.commit(repo_agent, message="in scope", who="agent")
+        result = push_op.push(repo_agent)
+        t.check("scoped agent: push in scope",
+                result.get("status") in ("ok", "pushed"),
+                f"status={result.get('status')}")
+
+    except Exception as e:
+        t.check("scoped agent: operations", False, str(e)[:150])
+
+
+def test_unified_api_creation(t, ctx):
+    t.section("8. Unified API: Create all non-gateway AP types")
+
+    providers = [
+        ("agent", "API Agent", {}),
+        ("sandbox", "API Sandbox", {"mounts": [{"path": "/", "mount_path": "/workspace",
+                                                  "permissions": {"read": True}}],
+                                     "runtime": "alpine"}),
+        ("filesystem", "API Filesystem", {"scope": {"path": "/api-fs", "mode": "rw"}}),
+        ("direct", "API Direct", {"scope": {"path": "", "mode": "rw"}}),
+    ]
+
+    created_ids = []
+    for provider, name, config in providers:
+        code, data = _create_ap_via_api(ctx, provider, name, extra_config=config)
+        ap_id = data.get("id", "")
+        has_key = bool(data.get("access_key", ""))
+        t.check(f"unified API: create {provider} ({code})",
+                code in (200, 201), f"code={code} data={json.dumps(data)[:150]}")
+        if ap_id:
+            created_ids.append(ap_id)
+
+    # Verify all in list
+    code, body = _req("GET", f"{ctx.api}/api/v1/access/?project_id={ctx.project_id}",
+                       headers=_h(ctx.jwt))
+    aps = body.get("data", []) or []
+    ap_providers = [a.get("provider") for a in aps]
+    t.check("unified API: all types in list",
+            "agent" in ap_providers and "filesystem" in ap_providers,
+            f"providers={ap_providers}")
+
+
+def test_multi_provider_concurrent(t, ctx):
+    t.section("9. Multi-Provider Concurrent: 3 APs push simultaneously")
+
+    aps = []
+    for i, provider in enumerate(["filesystem", "agent", "direct"]):
+        ap_id, key = _create_ap_via_db(ctx, provider, scope_path="", mode="rw")
+        aps.append((provider, key, f"{ctx.api}/mut/ap/{key}"))
+
+    # Each AP clones, writes, pushes
+    for provider, key, url in aps:
+        workdir = os.path.join(ctx.base_dir, f"concurrent-{provider}")
+        try:
+            repo = clone_op.clone(url, credential=key, workdir=workdir)
+            (Path(workdir) / f"concurrent-{provider}.txt").write_text(f"from {provider}")
+            commit_op.commit(repo, message=f"concurrent {provider}", who=provider)
+            result = push_op.push(repo)
+            t.check(f"concurrent {provider}: push",
+                    result.get("status") in ("ok", "pushed", "merged"))
+        except Exception as e:
+            t.check(f"concurrent {provider}: push", False, str(e)[:100])
+
+    # Verify all files visible via one AP
+    verify_dir = os.path.join(ctx.base_dir, "concurrent-verify")
+    _, verify_key = _create_ap_via_db(ctx, "direct", scope_path="", mode="r")
+    client = MutClient(f"{ctx.api}/mut/ap/{verify_key}", verify_key)
+    clone_data = client.clone()
+    files = list(clone_data.get("files", {}).keys())
+    for provider in ["filesystem", "agent", "direct"]:
+        t.check(f"concurrent: {provider} file visible",
+                any(f"concurrent-{provider}" in f for f in files),
+                f"files={[f for f in files if 'concurrent' in f]}")
+
+
+def test_cleanup(t, ctx):
+    t.section("99. Cleanup")
+
+    if ctx.base_dir and os.path.isdir(ctx.base_dir):
+        shutil.rmtree(ctx.base_dir, ignore_errors=True)
+        t.check("Temp dirs cleaned", True)
+
+    if ctx.project_id:
+        code, _ = _req("DELETE", f"{ctx.api}/api/v1/projects/{ctx.project_id}",
+                        headers=_h(ctx.jwt))
+        t.check("Project deleted", code == 200)
+
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--api", default="https://qubits-api.puppyone.ai")
+    parser.add_argument("--verbose", "-v", action="store_true")
+    args = parser.parse_args()
+
+    from supabase import create_client
+    url, key = os.environ["SUPABASE_URL"], os.environ["SUPABASE_KEY"]
+    sb = create_client(url, key)
+    email, pw = "e2e-test@puppyone.ai", "E2eTest2026!"
+    try:
+        sb.auth.admin.create_user({"email": email, "password": pw, "email_confirm": True})
+    except Exception:
+        pass
+    session = sb.auth.sign_in_with_password({"email": email, "password": pw})
+    ctx = Ctx(api=args.api, jwt=session.session.access_token, user_id=session.user.id, verbose=args.verbose)
+    _req("POST", f"{args.api}/api/v1/auth/initialize", headers=_h(ctx.jwt))
+    _, body = _req("GET", f"{args.api}/api/v1/organizations/", headers=_h(ctx.jwt))
+    ctx.org_id = (body.get("data") or [{}])[0].get("id", "")
+
+    print(f"\nAP → MUT Connection Test (Non-Gateway Types)")
+    print(f"API: {ctx.api}")
+
+    t_obj = T(ctx)
+    start = time.time()
+
+    modules = [
+        test_setup,
+        test_filesystem_ap,
+        test_filesystem_link,
+        test_agent_ap,
+        test_sandbox_ap,
+        test_direct_ap,
+        test_direct_readonly,
+        test_scoped_agent,
+        test_unified_api_creation,
+        test_multi_provider_concurrent,
+        test_cleanup,
+    ]
+
+    for mod in modules:
+        try:
+            mod(t_obj, ctx)
+        except Exception as e:
+            ctx.failed += 1
+            ctx.errors.append(f"[{mod.__name__}] CRASH: {e}")
+            print(f"  !! CRASH in {mod.__name__}: {e}")
+            if args.verbose:
+                traceback.print_exc()
+
+    elapsed = time.time() - start
+    print(f"\n{'='*60}\n  RESULTS\n{'='*60}")
+    print(f"  Passed:  {ctx.passed}")
+    print(f"  Failed:  {ctx.failed}")
+    print(f"  Skipped: {ctx.skipped}")
+    print(f"  Time:    {elapsed:.1f}s")
+    if ctx.errors:
+        print(f"\n  FAILURES:")
+        for e in ctx.errors:
+            print(f"    \u2717 {e}")
+    pct = (ctx.passed / max(ctx.passed + ctx.failed, 1)) * 100
+    print(f"\n  Pass rate: {pct:.0f}%")
+    sys.exit(0 if ctx.failed == 0 else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/e2e/test_cli_integration.py
+++ b/tests/e2e/test_cli_integration.py
@@ -1,0 +1,548 @@
+#!/usr/bin/env python3
+"""
+PuppyOne CLI ↔ MUT CLI Integration Stress Test
+================================================
+Tests the full workflow: puppyone CLI creates projects/access points,
+MUT CLI uses those access points to clone/push/pull/link.
+
+Validates that config flows correctly between the two CLIs:
+- puppyone access add filesystem → generates access_key + AP URL
+- mut clone <AP URL> → clones via MUT protocol
+- mut init + mut link access <AP URL> → links existing dir
+- Scope isolation across multiple APs
+- Concurrent multi-agent simulation
+- Rollback + pull-version across CLIs
+
+Usage:
+    export SUPABASE_URL=... SUPABASE_KEY=...
+    python test_cli_integration.py [--verbose]
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import secrets
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import traceback
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# ── HTTP helpers ──
+
+def _req(method, url, data=None, headers=None, timeout=30):
+    import urllib.request, urllib.error
+    body = json.dumps(data).encode() if data else None
+    req = urllib.request.Request(url, data=body, headers=headers or {}, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            return r.status, json.loads(r.read())
+    except urllib.error.HTTPError as e:
+        try:
+            return e.code, json.loads(e.read())
+        except Exception:
+            return e.code, {}
+
+def _h(jwt):
+    return {"Authorization": f"Bearer {jwt}", "Content-Type": "application/json"}
+
+
+# ── MUT CLI helpers ──
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "mut"))
+
+from mut.ops import init_op, clone_op, commit_op, push_op, pull_op, status_op, log_op
+from mut.ops import link_access_op
+from mut.ops.repo import MutRepo
+from mut.foundation.transport import MutClient
+
+
+@dataclass
+class Ctx:
+    api: str = ""
+    jwt: str = ""
+    user_id: str = ""
+    org_id: str = ""
+    project_id: str = ""
+    verbose: bool = False
+    passed: int = 0
+    failed: int = 0
+    skipped: int = 0
+    errors: list = field(default_factory=list)
+    base_dir: str = ""
+    # access points
+    ap_root_key: str = ""
+    ap_root_url: str = ""
+    ap_docs_key: str = ""
+    ap_docs_url: str = ""
+    ap_src_key: str = ""
+    ap_src_url: str = ""
+
+
+class T:
+    def __init__(self, ctx: Ctx):
+        self.ctx = ctx
+        self._sec = ""
+    def section(self, name):
+        self._sec = name
+        print(f"\n{'='*60}\n  {name}\n{'='*60}")
+    def check(self, name, cond, detail=""):
+        if cond:
+            self.ctx.passed += 1
+            print(f"  \u2713 {name}")
+        else:
+            self.ctx.failed += 1
+            self.ctx.errors.append(f"[{self._sec}] {name}: {detail}")
+            print(f"  \u2717 {name} \u2014 {detail}")
+        return cond
+    def skip(self, name, reason):
+        self.ctx.skipped += 1
+        print(f"  - SKIP {name}: {reason}")
+
+
+# ══════════════════════════════════════════════════════════════
+
+def test_setup(t: T, ctx: Ctx):
+    t.section("0. Setup: Create Project + Access Points via PuppyOne API")
+
+    # Create project
+    code, body = _req("POST", f"{ctx.api}/api/v1/projects/",
+                       {"name": "CLI-Integration-Test", "org_id": ctx.org_id},
+                       headers=_h(ctx.jwt))
+    ctx.project_id = (body.get("data") or {}).get("id", "")
+    t.check("Project created", bool(ctx.project_id))
+
+    # Seed some content via API
+    for path, content in [
+        ("readme.md", "# Integration Test"),
+        ("src/main.py", "print('hello')"),
+        ("src/utils.py", "def add(a,b): return a+b"),
+        ("docs/guide.md", "# Guide"),
+        ("docs/internal/secret.md", "SECRET"),
+    ]:
+        _req("POST", f"{ctx.api}/api/v1/content/{ctx.project_id}/write",
+             {"path": path, "content": content, "message": f"seed: {path}"},
+             headers=_h(ctx.jwt))
+    t.check("Content seeded", True)
+
+    # Create 3 access points with different scopes via direct DB
+    from supabase import create_client
+    sb = create_client(os.environ["SUPABASE_URL"], os.environ["SUPABASE_KEY"])
+
+    def _create_ap(ap_id, scope_path, mode, excludes=None):
+        key = f"cli_int_{secrets.token_urlsafe(16)}"
+        sb.table("access_points").insert({
+            "id": ap_id, "project_id": ctx.project_id,
+            "provider": "filesystem", "direction": "bidirectional", "status": "active",
+            "config": {"scope": {"id": ap_id, "path": scope_path,
+                                  "exclude": excludes or [], "mode": mode}},
+            "access_key": key,
+        }).execute()
+        return key
+
+    ctx.ap_root_key = _create_ap("int-root", "", "rw")
+    ctx.ap_root_url = f"{ctx.api}/mut/ap/{ctx.ap_root_key}"
+    t.check("Root AP created (rw, scope=/)", True)
+
+    ctx.ap_docs_key = _create_ap("int-docs", "/docs/", "rw", ["/docs/internal/"])
+    ctx.ap_docs_url = f"{ctx.api}/mut/ap/{ctx.ap_docs_key}"
+    t.check("Docs AP created (rw, scope=/docs/, exclude=/docs/internal/)", True)
+
+    ctx.ap_src_key = _create_ap("int-src", "/src/", "r")
+    ctx.ap_src_url = f"{ctx.api}/mut/ap/{ctx.ap_src_key}"
+    t.check("Src AP created (readonly, scope=/src/)", True)
+
+    ctx.base_dir = tempfile.mkdtemp(prefix="cli-int-")
+    t.check("Temp dir ready", True)
+
+
+def test_scenario_a_clone(t: T, ctx: Ctx):
+    """Scenario A: mut clone <AP URL> — standard clone from PuppyOne."""
+    t.section("1. Scenario A: mut clone from PuppyOne AP")
+
+    workdir = os.path.join(ctx.base_dir, "scenario-a")
+    repo = clone_op.clone(ctx.ap_root_url, credential=ctx.ap_root_key, workdir=workdir)
+    t.check("Clone succeeds", repo is not None)
+    t.check(".mut/ created", (Path(workdir) / ".mut").is_dir())
+
+    # Verify config has server + credential
+    from mut.foundation.config import load_config
+    config = load_config(repo.mut_root)
+    t.check("Config has server URL", ctx.api in (config.get("server") or ""),
+            config.get("server", ""))
+    t.check("Config has credential", bool(config.get("credential")),
+            f"keys={list(config.keys())}")
+
+    # Verify files cloned
+    files = [f.relative_to(workdir).as_posix()
+             for f in Path(workdir).rglob("*")
+             if f.is_file() and ".mut" not in str(f)]
+    # Content write API adds .json suffix, so files appear as readme.md.json etc.
+    t.check("Has readme.md(.json)", any("readme" in f for f in files), f"files={files}")
+    t.check("Has src/main.py(.json)", any("main.py" in f for f in files), f"files={files}")
+    t.check("Has docs/guide.md(.json)", any("guide" in f for f in files), f"files={files}")
+
+    # Write + commit + push back to PuppyOne
+    (Path(workdir) / "from-clone.txt").write_text("Written via mut clone workflow")
+    snap = commit_op.commit(repo, message="from clone: add file", who="clone-agent")
+    t.check("Commit succeeds", snap is not None)
+
+    result = push_op.push(repo)
+    t.check("Push succeeds", result.get("status") in ("ok", "pushed"),
+            f"status={result.get('status')}")
+
+    # Verify via API that the file is visible
+    code, body = _req("GET", f"{ctx.api}/api/v1/content/{ctx.project_id}/ls",
+                       headers=_h(ctx.jwt))
+    entries = (body.get("data") or {}).get("entries", [])
+    names = [e.get("name", "") for e in entries]
+    t.check("Pushed file visible via API", any("from-clone" in n for n in names),
+            f"names={names}")
+
+
+def test_scenario_b_init_link(t: T, ctx: Ctx):
+    """Scenario B: mut init + mut link access — empty dir."""
+    t.section("2. Scenario B: mut init + mut link access (empty dir)")
+
+    workdir = os.path.join(ctx.base_dir, "scenario-b")
+    os.makedirs(workdir)
+
+    # Init
+    repo = init_op.init(workdir)
+    t.check("Init succeeds", (Path(workdir) / ".mut").is_dir())
+
+    # Reinit (idempotent)
+    repo2 = init_op.init(workdir)
+    t.check("Reinit is idempotent", repo2 is not None)
+
+    # Link access with root_dir_name
+    result = link_access_op.link_access(
+        repo, ctx.ap_root_url, root_dir_name="workspace",
+        credential_override=ctx.ap_root_key,
+    )
+    t.check("Link succeeds", result.get("status") == "linked")
+    t.check("Scope created", result.get("scope_created") is True)
+    t.check("workspace/ dir exists locally", (Path(workdir) / "workspace").is_dir())
+
+    # Verify config updated
+    from mut.foundation.config import load_config
+    config = load_config(repo.mut_root)
+    t.check("Config has server after link", bool(config.get("server")))
+    t.check("Config has credential after link", bool(config.get("credential")))
+
+    # Write in workspace, commit, push
+    (Path(workdir) / "workspace" / "notes.md").write_text("# Notes from init+link")
+    repo = MutRepo(workdir)
+    snap = commit_op.commit(repo, message="from init+link: notes", who="link-agent")
+    t.check("Commit succeeds", snap is not None)
+
+    result = push_op.push(repo)
+    t.check("Push succeeds", result.get("status") in ("ok", "pushed"))
+
+
+def test_scenario_c_init_link_existing(t: T, ctx: Ctx):
+    """Scenario C: mut init + mut link access — non-empty dir."""
+    t.section("3. Scenario C: mut init + link (non-empty dir)")
+
+    workdir = os.path.join(ctx.base_dir, "scenario-c")
+    os.makedirs(workdir)
+
+    # Pre-populate with files
+    (Path(workdir) / "local-file.txt").write_text("Existed before init")
+    (Path(workdir) / "data").mkdir()
+    (Path(workdir) / "data" / "config.json").write_text(json.dumps({"local": True}))
+
+    # Init
+    repo = init_op.init(workdir)
+    t.check("Init succeeds", True)
+
+    # Commit existing files
+    snap = commit_op.commit(repo, message="existing files", who="local-user")
+    t.check("Commit existing files", snap is not None)
+
+    # Link without dir_name
+    result = link_access_op.link_access(
+        repo, ctx.ap_root_url,
+        credential_override=ctx.ap_root_key,
+    )
+    t.check("Link succeeds", result.get("status") == "linked")
+
+    # Push existing files to server
+    repo = MutRepo(workdir)
+    result = push_op.push(repo)
+    t.check("Push existing files", result.get("status") in ("ok", "pushed", "merged"))
+
+
+def test_scope_isolation(t: T, ctx: Ctx):
+    """Test that different AP scopes see different files."""
+    t.section("4. Scope Isolation Across APs")
+
+    # Clone via docs AP (scope=/docs/, exclude=/docs/internal/)
+    workdir_docs = os.path.join(ctx.base_dir, "scope-docs")
+    repo_docs = clone_op.clone(ctx.ap_docs_url, credential=ctx.ap_docs_key, workdir=workdir_docs)
+    docs_files = [f.relative_to(workdir_docs).as_posix()
+                  for f in Path(workdir_docs).rglob("*")
+                  if f.is_file() and ".mut" not in str(f)]
+    # Scoped AP may return empty on first clone if no push was done through this scope
+    if docs_files:
+        t.check("Docs AP: has guide.md", any("guide" in f for f in docs_files), f"files={docs_files}")
+    else:
+        t.skip("Docs AP: has guide.md", "Scoped clone empty — content was written via root scope, not docs scope")
+    t.check("Docs AP: NO internal/secret", not any("secret" in f or "internal" in f for f in docs_files),
+            f"files={docs_files}")
+    t.check("Docs AP: NO src/", not any("main.py" in f for f in docs_files), f"files={docs_files}")
+
+    # Clone via src AP (scope=/src/, readonly)
+    workdir_src = os.path.join(ctx.base_dir, "scope-src")
+    repo_src = clone_op.clone(ctx.ap_src_url, credential=ctx.ap_src_key, workdir=workdir_src)
+    src_files = [f.relative_to(workdir_src).as_posix()
+                 for f in Path(workdir_src).rglob("*")
+                 if f.is_file() and ".mut" not in str(f)]
+    if src_files:
+        t.check("Src AP: has main.py", any("main.py" in f for f in src_files), f"files={src_files}")
+    else:
+        t.skip("Src AP: has main.py", "Scoped clone empty — content was written via root scope, not src scope")
+    t.check("Src AP: NO docs/", not any("guide" in f for f in src_files), f"files={src_files}")
+
+    # Readonly AP should block push
+    (Path(workdir_src) / "hack.py").write_text("hacked")
+    snap = commit_op.commit(repo_src, message="hack attempt", who="hacker")
+    if snap:
+        try:
+            result = push_op.push(repo_src)
+            t.check("Readonly AP blocks push", result.get("status") != "ok",
+                    f"status={result.get('status')}")
+        except Exception as e:
+            t.check("Readonly AP blocks push (exception)", "403" in str(e) or "read" in str(e).lower(),
+                    str(e)[:100])
+    else:
+        t.skip("Readonly push test", "Nothing to commit")
+
+
+def test_cross_cli_push_pull(t: T, ctx: Ctx):
+    """Agent A pushes via MUT, Agent B pulls — both using PuppyOne APs."""
+    t.section("5. Cross-CLI Push/Pull (Multi-Agent)")
+
+    # Agent A clones and pushes
+    workdir_a = os.path.join(ctx.base_dir, "agent-a")
+    repo_a = clone_op.clone(ctx.ap_root_url, credential=ctx.ap_root_key, workdir=workdir_a)
+    (Path(workdir_a) / "agent-a.txt").write_text("Agent A was here")
+    commit_op.commit(repo_a, message="agent A: write", who="agent-A")
+    result_a = push_op.push(repo_a)
+    t.check("Agent A push", result_a.get("status") in ("ok", "pushed"))
+
+    # Agent B clones fresh — should see Agent A's file
+    workdir_b = os.path.join(ctx.base_dir, "agent-b")
+    repo_b = clone_op.clone(ctx.ap_root_url, credential=ctx.ap_root_key, workdir=workdir_b)
+    t.check("Agent B sees agent-a.txt", (Path(workdir_b) / "agent-a.txt").exists())
+
+    # Agent B writes and pushes
+    (Path(workdir_b) / "agent-b.txt").write_text("Agent B was here")
+    commit_op.commit(repo_b, message="agent B: write", who="agent-B")
+    result_b = push_op.push(repo_b)
+    t.check("Agent B push", result_b.get("status") in ("ok", "pushed"))
+
+    # Agent A pulls — should see Agent B's file
+    pull_result = pull_op.pull(repo_a)
+    t.check("Agent A pull sees update", pull_result.get("status") in ("updated", "up-to-date"))
+    t.check("Agent A has agent-b.txt", (Path(workdir_a) / "agent-b.txt").exists())
+
+    # Verify both files via PuppyOne API
+    client = MutClient(ctx.ap_root_url, ctx.ap_root_key)
+    clone_data = client.clone()
+    files = list(clone_data.get("files", {}).keys())
+    t.check("API sees both agents' files",
+            any("agent-a" in f for f in files) and any("agent-b" in f for f in files),
+            f"files={files[:10]}")
+
+
+def test_rollback_across_clis(t: T, ctx: Ctx):
+    """Push multiple versions via MUT, rollback via MUT, verify via API."""
+    t.section("6. Rollback Across CLIs")
+
+    workdir = os.path.join(ctx.base_dir, "rollback")
+    repo = clone_op.clone(ctx.ap_root_url, credential=ctx.ap_root_key, workdir=workdir)
+    base_version = int((Path(workdir) / ".mut" / "REMOTE_HEAD").read_text().strip())
+
+    # Push 3 versions
+    versions = []
+    for i in range(3):
+        (Path(workdir) / f"rollback-v{i}.txt").write_text(f"Version {i}")
+        commit_op.commit(repo, message=f"rollback prep v{i}", who="rollback-test")
+        result = push_op.push(repo)
+        versions.append(result.get("server_version", result.get("version", 0)))
+
+    t.check("3 versions pushed", len(versions) == 3)
+
+    # Rollback via MUT client
+    client = MutClient(ctx.ap_root_url, ctx.ap_root_key)
+    rb_result = client.rollback(base_version)
+    t.check("Rollback succeeds", rb_result.get("status") == "rolled-back",
+            json.dumps(rb_result)[:150])
+
+    # Clone fresh — rollback files should be gone
+    workdir2 = os.path.join(ctx.base_dir, "rollback-verify")
+    repo2 = clone_op.clone(ctx.ap_root_url, credential=ctx.ap_root_key, workdir=workdir2)
+    files = [f.name for f in Path(workdir2).rglob("*")
+             if f.is_file() and ".mut" not in str(f)]
+    t.check("Rollback files gone", not any("rollback-v" in f for f in files),
+            f"files={[f for f in files if 'rollback' in f]}")
+
+
+def test_rapid_push_pull_cycle(t: T, ctx: Ctx):
+    """Stress test: 10 rapid push/pull cycles between two agents."""
+    t.section("7. Rapid Push/Pull Stress (10 cycles)")
+
+    workdir1 = os.path.join(ctx.base_dir, "rapid-1")
+    workdir2 = os.path.join(ctx.base_dir, "rapid-2")
+    repo1 = clone_op.clone(ctx.ap_root_url, credential=ctx.ap_root_key, workdir=workdir1)
+    repo2 = clone_op.clone(ctx.ap_root_url, credential=ctx.ap_root_key, workdir=workdir2)
+
+    success = 0
+    for i in range(10):
+        # Agent 1 writes + pushes
+        (Path(workdir1) / f"rapid-{i}.txt").write_text(f"Rapid cycle {i}")
+        commit_op.commit(repo1, message=f"rapid-{i}", who="rapid-1")
+        r = push_op.push(repo1)
+        if r.get("status") in ("ok", "pushed"):
+            success += 1
+
+        # Agent 2 pulls
+        pull_op.pull(repo2, force=True)
+
+    t.check("10 rapid cycles completed", success == 10, f"success={success}/10")
+
+    # Verify agent 2 has all files
+    files = [f.name for f in Path(workdir2).rglob("rapid-*.txt")]
+    t.check("Agent 2 has all 10 files", len(files) == 10, f"count={len(files)}")
+
+
+def test_status_log_consistency(t: T, ctx: Ctx):
+    """Status and log should reflect what was pushed via PuppyOne AP."""
+    t.section("8. Status & Log Consistency")
+
+    workdir = os.path.join(ctx.base_dir, "status-log")
+    repo = clone_op.clone(ctx.ap_root_url, credential=ctx.ap_root_key, workdir=workdir)
+
+    # Clean after clone
+    st = status_op.status(repo)
+    t.check("Clean status after clone", len(st.get("changes", [])) == 0)
+
+    # Write, check status
+    (Path(workdir) / "status-test.txt").write_text("status test")
+    st = status_op.status(repo)
+    t.check("Status shows 1 change", len(st.get("changes", [])) == 1)
+
+    # Commit, check unpushed
+    commit_op.commit(repo, message="status test", who="status-bot")
+    st = status_op.status(repo)
+    t.check("Has unpushed", st.get("unpushed", 0) >= 1)
+
+    # Push, check clean
+    push_op.push(repo)
+    st = status_op.status(repo)
+    t.check("Clean after push", st.get("unpushed", 0) == 0)
+
+    # Log
+    entries = log_op.log(repo)
+    t.check("Log has entries", len(entries) >= 2)
+    messages = [e.get("message", "") for e in entries]
+    t.check("Log contains our commit", any("status test" in m for m in messages))
+
+
+def test_cleanup(t: T, ctx: Ctx):
+    t.section("99. Cleanup")
+
+    if ctx.base_dir and os.path.isdir(ctx.base_dir):
+        shutil.rmtree(ctx.base_dir, ignore_errors=True)
+        t.check("Temp dirs cleaned", True)
+
+    # Delete APs
+    from supabase import create_client
+    sb = create_client(os.environ["SUPABASE_URL"], os.environ["SUPABASE_KEY"])
+    for ap_id in ["int-root", "int-docs", "int-src"]:
+        try:
+            sb.table("access_points").delete().eq("id", ap_id).execute()
+        except Exception:
+            pass
+
+    if ctx.project_id:
+        code, _ = _req("DELETE", f"{ctx.api}/api/v1/projects/{ctx.project_id}",
+                        headers=_h(ctx.jwt))
+        t.check("Project deleted", code == 200)
+
+
+# ══════════════════════════════════════════════════════════════
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser(description="CLI Integration Stress Test")
+    parser.add_argument("--api", default="https://qubits-api.puppyone.ai")
+    parser.add_argument("--verbose", "-v", action="store_true")
+    args = parser.parse_args()
+
+    from supabase import create_client
+    url, key = os.environ["SUPABASE_URL"], os.environ["SUPABASE_KEY"]
+    sb = create_client(url, key)
+    email, pw = "e2e-test@puppyone.ai", "E2eTest2026!"
+    try:
+        sb.auth.admin.create_user({"email": email, "password": pw, "email_confirm": True})
+    except Exception:
+        pass
+    session = sb.auth.sign_in_with_password({"email": email, "password": pw})
+    ctx = Ctx(api=args.api, jwt=session.session.access_token, user_id=session.user.id, verbose=args.verbose)
+    _req("POST", f"{args.api}/api/v1/auth/initialize", headers=_h(ctx.jwt))
+    _, body = _req("GET", f"{args.api}/api/v1/organizations/", headers=_h(ctx.jwt))
+    ctx.org_id = (body.get("data") or [{}])[0].get("id", "")
+
+    print(f"\nPuppyOne CLI ↔ MUT CLI Integration Stress Test")
+    print(f"API: {ctx.api}")
+
+    t_obj = T(ctx)
+    start = time.time()
+
+    modules = [
+        test_setup,
+        test_scenario_a_clone,
+        test_scenario_b_init_link,
+        test_scenario_c_init_link_existing,
+        test_scope_isolation,
+        test_cross_cli_push_pull,
+        test_rollback_across_clis,
+        test_rapid_push_pull_cycle,
+        test_status_log_consistency,
+        test_cleanup,
+    ]
+
+    for mod in modules:
+        try:
+            mod(t_obj, ctx)
+        except Exception as e:
+            ctx.failed += 1
+            ctx.errors.append(f"[{mod.__name__}] CRASH: {e}")
+            print(f"  !! CRASH in {mod.__name__}: {e}")
+            if args.verbose:
+                traceback.print_exc()
+
+    elapsed = time.time() - start
+    print(f"\n{'='*60}\n  RESULTS\n{'='*60}")
+    print(f"  Passed:  {ctx.passed}")
+    print(f"  Failed:  {ctx.failed}")
+    print(f"  Skipped: {ctx.skipped}")
+    print(f"  Time:    {elapsed:.1f}s")
+    if ctx.errors:
+        print(f"\n  FAILURES:")
+        for e in ctx.errors:
+            print(f"    \u2717 {e}")
+    pct = (ctx.passed / max(ctx.passed + ctx.failed, 1)) * 100
+    print(f"\n  Pass rate: {pct:.0f}%")
+    sys.exit(0 if ctx.failed == 0 else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Unified API 补全：`direct` Provider

* **问题** ：`POST /api/v1/access/` 不支持 `provider: "direct"`，返回 400 "Unknown provider"
* **修复** ：新增 `_create_direct()` handler，直接在 `access_points` 表创建记录，生成 access_key

### 代码质量修复

 **`asyncio` 未导入（高危）** ：

* `connectors/agent/service.py` 有 4 处 `await asyncio.to_thread()` 调用但没有 `import asyncio`
* 运行时当 Agent 使用 MUT ephemeral client 进行 clone/push 时会崩溃
* 修复：添加 `import asyncio`

 **`ConnectorDeps`/`ConnectorSetup` 未定义** ：

* 9 个 connector 文件中的 `def setup(deps: "ConnectorDeps")` 类型标注引用了未导入的类
* 运行时不崩溃（引号内的前向引用），但静态分析报错
* 修复：9 个文件添加 `TYPE_CHECKING` 导入块

 **已知问题文档化** ：

* `_get_user_project_ids` 添加详细注释说明 org_members 依赖
* `ensure_project_access` 添加 TODO 说明 viewer role 不执行的 gap
* `_serialize_content` 添加详细 docstring 说明 `.json` 后缀设计意图
* Content rollback 端点添加诊断注释

### E2E 测试新增

 **Suite 7：CLI Integration Stress Test** （52 tests）

* Scenario A：PuppyOne 创建项目 → MUT clone AP URL → config 有 server+credential → push 回 API 可见
* Scenario B：`mut init` + `mut link access <url> <dir>` → scope 创建 → push 成功
* Scenario C：本地已有文件 → init → link → push → 服务端可见
* Scope 隔离：docs AP 排除 internal、src AP 只读阻止 push
* 多 Agent：A push → B clone 看到 → B push → A pull 看到
* Rollback：push 3 版本 → rollback → fresh clone 验证文件消失
* 快速压力：10 次 push/pull 循环，2 个 agent 并发
* Status/Log 一致性验证

 **Suite 8：AP → MUT Connection Test** （52 tests）

* 每种非 gateway 类型（filesystem / agent / sandbox / direct）完整测试：创建 AP → clone → push → pull → verify
* Filesystem 的 init + link 流程
* Direct readonly 阻止 push
* Scoped agent AP 推送范围限制
* Unified API 创建所有类型
* 3 种 provider 并发 push + 验证