### PR TITLE
chore(ci): make full-stack e2e manual-only

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,18 +1,11 @@
 name: E2E Visual Tests
 
 on:
-  push:
-    branches: [main, newmu]
-    paths:
-      - 'frontend/**'
-      - 'backend/**'
-      - 'e2e/**'
-  pull_request:
-    branches: [main]
-    paths:
-      - 'frontend/**'
-      - 'backend/**'
-      - 'e2e/**'
+  # Full-stack e2e is intentionally manual. It depends on live Supabase
+  # secrets, a pre-baked E2E auth session, browser installation, backend boot,
+  # frontend build/start, and external service availability, so it is too
+  # fragile/noisy as an automatic PR signal. Keep it available for release
+  # verification or focused debugging without blocking normal PRs.
   workflow_dispatch:
 
 env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ rules (PR + required reviews + required status checks).
 | **Frontend Build**   | PRs that touch `frontend/**`             | `main`, `qubits`                    |
 | **Run Gitleaks**     | All PRs, push to `main`, weekly schedule | `main`, `qubits`                    |
 | **Main Release Gate** | PRs targeting `main`                    | `main` (release/hotfix source + owner gate) |
-| **E2E Visual Tests** | PRs touching `frontend/**`/`backend/**`/`e2e/**` | (advisory, not blocking)    |
+| **E2E Visual Tests** | Manual (`workflow_dispatch`)            | (manual release/debug check)        |
 | **Supabase Preview** | All PRs                                  | (advisory, not blocking)            |
 | **Branch housekeeping** | Weekly schedule                       | n/a (cleanup job)                   |
 


### PR DESCRIPTION
## Summary

Stops running `E2E Visual Tests` automatically on PRs/pushes and keeps it
available as a manual `workflow_dispatch` workflow.

## Why

The current e2e job is full-stack, not just frontend or backend:

- starts the backend with Supabase secrets
- installs frontend deps
- builds and starts the Next.js frontend
- creates an auth session from `E2E_SESSION_JSON`
- installs Playwright Chromium
- runs browser scenarios from `e2e/run.mjs`

That is useful for release verification and focused debugging, but it is too
fragile/noisy as an automatic PR signal. It was not required for branch
protection, but it still showed as a failed check on `qubits` -> `main` PRs and
made the merge UI confusing.

`Frontend Build` and `Run Gitleaks` remain the required automatic checks.

## Test plan

- [x] `git diff --check`
- [x] no linter diagnostics for changed files
- [ ] After merge: confirm future PRs no longer auto-run `E2E Visual Tests`
- [ ] Manual run still available from Actions -> E2E Visual Tests -> Run workflow

Made with [Cursor](https://cursor.com)