### PR TITLE
hotfix(login): wrap useSearchParams in Suspense (prod deploy fix)

### DIFF
--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useCallback, useEffect, useRef } from 'react';
+import React, { Suspense, useState, useCallback, useEffect, useRef } from 'react';
 import { useAuth } from '../supabase/SupabaseAuthProvider';
 import { useRouter, useSearchParams } from 'next/navigation';
 
@@ -20,7 +20,36 @@ type AuthView = 'main' | 'signin' | 'signup' | 'verify-otp' | 'forgot';
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:9090';
 const RESEND_COOLDOWN_SECONDS = 300; // 5 minutes
 
+/**
+ * Default export wraps the inner page in <Suspense> because
+ * useSearchParams() forces client-side rendering and Next.js 15
+ * requires an explicit Suspense boundary during prerender.
+ * Without this wrapper the production build fails with:
+ *   "useSearchParams() should be wrapped in a suspense boundary at page /login"
+ */
 export default function LoginPage() {
+  return (
+    <Suspense fallback={<LoginPageFallback />}>
+      <LoginPageInner />
+    </Suspense>
+  );
+}
+
+function LoginPageFallback() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-[#0a0a0a]">
+      <img
+        src="/puppyone-logo.svg"
+        alt="PuppyOne"
+        width={48}
+        height={48}
+        className="opacity-50 animate-pulse"
+      />
+    </div>
+  );
+}
+
+function LoginPageInner() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const {


### PR DESCRIPTION
## Summary

**Production hotfix — 1 file, 30 insertions, 1 deletion.**

Current `main` deploy fails with:
```
useSearchParams() should be wrapped in a suspense boundary at page "/login"
Error occurred prerendering page "/login"
```

The OTP migration (`7e178555`, direct push to `main`) introduced `searchParams.get('error')` at the top level of `LoginPage`. Next.js 15 App Router requires any page calling `useSearchParams()` to be wrapped in `<Suspense>`, otherwise static prerender bails.

## Fix

`LoginPage` is split into:
- thin default export returning `<Suspense fallback={<LoginPageFallback />}><LoginPageInner /></Suspense>`
- `LoginPageInner` containing all existing logic
- `LoginPageFallback` rendering the PuppyOne logo

No behavior change.

## Verification

- `tsc --noEmit` clean
- `next build` succeeds locally; `/login` renders as `○ Static, 5.61 kB`
- All other pages using `useSearchParams` already have Suspense / `force-dynamic`
- Already merged into `qubits` via #1172 (Run Gitleaks passed there)

## Why a cherry-pick PR (not `qubits → main`)

A direct `qubits → main` PR (#1173, closed) would have bundled **143 files / 30+ commits** of accumulated qubits work that hasn't been promoted to `main` yet (CLI rewrites, connector gateway, mutai 0.1.x, etc). That's a separate release decision and absolutely **not** appropriate for a hotfix.

This PR is one cherry-pick of the Suspense fix on top of `main`. Single concern, single commit, single file.

## Follow-up (after this lands)

1. Re-run cloud deploy to verify production unblocks
2. Clean up stale required status checks on `main` (`Prettier Check & Auto-fix`, `NPM Build Check` — no producing workflows)
3. Add `e2e` to `main` required checks (catches build break before merge)
4. Enable `enforce_admins: true` on `main` (Plan B you picked)
5. Separately plan a real `qubits → main` release for the 30+ accumulated commits — this should be staged carefully, not in a hotfix

Made with [Cursor](https://cursor.com)