### PR TITLE
fix(login): wrap useSearchParams in Suspense (prod hotfix)

### DIFF
--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useCallback, useEffect, useRef } from 'react';
+import React, { Suspense, useState, useCallback, useEffect, useRef } from 'react';
 import { useAuth } from '../supabase/SupabaseAuthProvider';
 import { useRouter, useSearchParams } from 'next/navigation';
 
@@ -20,7 +20,36 @@ type AuthView = 'main' | 'signin' | 'signup' | 'verify-otp' | 'forgot';
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:9090';
 const RESEND_COOLDOWN_SECONDS = 300; // 5 minutes
 
+/**
+ * Default export wraps the inner page in <Suspense> because
+ * useSearchParams() forces client-side rendering and Next.js 15
+ * requires an explicit Suspense boundary during prerender.
+ * Without this wrapper the production build fails with:
+ *   "useSearchParams() should be wrapped in a suspense boundary at page /login"
+ */
 export default function LoginPage() {
+  return (
+    <Suspense fallback={<LoginPageFallback />}>
+      <LoginPageInner />
+    </Suspense>
+  );
+}
+
+function LoginPageFallback() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-[#0a0a0a]">
+      <img
+        src="/puppyone-logo.svg"
+        alt="PuppyOne"
+        width={48}
+        height={48}
+        className="opacity-50 animate-pulse"
+      />
+    </div>
+  );
+}
+
+function LoginPageInner() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const {


### PR DESCRIPTION
## Summary

**Production hotfix.** Current `main` deploy fails with:

```
useSearchParams() should be wrapped in a suspense boundary at page "/login"
Error occurred prerendering page "/login"
```

The OTP migration added `searchParams.get('error')` handling at the top level of `LoginPage`. In Next.js 15 App Router, any page that calls `useSearchParams()` MUST be wrapped in a `<Suspense>` boundary or static prerender bails out.

## Fix

Split `LoginPage` into:
- thin default export that returns `<Suspense fallback={<LoginPageFallback />}><LoginPageInner /></Suspense>`
- `LoginPageInner` containing all existing logic (incl. `useSearchParams`)
- `LoginPageFallback` rendering the PuppyOne logo while Suspense settles

No behavior change; just satisfies the framework contract.

## Verification

- `tsc --noEmit` clean
- `next build` succeeds locally; `/login` renders as `○ Static, 5.61 kB`
- All other pages using `useSearchParams` already have Suspense / `force-dynamic`

## Why this PR replaces #1171

The earlier `newmu → qubits` PR hit a criss-cross merge conflict because the OTP commit was backmerged to both `qubits` (via #1169) and `newmu` (via #1170) through different merge commits. Git's recursive 3-way merge couldn't reconcile the two equivalent backmerges and conflicted on identical OTP content.

This PR is a **single cherry-pick** of the Suspense fix on top of `qubits`, no merge gymnastics, no conflict.

## After this lands

I will immediately open `qubits → main` to unblock production.

## Follow-up (separate work)

- Add `e2e` to required status checks on both `qubits` and `main` (would have caught this build break before merge)
- Drop the stale `Prettier Check & Auto-fix` and `NPM Build Check` required checks (no producing workflows exist)
- Then enable `enforce_admins: true` on `main`

Made with [Cursor](https://cursor.com)