### PR TITLE
fix(agent): correct deployAgent return type to unblock prod build

### DIFF
--- a/frontend/contexts/AgentContext.tsx
+++ b/frontend/contexts/AgentContext.tsx
@@ -122,7 +122,7 @@ interface AgentContextValue {
   editAgent: (agentId: string) => void;
   editingAgentId: string | null;
   cancelSetting: () => void;
-  deployAgent: (name: string, icon: string) => void;
+  deployAgent: (name: string, icon: string) => Promise<string | null>;
   deploySyncEndpoint: (params: {
     provider: string;
     direction: string;


### PR DESCRIPTION
The AgentContextValue interface declared deployAgent as `() => void`, but the implementation returns Promise<string | null>. This made SyncConfigPanel's `await deployAgent(...)` infer as void and broke the prod type-check with "expression of type 'void' cannot be tested for truthiness" on the subsequent `if (agentId)` check.

Made-with: Cursor