### PR TITLE
feat(home): inline AP chips on Data tree + collapse Connections by default

### DIFF
--- a/frontend/app/(main)/projects/[projectId]/data/[[...path]]/page.tsx
+++ b/frontend/app/(main)/projects/[projectId]/data/[[...path]]/page.tsx
@@ -551,11 +551,13 @@ export default function DataPage({ params }: DataPageProps) {
     createMenuOpen,
     createMenuOpenForId,
     createMenuPosition,
+    createMenuAccessOnly,
     createMenuRef,
     createMenuActions,
     highlightNodeId,
     handleCreateClick,
     handleMillerCreateClick,
+    handleAccessMenuClick,
     closeCreateTable,
   } = useDataCreateFlow({
     projectId,
@@ -887,6 +889,7 @@ export default function DataPage({ params }: DataPageProps) {
         toast={nodeActions.toast}
         createMenuOpen={createMenuOpen}
         createMenuPosition={createMenuPosition}
+        createMenuAccessOnly={createMenuAccessOnly}
         createMenuRef={createMenuRef}
         createMenuActions={createMenuActions}
       />
@@ -927,7 +930,7 @@ export default function DataPage({ params }: DataPageProps) {
             }
             onNavigate={handleMillerNavigate}
             onCreate={handleMillerCreateClick}
-            onCreateSync={openSyncCreatePanelForFolder}
+            onCreateSync={handleAccessMenuClick}
             onRename={nodeActions.handleRename}
             onDelete={nodeActions.handleDelete}
             onMoveNode={nodeActions.handleMoveNode}

--- a/frontend/app/(main)/projects/[projectId]/data/[[...path]]/page.tsx
+++ b/frontend/app/(main)/projects/[projectId]/data/[[...path]]/page.tsx
@@ -485,37 +485,42 @@ export default function DataPage({ params }: DataPageProps) {
     openPanel({ type: 'sync_create' });
   }, [openPanel]);
 
-  // Same as openSyncCreatePanel, but with the target resource
-  // pre-filled to the user's current navigation context.  This is
-  // what the Sidebar's "+ New connection" button calls — the user's
-  // mental model is "I'm looking at folder X, I want to add an
-  // access point to it", and the panel landing with that folder
-  // already in the target list collapses a 4-step flow (jump to
-  // /access → click Create → drag the folder from sidebar → click
-  // Create) into a single click.
+  // Same as openSyncCreatePanel, but with a *given* folder path
+  // pre-filled as the target resource.  Two callsites:
+  //   - sidebar header "Connect" button → passes the user's
+  //     current navigation focus
+  //   - per-folder row plug button → passes that row's own folder id
+  // Either way the panel lands ready-to-create — the user picks a
+  // provider type and clicks Create, instead of going through the
+  // old "open empty panel → drag folder from sidebar" flow.
   //
-  // currentFolderId is the path string of the user's current
-  // navigation focus (or `null` for the project root).  We
-  // normalise null → '' (root scope) and try to derive a
-  // human-readable name from the trailing path segment so the
-  // pre-filled chip in the panel reads as something other than
-  // an opaque blob.
-  const openSyncCreatePanelForCurrentFolder = useCallback(() => {
-    const targetPath = currentFolderId ?? '';
-    const segments = targetPath.split('/').filter(Boolean);
-    const nodeName = segments.length > 0 ? segments[segments.length - 1] : 'Root';
-    setDraftResources([
-      {
-        path: targetPath,
-        nodeName,
-        nodeType: 'folder',
-        readonly: false,
-      },
-    ]);
-    setEditorTarget(null);
-    setIsEditorFullScreen(false);
-    openPanel({ type: 'sync_create' });
-  }, [currentFolderId, openPanel, setDraftResources]);
+  // `folderPath` is normalised in two ways:
+  //   - null/undefined → '' (project root, the canonical "root
+  //     scope" key used elsewhere in the codebase via
+  //     `accessByPath` etc.)
+  //   - a non-empty path → trailing segment becomes the chip's
+  //     human-readable nodeName so the pre-filled chip reads as
+  //     something more useful than an opaque blob
+  const openSyncCreatePanelForFolder = useCallback(
+    (folderPath: string | null | undefined) => {
+      const targetPath = folderPath ?? '';
+      const segments = targetPath.split('/').filter(Boolean);
+      const nodeName =
+        segments.length > 0 ? segments[segments.length - 1] : 'Root';
+      setDraftResources([
+        {
+          path: targetPath,
+          nodeName,
+          nodeType: 'folder',
+          readonly: false,
+        },
+      ]);
+      setEditorTarget(null);
+      setIsEditorFullScreen(false);
+      openPanel({ type: 'sync_create' });
+    },
+    [openPanel, setDraftResources],
+  );
 
   const handleSyncCreated = useCallback(async (nodeId: string) => {
     await mutateSyncStatus();
@@ -922,7 +927,7 @@ export default function DataPage({ params }: DataPageProps) {
             }
             onNavigate={handleMillerNavigate}
             onCreate={handleMillerCreateClick}
-            onCreateSync={openSyncCreatePanelForCurrentFolder}
+            onCreateSync={openSyncCreatePanelForFolder}
             onRename={nodeActions.handleRename}
             onDelete={nodeActions.handleDelete}
             onMoveNode={nodeActions.handleMoveNode}

--- a/frontend/app/(main)/projects/[projectId]/data/[[...path]]/page.tsx
+++ b/frontend/app/(main)/projects/[projectId]/data/[[...path]]/page.tsx
@@ -377,7 +377,7 @@ export default function DataPage({ params }: DataPageProps) {
   const { syncStatusData, mutateSyncStatus, projectTools, syncEndpoints, nodeEndpointMap } = useDataLayout();
 
   // Agent context (needed early for syncEndpoints merge)
-  const { draftResources, currentAgentId, savedAgents, hoveredAgentId, openSyncSetting, editingAgentId, selectedSyncId, selectedSyncNodeId, hoveredSyncNodeId, selectAgent } = useAgent();
+  const { draftResources, setDraftResources, currentAgentId, savedAgents, hoveredAgentId, openSyncSetting, editingAgentId, selectedSyncId, selectedSyncNodeId, hoveredSyncNodeId, selectAgent } = useAgent();
 
   // Auto-complete onboarding steps
   const { completeStep } = useOnboarding();
@@ -484,6 +484,38 @@ export default function DataPage({ params }: DataPageProps) {
     setIsEditorFullScreen(false);
     openPanel({ type: 'sync_create' });
   }, [openPanel]);
+
+  // Same as openSyncCreatePanel, but with the target resource
+  // pre-filled to the user's current navigation context.  This is
+  // what the Sidebar's "+ New connection" button calls — the user's
+  // mental model is "I'm looking at folder X, I want to add an
+  // access point to it", and the panel landing with that folder
+  // already in the target list collapses a 4-step flow (jump to
+  // /access → click Create → drag the folder from sidebar → click
+  // Create) into a single click.
+  //
+  // currentFolderId is the path string of the user's current
+  // navigation focus (or `null` for the project root).  We
+  // normalise null → '' (root scope) and try to derive a
+  // human-readable name from the trailing path segment so the
+  // pre-filled chip in the panel reads as something other than
+  // an opaque blob.
+  const openSyncCreatePanelForCurrentFolder = useCallback(() => {
+    const targetPath = currentFolderId ?? '';
+    const segments = targetPath.split('/').filter(Boolean);
+    const nodeName = segments.length > 0 ? segments[segments.length - 1] : 'Root';
+    setDraftResources([
+      {
+        path: targetPath,
+        nodeName,
+        nodeType: 'folder',
+        readonly: false,
+      },
+    ]);
+    setEditorTarget(null);
+    setIsEditorFullScreen(false);
+    openPanel({ type: 'sync_create' });
+  }, [currentFolderId, openPanel, setDraftResources]);
 
   const handleSyncCreated = useCallback(async (nodeId: string) => {
     await mutateSyncStatus();
@@ -890,6 +922,7 @@ export default function DataPage({ params }: DataPageProps) {
             }
             onNavigate={handleMillerNavigate}
             onCreate={handleMillerCreateClick}
+            onCreateSync={openSyncCreatePanelForCurrentFolder}
             onRename={nodeActions.handleRename}
             onDelete={nodeActions.handleDelete}
             onMoveNode={nodeActions.handleMoveNode}

--- a/frontend/app/(main)/projects/[projectId]/data/components/DataPageOverlays.tsx
+++ b/frontend/app/(main)/projects/[projectId]/data/components/DataPageOverlays.tsx
@@ -8,6 +8,12 @@ interface DataPageOverlaysProps {
   toast: { message: string; type: 'success' | 'error' } | null;
   createMenuOpen: boolean;
   createMenuPosition: CreateMenuPosition | null;
+  // When the menu was opened by a per-folder plug button rather
+  // than the regular `+`, this flag flips CreateMenu into its
+  // `accessOnly` rendering — flat list of providers / agents /
+  // endpoints, no Create Blank / Upload sections.  Same menu
+  // instance, different layout based on intent.
+  createMenuAccessOnly: boolean;
   createMenuRef: RefObject<HTMLDivElement>;
   createMenuActions: DataCreateMenuActions;
 }
@@ -16,6 +22,7 @@ export function DataPageOverlays({
   toast,
   createMenuOpen,
   createMenuPosition,
+  createMenuAccessOnly,
   createMenuRef,
   createMenuActions,
 }: DataPageOverlaysProps) {
@@ -62,6 +69,7 @@ export function DataPageOverlays({
             x={createMenuPosition.x}
             y={createMenuPosition.y}
             anchorLeft={createMenuPosition.anchorLeft}
+            accessOnly={createMenuAccessOnly}
             onClose={createMenuActions.onClose}
             onCreateFolder={createMenuActions.onCreateFolder}
             onCreateBlankJson={createMenuActions.onCreateBlankJson}

--- a/frontend/app/(main)/projects/[projectId]/data/components/SyncConfigPanel.tsx
+++ b/frontend/app/(main)/projects/[projectId]/data/components/SyncConfigPanel.tsx
@@ -216,12 +216,24 @@ function CreateView({ projectId, onClose, onSyncCreated }: {
     }
   }, [pendingSyncProvider, syncProviders]);
 
+  // CRITICAL: handleSelect*/handleBack must NOT clear draftResources.
+  // The previous version called `setDraftResources([])` on every
+  // provider/agent/endpoint pick, which silently wiped any target
+  // pre-filled by an external caller (sidebar Connect button, per-row
+  // plug button, etc.).  Symptom: user clicked the plug on a folder
+  // row, panel opened with that folder set as target, user clicked a
+  // provider → target zone snapped back to "Drag a folder into this
+  // zone" and the panel looked broken.  Switching providers within
+  // the same panel session is NOT a "I want a different target" gesture
+  // — the user is just exploring sync options for the same folder.
+  // Only handleBack-then-explicit-cancel-and-reopen would justify
+  // clearing target, and that flow already runs through
+  // setDraftResources upstream from page.tsx.
   const handleSelectAgentType = (type: AgentTypeId) => {
     setSelectedAgentType(type);
     setSelectedEndpointType(null);
     setSelectedSyncProvider(null);
     setDraftType('chat');
-    setDraftResources([]);
     setDisplayName('');
     setDeployError(null);
   };
@@ -230,7 +242,6 @@ function CreateView({ projectId, onClose, onSyncCreated }: {
     setSelectedEndpointType(type);
     setSelectedAgentType(null);
     setSelectedSyncProvider(null);
-    setDraftResources([]);
     setDisplayName('');
     setDeployError(null);
   };
@@ -239,7 +250,6 @@ function CreateView({ projectId, onClose, onSyncCreated }: {
     setSelectedSyncProvider(id);
     setSelectedAgentType(null);
     setSelectedEndpointType(null);
-    setDraftResources([]);
     setDisplayName('');
     setDeployError(null);
     const provider = syncProviders.find(p => p.id === id);
@@ -256,7 +266,6 @@ function CreateView({ projectId, onClose, onSyncCreated }: {
     setSelectedAgentType(null);
     setSelectedEndpointType(null);
     setSelectedSyncProvider(null);
-    setDraftResources([]);
     setSyncConfigValues({});
     setDisplayName('');
     setDeployError(null);

--- a/frontend/app/(main)/projects/[projectId]/data/components/explorer/ExplorerSidebar.tsx
+++ b/frontend/app/(main)/projects/[projectId]/data/components/explorer/ExplorerSidebar.tsx
@@ -14,6 +14,7 @@ export const ExplorerSidebar = memo(function ExplorerSidebar({
   activeNodeId,
   onNavigate,
   onCreate,
+  onCreateSync,
   onRename,
   onDelete,
   onMoveNode,
@@ -84,44 +85,105 @@ export const ExplorerSidebar = memo(function ExplorerSidebar({
           Workspace
         </div>
 
-        {onCreate && (
-          <button
-            type="button"
-            aria-haspopup="menu"
-            aria-expanded={isRootCreateMenuOpen}
-            onClick={(e) => onCreate(e, null)}
-            title="Add file/folder"
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              width: 24,
-              height: 24,
-              borderRadius: 4,
-              background: isRootCreateMenuOpen ? 'rgba(255,255,255,0.08)' : 'transparent',
-              border: 'none',
-              cursor: 'pointer',
-              color: isRootCreateMenuOpen ? '#ddd' : '#888',
-              padding: 0,
-              transition: 'background 0.12s, color 0.12s',
-            }}
-            onMouseEnter={(e) => {
-              e.currentTarget.style.background = 'rgba(255,255,255,0.08)';
-              e.currentTarget.style.color = '#ddd';
-            }}
-            onMouseLeave={(e) => {
-              if (!isRootCreateMenuOpen) {
+        {/* Header actions cluster — file/folder + button, then a
+            separate "+ Connect" button for opening the sync_create
+            panel with the user's current folder pre-filled.  Two
+            buttons instead of one combined dropdown because the
+            two affordances ("create thing inside the workspace" vs
+            "expose the workspace to an external consumer") are
+            conceptually different — they shouldn't share a single
+            menu trigger. */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+          {onCreateSync && (
+            <button
+              type="button"
+              onClick={onCreateSync}
+              title="Create access point for the current folder"
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 4,
+                height: 24,
+                padding: '0 8px',
+                borderRadius: 4,
+                background: 'transparent',
+                border: 'none',
+                cursor: 'pointer',
+                color: '#888',
+                fontSize: 12,
+                fontWeight: 500,
+                fontFamily: 'inherit',
+                transition: 'background 0.12s, color 0.12s',
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.background = 'rgba(255,255,255,0.08)';
+                e.currentTarget.style.color = '#ddd';
+              }}
+              onMouseLeave={(e) => {
                 e.currentTarget.style.background = 'transparent';
                 e.currentTarget.style.color = '#888';
-              }
-            }}
-          >
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
-              <line x1="12" y1="5" x2="12" y2="19" />
-              <line x1="5" y1="12" x2="19" y2="12" />
-            </svg>
-          </button>
-        )}
+              }}
+            >
+              {/* Plug-shaped link icon — communicates "external
+                  connection" without leaning on the same `+`
+                  glyph the file/folder button uses next to it. */}
+              <svg
+                width="13"
+                height="13"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M9 17H7A5 5 0 0 1 7 7h2" />
+                <path d="M15 7h2a5 5 0 1 1 0 10h-2" />
+                <line x1="8" y1="12" x2="16" y2="12" />
+              </svg>
+              Connect
+            </button>
+          )}
+
+          {onCreate && (
+            <button
+              type="button"
+              aria-haspopup="menu"
+              aria-expanded={isRootCreateMenuOpen}
+              onClick={(e) => onCreate(e, null)}
+              title="Add file/folder"
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                width: 24,
+                height: 24,
+                borderRadius: 4,
+                background: isRootCreateMenuOpen ? 'rgba(255,255,255,0.08)' : 'transparent',
+                border: 'none',
+                cursor: 'pointer',
+                color: isRootCreateMenuOpen ? '#ddd' : '#888',
+                padding: 0,
+                transition: 'background 0.12s, color 0.12s',
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.background = 'rgba(255,255,255,0.08)';
+                e.currentTarget.style.color = '#ddd';
+              }}
+              onMouseLeave={(e) => {
+                if (!isRootCreateMenuOpen) {
+                  e.currentTarget.style.background = 'transparent';
+                  e.currentTarget.style.color = '#888';
+                }
+              }}
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                <line x1="12" y1="5" x2="12" y2="19" />
+                <line x1="5" y1="12" x2="19" y2="12" />
+              </svg>
+            </button>
+          )}
+        </div>
       </div>
 
       <div style={{ flex: 1, overflow: 'auto', overflowX: 'hidden', position: 'relative', paddingTop: 6 }}>

--- a/frontend/app/(main)/projects/[projectId]/data/components/explorer/ExplorerSidebar.tsx
+++ b/frontend/app/(main)/projects/[projectId]/data/components/explorer/ExplorerSidebar.tsx
@@ -97,7 +97,19 @@ export const ExplorerSidebar = memo(function ExplorerSidebar({
           {onCreateSync && (
             <button
               type="button"
-              onClick={onCreateSync}
+              onClick={() => {
+                // Sidebar-header version of "Create access point":
+                // targets the user's current navigation focus
+                // (last breadcrumb segment), or the project root
+                // ('') when nothing's selected.  Per-row plug
+                // buttons in the tree call onCreateSync directly
+                // with their own item.id.
+                const focusId =
+                  currentPath.length > 0
+                    ? currentPath[currentPath.length - 1].id
+                    : '';
+                onCreateSync(focusId);
+              }}
               title="Create access point for the current folder"
               style={{
                 display: 'flex',
@@ -252,6 +264,7 @@ export const ExplorerSidebar = memo(function ExplorerSidebar({
                 activeId={activeId}
                 onNavigate={onNavigate}
                 onCreate={onCreate}
+                onCreateSync={onCreateSync}
                 onRename={onRename}
                 onDelete={onDelete}
                 onMoveNode={onMoveNode}

--- a/frontend/app/(main)/projects/[projectId]/data/components/explorer/ExplorerSidebar.tsx
+++ b/frontend/app/(main)/projects/[projectId]/data/components/explorer/ExplorerSidebar.tsx
@@ -221,7 +221,7 @@ export const ExplorerSidebar = memo(function ExplorerSidebar({
                 {onCreateSync && (
                   <button
                     type="button"
-                    onClick={() => onCreateSync('')}
+                    onClick={(e) => onCreateSync(e, '')}
                     title="Create access point at project root"
                     aria-label="Create access point at project root"
                     style={{

--- a/frontend/app/(main)/projects/[projectId]/data/components/explorer/ExplorerSidebar.tsx
+++ b/frontend/app/(main)/projects/[projectId]/data/components/explorer/ExplorerSidebar.tsx
@@ -85,117 +85,16 @@ export const ExplorerSidebar = memo(function ExplorerSidebar({
           Workspace
         </div>
 
-        {/* Header actions cluster — file/folder + button, then a
-            separate "+ Connect" button for opening the sync_create
-            panel with the user's current folder pre-filled.  Two
-            buttons instead of one combined dropdown because the
-            two affordances ("create thing inside the workspace" vs
-            "expose the workspace to an external consumer") are
-            conceptually different — they shouldn't share a single
-            menu trigger. */}
-        <div style={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-          {onCreateSync && (
-            <button
-              type="button"
-              onClick={() => {
-                // Sidebar-header version of "Create access point":
-                // targets the user's current navigation focus
-                // (last breadcrumb segment), or the project root
-                // ('') when nothing's selected.  Per-row plug
-                // buttons in the tree call onCreateSync directly
-                // with their own item.id.
-                const focusId =
-                  currentPath.length > 0
-                    ? currentPath[currentPath.length - 1].id
-                    : '';
-                onCreateSync(focusId);
-              }}
-              title="Create access point for the current folder"
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: 4,
-                height: 24,
-                padding: '0 8px',
-                borderRadius: 4,
-                background: 'transparent',
-                border: 'none',
-                cursor: 'pointer',
-                color: '#888',
-                fontSize: 12,
-                fontWeight: 500,
-                fontFamily: 'inherit',
-                transition: 'background 0.12s, color 0.12s',
-              }}
-              onMouseEnter={(e) => {
-                e.currentTarget.style.background = 'rgba(255,255,255,0.08)';
-                e.currentTarget.style.color = '#ddd';
-              }}
-              onMouseLeave={(e) => {
-                e.currentTarget.style.background = 'transparent';
-                e.currentTarget.style.color = '#888';
-              }}
-            >
-              {/* Plug-shaped link icon — communicates "external
-                  connection" without leaning on the same `+`
-                  glyph the file/folder button uses next to it. */}
-              <svg
-                width="13"
-                height="13"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              >
-                <path d="M9 17H7A5 5 0 0 1 7 7h2" />
-                <path d="M15 7h2a5 5 0 1 1 0 10h-2" />
-                <line x1="8" y1="12" x2="16" y2="12" />
-              </svg>
-              Connect
-            </button>
-          )}
-
-          {onCreate && (
-            <button
-              type="button"
-              aria-haspopup="menu"
-              aria-expanded={isRootCreateMenuOpen}
-              onClick={(e) => onCreate(e, null)}
-              title="Add file/folder"
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                width: 24,
-                height: 24,
-                borderRadius: 4,
-                background: isRootCreateMenuOpen ? 'rgba(255,255,255,0.08)' : 'transparent',
-                border: 'none',
-                cursor: 'pointer',
-                color: isRootCreateMenuOpen ? '#ddd' : '#888',
-                padding: 0,
-                transition: 'background 0.12s, color 0.12s',
-              }}
-              onMouseEnter={(e) => {
-                e.currentTarget.style.background = 'rgba(255,255,255,0.08)';
-                e.currentTarget.style.color = '#ddd';
-              }}
-              onMouseLeave={(e) => {
-                if (!isRootCreateMenuOpen) {
-                  e.currentTarget.style.background = 'transparent';
-                  e.currentTarget.style.color = '#888';
-                }
-              }}
-            >
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
-                <line x1="12" y1="5" x2="12" y2="19" />
-                <line x1="5" y1="12" x2="19" y2="12" />
-              </svg>
-            </button>
-          )}
-        </div>
+        {/* Header is now label-only.  The previous "Connect" and
+            "+" buttons that lived here moved down onto the Root
+            row's hover-revealed actions cluster — review feedback
+            was that header-level actions were both redundant
+            (every other folder row already has + in its hover
+            cluster, so root should match) and conceptually misplaced
+            (they conflated "this is what the panel is" with "what
+            you can do to its root").  Putting the actions on Root
+            itself unifies the affordance: every folder, root or
+            not, exposes the same per-row create cluster on hover. */}
       </div>
 
       <div style={{ flex: 1, overflow: 'auto', overflowX: 'hidden', position: 'relative', paddingTop: 6 }}>
@@ -249,6 +148,123 @@ export const ExplorerSidebar = memo(function ExplorerSidebar({
                 Root
               </span>
             </div>
+
+            {/* Hover-revealed actions on the Root row.  Same cluster
+                shape as ExplorerTreeRow's per-folder actions —
+                [+] [link] — minus the [more menu] (rename / delete
+                don't apply to the project root: it can't be renamed
+                or removed).  This is what replaces the previous
+                sidebar-header buttons; every folder row including
+                root now exposes the same affordances on the same
+                hover trigger, so the user doesn't need a separate
+                mental model for "the root case".  Wrapper stops
+                click propagation so the buttons don't trigger the
+                row's navigate-to-root onClick. */}
+            {(onCreate || onCreateSync) && (
+              <div
+                className={`flex items-center gap-0.5 flex-shrink-0 mr-2 ${
+                  isRootCreateMenuOpen
+                    ? 'visible'
+                    : 'invisible group-hover/row:visible'
+                }`}
+                onClick={(e) => e.stopPropagation()}
+              >
+                {onCreate && (
+                  <button
+                    type="button"
+                    aria-haspopup="menu"
+                    aria-expanded={isRootCreateMenuOpen}
+                    onClick={(e) => onCreate(e, null)}
+                    title="New item"
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      width: 22,
+                      height: 22,
+                      borderRadius: 4,
+                      background: isRootCreateMenuOpen
+                        ? 'rgba(255,255,255,0.1)'
+                        : 'transparent',
+                      border: 'none',
+                      cursor: 'pointer',
+                      color: isRootCreateMenuOpen ? '#ddd' : '#999',
+                      padding: 0,
+                      transition: 'background 0.1s, color 0.1s',
+                    }}
+                    onMouseEnter={(e) => {
+                      e.currentTarget.style.background = 'rgba(255,255,255,0.1)';
+                      e.currentTarget.style.color = '#ddd';
+                    }}
+                    onMouseLeave={(e) => {
+                      if (!isRootCreateMenuOpen) {
+                        e.currentTarget.style.background = 'transparent';
+                        e.currentTarget.style.color = '#999';
+                      }
+                    }}
+                  >
+                    <svg
+                      width="14"
+                      height="14"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2.5"
+                      strokeLinecap="round"
+                    >
+                      <line x1="12" y1="5" x2="12" y2="19" />
+                      <line x1="5" y1="12" x2="19" y2="12" />
+                    </svg>
+                  </button>
+                )}
+
+                {onCreateSync && (
+                  <button
+                    type="button"
+                    onClick={() => onCreateSync('')}
+                    title="Create access point at project root"
+                    aria-label="Create access point at project root"
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      width: 22,
+                      height: 22,
+                      borderRadius: 4,
+                      background: 'transparent',
+                      border: 'none',
+                      cursor: 'pointer',
+                      color: '#999',
+                      padding: 0,
+                      transition: 'background 0.1s, color 0.1s',
+                    }}
+                    onMouseEnter={(e) => {
+                      e.currentTarget.style.background = 'rgba(255,255,255,0.1)';
+                      e.currentTarget.style.color = '#ddd';
+                    }}
+                    onMouseLeave={(e) => {
+                      e.currentTarget.style.background = 'transparent';
+                      e.currentTarget.style.color = '#999';
+                    }}
+                  >
+                    <svg
+                      width="13"
+                      height="13"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    >
+                      <path d="M9 17H7A5 5 0 0 1 7 7h2" />
+                      <path d="M15 7h2a5 5 0 1 1 0 10h-2" />
+                      <line x1="8" y1="12" x2="16" y2="12" />
+                    </svg>
+                  </button>
+                )}
+              </div>
+            )}
           </div>
 
           {loading && rootItems.length === 0 ? (

--- a/frontend/app/(main)/projects/[projectId]/data/components/explorer/ExplorerTreeRow.tsx
+++ b/frontend/app/(main)/projects/[projectId]/data/components/explorer/ExplorerTreeRow.tsx
@@ -459,7 +459,7 @@ export const ExplorerTreeRow = memo(function ExplorerTreeRow({
                   type="button"
                   onClick={(e) => {
                     e.stopPropagation();
-                    onCreateSync(item.id);
+                    onCreateSync(e, item.id);
                   }}
                   title="Create access point for this folder"
                   aria-label="Create access point for this folder"

--- a/frontend/app/(main)/projects/[projectId]/data/components/explorer/ExplorerTreeRow.tsx
+++ b/frontend/app/(main)/projects/[projectId]/data/components/explorer/ExplorerTreeRow.tsx
@@ -393,16 +393,67 @@ export const ExplorerTreeRow = memo(function ExplorerTreeRow({
               className={`flex items-center gap-0.5 flex-shrink-0 ml-auto ${menuOpen || isCreateMenuOpen ? 'visible' : 'invisible group-hover/row:visible'}`}
               onClick={(e) => e.stopPropagation()}
             >
-              {/* Plug-link icon: "create access point for this folder".
-                  Sits *before* the + button so the action cluster
-                  reads left-to-right as
-                    [external surface]  [add child]  [more]
-                  — the user's first scan for "expose this folder
-                  to an agent / tool" lands on the plug icon, and
-                  the existing + stays focused on its single
-                  responsibility ("add a thing inside this
-                  folder"), which review feedback explicitly
-                  flagged as the better grouping. */}
+              {/* Per-folder action cluster reads left → right:
+                    [+]  [link]  [⋮]
+                  + is the most-used action (add a child) so it
+                  takes the leftmost position in the user's eye
+                  scan; link (create access point for this folder)
+                  is one step less common; ⋮ catches the long-tail
+                  rename / delete / move actions.  Earlier draft
+                  put link first, but review feedback flagged that
+                  as the wrong grouping — `+` and the access-point
+                  link are conceptually peers (both "create"
+                  actions, just inside vs outside scopes), and
+                  putting + first matches the muscle memory the
+                  user already has from every other file manager. */}
+              {isFolder && onCreate && (
+                <button
+                  type="button"
+                  aria-haspopup="menu"
+                  aria-expanded={isCreateMenuOpen}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onCreate(e, item.id);
+                  }}
+                  title="New item"
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    width: 22,
+                    height: 22,
+                    borderRadius: 4,
+                    background: isCreateMenuOpen ? 'rgba(255,255,255,0.1)' : 'transparent',
+                    border: 'none',
+                    cursor: 'pointer',
+                    color: isCreateMenuOpen ? '#ddd' : '#999',
+                    padding: 0,
+                    transition: 'background 0.1s, color 0.1s',
+                  }}
+                  onMouseEnter={(e) => {
+                    e.currentTarget.style.background = 'rgba(255,255,255,0.1)';
+                    e.currentTarget.style.color = '#ddd';
+                  }}
+                  onMouseLeave={(e) => {
+                    if (!isCreateMenuOpen) {
+                      e.currentTarget.style.background = 'transparent';
+                      e.currentTarget.style.color = '#999';
+                    }
+                  }}
+                >
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
+                    <line x1="12" y1="5" x2="12" y2="19" />
+                    <line x1="5" y1="12" x2="19" y2="12" />
+                  </svg>
+                </button>
+              )}
+
+              {/* Link icon: "create access point for this folder".
+                  Visually paired with the + button (both "create"
+                  actions, just for inside vs outside scopes).
+                  Same Lucide Link2 SVG used in the Home Data
+                  card's ApChip and elsewhere — keeping the icon
+                  consistent so users learn one shape, not three. */}
               {isFolder && onCreateSync && (
                 <button
                   type="button"
@@ -448,48 +499,6 @@ export const ExplorerTreeRow = memo(function ExplorerTreeRow({
                     <path d="M9 17H7A5 5 0 0 1 7 7h2" />
                     <path d="M15 7h2a5 5 0 1 1 0 10h-2" />
                     <line x1="8" y1="12" x2="16" y2="12" />
-                  </svg>
-                </button>
-              )}
-
-              {isFolder && onCreate && (
-                <button
-                  type="button"
-                  aria-haspopup="menu"
-                  aria-expanded={isCreateMenuOpen}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onCreate(e, item.id);
-                  }}
-                  title="New item"
-                  style={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    width: 22,
-                    height: 22,
-                    borderRadius: 4,
-                    background: isCreateMenuOpen ? 'rgba(255,255,255,0.1)' : 'transparent',
-                    border: 'none',
-                    cursor: 'pointer',
-                    color: isCreateMenuOpen ? '#ddd' : '#999',
-                    padding: 0,
-                    transition: 'background 0.1s, color 0.1s',
-                  }}
-                  onMouseEnter={(e) => {
-                    e.currentTarget.style.background = 'rgba(255,255,255,0.1)';
-                    e.currentTarget.style.color = '#ddd';
-                  }}
-                  onMouseLeave={(e) => {
-                    if (!isCreateMenuOpen) {
-                      e.currentTarget.style.background = 'transparent';
-                      e.currentTarget.style.color = '#999';
-                    }
-                  }}
-                >
-                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
-                    <line x1="12" y1="5" x2="12" y2="19" />
-                    <line x1="5" y1="12" x2="19" y2="12" />
                   </svg>
                 </button>
               )}

--- a/frontend/app/(main)/projects/[projectId]/data/components/explorer/ExplorerTreeRow.tsx
+++ b/frontend/app/(main)/projects/[projectId]/data/components/explorer/ExplorerTreeRow.tsx
@@ -122,6 +122,7 @@ interface ExplorerTreeRowProps {
   activeId: string | null;
   onNavigate: (item: MillerColumnItem) => void;
   onCreate?: ExplorerSidebarProps['onCreate'];
+  onCreateSync?: ExplorerSidebarProps['onCreateSync'];
   onRename?: ExplorerSidebarProps['onRename'];
   onDelete?: ExplorerSidebarProps['onDelete'];
   onMoveNode?: ExplorerSidebarProps['onMoveNode'];
@@ -138,6 +139,7 @@ export const ExplorerTreeRow = memo(function ExplorerTreeRow({
   activeId,
   onNavigate,
   onCreate,
+  onCreateSync,
   onRename,
   onDelete,
   onMoveNode,
@@ -219,7 +221,7 @@ export const ExplorerTreeRow = memo(function ExplorerTreeRow({
     [children],
   );
 
-  const hasActions = !!(onCreate || onRename || onDelete);
+  const hasActions = !!(onCreate || onCreateSync || onRename || onDelete);
 
   return (
     <div>
@@ -391,6 +393,65 @@ export const ExplorerTreeRow = memo(function ExplorerTreeRow({
               className={`flex items-center gap-0.5 flex-shrink-0 ml-auto ${menuOpen || isCreateMenuOpen ? 'visible' : 'invisible group-hover/row:visible'}`}
               onClick={(e) => e.stopPropagation()}
             >
+              {/* Plug-link icon: "create access point for this folder".
+                  Sits *before* the + button so the action cluster
+                  reads left-to-right as
+                    [external surface]  [add child]  [more]
+                  — the user's first scan for "expose this folder
+                  to an agent / tool" lands on the plug icon, and
+                  the existing + stays focused on its single
+                  responsibility ("add a thing inside this
+                  folder"), which review feedback explicitly
+                  flagged as the better grouping. */}
+              {isFolder && onCreateSync && (
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onCreateSync(item.id);
+                  }}
+                  title="Create access point for this folder"
+                  aria-label="Create access point for this folder"
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    width: 22,
+                    height: 22,
+                    borderRadius: 4,
+                    background: 'transparent',
+                    border: 'none',
+                    cursor: 'pointer',
+                    color: '#999',
+                    padding: 0,
+                    transition: 'background 0.1s, color 0.1s',
+                  }}
+                  onMouseEnter={(e) => {
+                    e.currentTarget.style.background = 'rgba(255,255,255,0.1)';
+                    e.currentTarget.style.color = '#ddd';
+                  }}
+                  onMouseLeave={(e) => {
+                    e.currentTarget.style.background = 'transparent';
+                    e.currentTarget.style.color = '#999';
+                  }}
+                >
+                  <svg
+                    width="13"
+                    height="13"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <path d="M9 17H7A5 5 0 0 1 7 7h2" />
+                    <path d="M15 7h2a5 5 0 1 1 0 10h-2" />
+                    <line x1="8" y1="12" x2="16" y2="12" />
+                  </svg>
+                </button>
+              )}
+
               {isFolder && onCreate && (
                 <button
                   type="button"
@@ -502,6 +563,7 @@ export const ExplorerTreeRow = memo(function ExplorerTreeRow({
                 activeId={activeId}
                 onNavigate={onNavigate}
                 onCreate={onCreate}
+                onCreateSync={onCreateSync}
                 onRename={onRename}
                 onDelete={onDelete}
                 onMoveNode={onMoveNode}

--- a/frontend/app/(main)/projects/[projectId]/data/components/explorer/types.ts
+++ b/frontend/app/(main)/projects/[projectId]/data/components/explorer/types.ts
@@ -27,6 +27,14 @@ export interface ExplorerSidebarProps {
     targetFolderId: string | null,
     sourceParentId?: string | null,
   ) => Promise<void>;
+  // Open the right-side sync_create panel with the user's current
+  // navigation context pre-filled as the target resource.  The
+  // sidebar surfaces this as a "+ Connect" button next to the
+  // file/folder + button, replacing the previous "click Create
+  // Access in the toolbar → drag the folder from the sidebar
+  // back into the panel" flow.  No-op fallback to nothing if
+  // omitted, so the prop stays additive.
+  onCreateSync?: () => void;
   activeSyncNodeId?: string | null;
   highlightNodeId?: string | null;
   createMenuOpenForId?: string | null;

--- a/frontend/app/(main)/projects/[projectId]/data/components/explorer/types.ts
+++ b/frontend/app/(main)/projects/[projectId]/data/components/explorer/types.ts
@@ -27,14 +27,20 @@ export interface ExplorerSidebarProps {
     targetFolderId: string | null,
     sourceParentId?: string | null,
   ) => Promise<void>;
-  // Open the right-side sync_create panel with the user's current
-  // navigation context pre-filled as the target resource.  The
-  // sidebar surfaces this as a "+ Connect" button next to the
-  // file/folder + button, replacing the previous "click Create
-  // Access in the toolbar → drag the folder from the sidebar
-  // back into the panel" flow.  No-op fallback to nothing if
-  // omitted, so the prop stays additive.
-  onCreateSync?: () => void;
+  // Open the right-side sync_create panel with the given folder
+  // path pre-filled as the target resource.  Two surfaces invoke
+  // it:
+  //   - sidebar header "Connect" button → passes the user's
+  //     current navigation focus (or '' for project root) so the
+  //     panel lands targeting wherever the user is right now
+  //   - per-folder row plug button (hover-revealed, next to + and
+  //     the action menu) → passes that row's own folder id, so
+  //     the user doesn't have to navigate into a folder before
+  //     creating an AP for it
+  // Either entry collapses what used to be a 4-step flow ("toolbar
+  // Create Access → drag the folder from the sidebar → click
+  // Create") into one targeted click.
+  onCreateSync?: (folderPath: string) => void;
   activeSyncNodeId?: string | null;
   highlightNodeId?: string | null;
   createMenuOpenForId?: string | null;

--- a/frontend/app/(main)/projects/[projectId]/data/components/explorer/types.ts
+++ b/frontend/app/(main)/projects/[projectId]/data/components/explorer/types.ts
@@ -27,20 +27,21 @@ export interface ExplorerSidebarProps {
     targetFolderId: string | null,
     sourceParentId?: string | null,
   ) => Promise<void>;
-  // Open the right-side sync_create panel with the given folder
-  // path pre-filled as the target resource.  Two surfaces invoke
-  // it:
-  //   - sidebar header "Connect" button → passes the user's
-  //     current navigation focus (or '' for project root) so the
-  //     panel lands targeting wherever the user is right now
-  //   - per-folder row plug button (hover-revealed, next to + and
-  //     the action menu) → passes that row's own folder id, so
-  //     the user doesn't have to navigate into a folder before
-  //     creating an AP for it
-  // Either entry collapses what used to be a 4-step flow ("toolbar
-  // Create Access → drag the folder from the sidebar → click
-  // Create") into one targeted click.
-  onCreateSync?: (folderPath: string) => void;
+  // Open the per-folder access-provider menu, anchored at the
+  // event's currentTarget, with `folderPath` stashed as the target
+  // that gets pre-bound on the panel after the user picks a
+  // provider from the menu.  Two surfaces invoke it:
+  //   - per-folder row plug button (hover-revealed, next to +)
+  //     → passes that row's own folder id, so the user creates
+  //     for that exact folder without navigating first
+  //   - the Root row's hover plug button → passes '' (project
+  //     root scope)
+  // The flow is: plug click → access-only menu of
+  // providers/agents/endpoints → user picks one → panel opens
+  // already-selected on that provider's config view, with the
+  // folder pre-bound as the target chip.  Avoids the "open empty
+  // panel + drag folder from sidebar" anti-pattern entirely.
+  onCreateSync?: (event: MouseEvent<Element>, folderPath: string) => void;
   activeSyncNodeId?: string | null;
   highlightNodeId?: string | null;
   createMenuOpenForId?: string | null;

--- a/frontend/app/(main)/projects/[projectId]/data/components/menus/CreateMenu.tsx
+++ b/frontend/app/(main)/projects/[projectId]/data/components/menus/CreateMenu.tsx
@@ -452,13 +452,23 @@ export function CreateMenu({
             <MenuItem icon={<McpIcon />} label="MCP Server" sublabel="Coming soon" disabled />
             <MenuItem icon={<SandboxIcon />} label="Sandbox" sublabel="Coming soon" disabled />
 
-            <Divider />
+            {/* "More Sources…" is the open-the-empty-picker fallback
+                — useful from `+ → New Access` when the user is
+                exploring, but pointless from the per-folder plug
+                button (the user has already declared intent by
+                clicking the plug, an empty picker is a step
+                backwards).  Hide it in accessOnly mode. */}
+            {!accessOnly && (
+              <>
+                <Divider />
 
-            <MenuItem
-              icon={<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke={iconColor} strokeWidth="2" strokeLinecap="round"><circle cx="11" cy="11" r="8" /><line x1="21" y1="21" x2="16.65" y2="16.65" /></svg>}
-              label="More Sources..."
-              onClick={() => { onImportFromSaas(); onClose(); }}
-            />
+                <MenuItem
+                  icon={<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke={iconColor} strokeWidth="2" strokeLinecap="round"><circle cx="11" cy="11" r="8" /><line x1="21" y1="21" x2="16.65" y2="16.65" /></svg>}
+                  label="More Sources..."
+                  onClick={() => { onImportFromSaas(); onClose(); }}
+                />
+              </>
+            )}
           </div>
         )}
       </div>

--- a/frontend/app/(main)/projects/[projectId]/data/components/menus/CreateMenu.tsx
+++ b/frontend/app/(main)/projects/[projectId]/data/components/menus/CreateMenu.tsx
@@ -16,6 +16,15 @@ export interface CreateMenuProps {
   y: number;
   anchorLeft?: number;
   onClose: () => void;
+  // When `accessOnly` is true, the menu skips the Create Blank /
+  // Upload sections entirely and renders the access-provider list
+  // (Notion, Gmail, Calendar, …, Machine Folder, Chat Agent, etc.)
+  // as the top-level menu — flat, no `New Access >` submenu trigger.
+  // This is what the per-folder plug button uses: the user already
+  // expressed the intent "create access for this folder" by clicking
+  // the plug, so the picker shouldn't make them traverse a nested
+  // submenu to *get* to the access list.
+  accessOnly?: boolean;
   onCreateFolder: () => void;
   onCreateBlankJson: () => void;
   onCreateBlankMarkdown: () => void;
@@ -215,6 +224,7 @@ export function CreateMenu({
   y,
   anchorLeft,
   onClose,
+  accessOnly,
   onCreateFolder,
   onCreateBlankJson,
   onCreateBlankMarkdown,
@@ -281,79 +291,93 @@ export function CreateMenu({
         visibility: position ? 'visible' : 'hidden',
       }}
     >
-      <div style={{ padding: '6px 16px 2px', fontSize: 11, fontWeight: 600, color: '#71717a', letterSpacing: '0.05em' }}>
-        Create Blank
-      </div>
-
-      <MenuItem icon={<FolderIcon />} label="Folder" onClick={() => { onCreateFolder(); onClose(); }} onMouseEnter={() => setActiveSubMenu(null)} />
-      <MenuItem icon={<MarkdownIcon />} label="Markdown" onClick={() => { onCreateBlankMarkdown(); onClose(); }} onMouseEnter={() => setActiveSubMenu(null)} />
-      <MenuItem icon={<JsonIcon />} label="JSON" onClick={() => { onCreateBlankJson(); onClose(); }} onMouseEnter={() => setActiveSubMenu(null)} />
-
-      <Divider />
-
-      <div style={{ position: 'relative' }}>
-        <MenuItem
-          icon={<UploadIcon />}
-          label="Upload"
-          hasSubmenu
-          isActive={activeSubMenu === 'upload'}
-          onMouseEnter={() => setActiveSubMenu('upload')}
-        />
-        {activeSubMenu === 'upload' && (
-          <div
-            style={{
-              position: 'absolute',
-              top: 0,
-              left: '100%',
-              marginLeft: 4,
-              background: 'rgba(28, 28, 30, 0.98)',
-              backdropFilter: 'blur(20px)',
-              border: '1px solid rgba(255,255,255,0.1)',
-              borderRadius: 8,
-              padding: '4px 0',
-              minWidth: 180,
-              boxShadow: '0 8px 32px rgba(0,0,0,0.4)',
-              zIndex: 1001,
-            }}
-          >
-            <MenuItem
-              icon={
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none">
-                  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" stroke={iconColor} strokeWidth="1.5" />
-                  <polyline points="14,2 14,8 20,8" stroke={iconColor} strokeWidth="1.5" />
-                </svg>
-              }
-              label="Files"
-              sublabel="PDF, MD, CSV"
-              onClick={() => { onImportFromFiles(); onClose(); }}
-            />
-            <MenuItem
-              icon={
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none">
-                  <circle cx="12" cy="12" r="10" stroke={iconColor} strokeWidth="1.5" />
-                  <path d="M2 12h20" stroke={iconColor} strokeWidth="1.5" />
-                  <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" stroke={iconColor} strokeWidth="1.5" />
-                </svg>
-              }
-              label="URL"
-              sublabel="Web page"
-              onClick={() => { onImportFromUrl(); onClose(); }}
-            />
+      {!accessOnly && (
+        <>
+          <div style={{ padding: '6px 16px 2px', fontSize: 11, fontWeight: 600, color: '#71717a', letterSpacing: '0.05em' }}>
+            Create Blank
           </div>
-        )}
-      </div>
+
+          <MenuItem icon={<FolderIcon />} label="Folder" onClick={() => { onCreateFolder(); onClose(); }} onMouseEnter={() => setActiveSubMenu(null)} />
+          <MenuItem icon={<MarkdownIcon />} label="Markdown" onClick={() => { onCreateBlankMarkdown(); onClose(); }} onMouseEnter={() => setActiveSubMenu(null)} />
+          <MenuItem icon={<JsonIcon />} label="JSON" onClick={() => { onCreateBlankJson(); onClose(); }} onMouseEnter={() => setActiveSubMenu(null)} />
+
+          <Divider />
+
+          <div style={{ position: 'relative' }}>
+            <MenuItem
+              icon={<UploadIcon />}
+              label="Upload"
+              hasSubmenu
+              isActive={activeSubMenu === 'upload'}
+              onMouseEnter={() => setActiveSubMenu('upload')}
+            />
+            {activeSubMenu === 'upload' && (
+              <div
+                style={{
+                  position: 'absolute',
+                  top: 0,
+                  left: '100%',
+                  marginLeft: 4,
+                  background: 'rgba(28, 28, 30, 0.98)',
+                  backdropFilter: 'blur(20px)',
+                  border: '1px solid rgba(255,255,255,0.1)',
+                  borderRadius: 8,
+                  padding: '4px 0',
+                  minWidth: 180,
+                  boxShadow: '0 8px 32px rgba(0,0,0,0.4)',
+                  zIndex: 1001,
+                }}
+              >
+                <MenuItem
+                  icon={
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none">
+                      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" stroke={iconColor} strokeWidth="1.5" />
+                      <polyline points="14,2 14,8 20,8" stroke={iconColor} strokeWidth="1.5" />
+                    </svg>
+                  }
+                  label="Files"
+                  sublabel="PDF, MD, CSV"
+                  onClick={() => { onImportFromFiles(); onClose(); }}
+                />
+                <MenuItem
+                  icon={
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none">
+                      <circle cx="12" cy="12" r="10" stroke={iconColor} strokeWidth="1.5" />
+                      <path d="M2 12h20" stroke={iconColor} strokeWidth="1.5" />
+                      <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" stroke={iconColor} strokeWidth="1.5" />
+                    </svg>
+                  }
+                  label="URL"
+                  sublabel="Web page"
+                  onClick={() => { onImportFromUrl(); onClose(); }}
+                />
+              </div>
+            )}
+          </div>
+        </>
+      )}
 
       <div style={{ position: 'relative' }}>
-        <MenuItem
-          icon={<ConnectIcon />}
-          label="New Access"
-          hasSubmenu
-          isActive={activeSubMenu === 'connect'}
-          onMouseEnter={() => setActiveSubMenu('connect')}
-        />
-        {activeSubMenu === 'connect' && (
+        {/* In accessOnly mode the access list IS the menu, so we
+            skip the "New Access >" parent row and render the
+            access content flat at the menu's top level.  The
+            wrapper still exists because we share the same content
+            block between flat and submenu modes. */}
+        {!accessOnly && (
+          <MenuItem
+            icon={<ConnectIcon />}
+            label="New Access"
+            hasSubmenu
+            isActive={activeSubMenu === 'connect'}
+            onMouseEnter={() => setActiveSubMenu('connect')}
+          />
+        )}
+        {(accessOnly || activeSubMenu === 'connect') && (
           <div
-            style={{
+            style={accessOnly ? {
+              padding: '4px 0',
+              minWidth: 240,
+            } : {
               position: 'absolute',
               top: 0,
               left: '100%',

--- a/frontend/app/(main)/projects/[projectId]/data/hooks/useDataCreateFlow.ts
+++ b/frontend/app/(main)/projects/[projectId]/data/hooks/useDataCreateFlow.ts
@@ -429,11 +429,33 @@ export function useDataCreateFlow({
         setDefaultStartOption('documents');
         setCreateTableOpen(true);
       },
+      // From `+` menu (Upload → URL): open the createTable dialog
+      // for inline URL import.
+      // From plug menu (New Access → Web Page): same provider id
+      // ("url" on the backend), but go through handleAccessSelect
+      // so the panel lands on the URL connector's config view with
+      // the user's plug-clicked folder pre-bound as target.  Branch
+      // on accessTargetPath to pick which flow to run.
       onImportFromUrl: () => {
-        setDefaultStartOption('url');
-        setCreateTableOpen(true);
+        if (accessTargetPath !== null) {
+          handleAccessSelect('url');
+        } else {
+          setDefaultStartOption('url');
+          setCreateTableOpen(true);
+        }
       },
+      // From `+` menu (New Access → More Sources…): generic
+      // exploration entry, opens the panel on the picker view.
+      // From plug menu: this entry is suppressed at the menu level
+      // (see CreateMenu's accessOnly branch) — there's no
+      // sensible "I don't know what kind of access I want" path
+      // when the user already committed by clicking a specific
+      // folder's plug.  Keep the callback defined for the `+` menu
+      // path; the no-op-on-prefilled-target branch is just safety.
       onImportFromSaas: () => {
+        if (accessTargetPath !== null) {
+          return;
+        }
         openSyncSetting('_generic');
         openSyncCreatePanel();
       },
@@ -455,6 +477,7 @@ export function useDataCreateFlow({
       onCreateSandbox: () => handleAccessSelect('sandbox'),
     };
   }, [
+    accessTargetPath,
     closeCreateMenu,
     createInFolderId,
     currentFolderId,

--- a/frontend/app/(main)/projects/[projectId]/data/hooks/useDataCreateFlow.ts
+++ b/frontend/app/(main)/projects/[projectId]/data/hooks/useDataCreateFlow.ts
@@ -64,6 +64,17 @@ export function useDataCreateFlow({
   const [createMenuOpen, setCreateMenuOpen] = useState(false);
   const [createMenuPosition, setCreateMenuPosition] = useState<CreateMenuPosition | null>(null);
   const [createInFolderId, setCreateInFolderId] = useState<string | null | undefined>(undefined);
+  // Two pieces of state for the per-folder plug-button flow.  When
+  // a user clicks the plug, we open the same CreateMenu instance
+  // but flip it into accessOnly mode (only renders the New Access
+  // submenu content, flat) and stash the folder path that should
+  // be pre-filled as the target on whichever provider the user
+  // picks from the menu.  Reusing the existing create-menu state
+  // machine — same position / outside-click-to-close /
+  // reposition-on-scroll behaviour — instead of standing up a
+  // second menu instance.
+  const [createMenuAccessOnly, setCreateMenuAccessOnly] = useState(false);
+  const [accessTargetPath, setAccessTargetPath] = useState<string | null>(null);
   const [highlightNodeId, setHighlightNodeId] = useState<string | null>(null);
   const createMenuRef = useRef<HTMLDivElement>(null);
   const createMenuTriggerRef = useRef<HTMLElement | null>(null);
@@ -93,6 +104,8 @@ export function useDataCreateFlow({
 
   const closeCreateMenu = useCallback(() => {
     setCreateMenuOpen(false);
+    setCreateMenuAccessOnly(false);
+    setAccessTargetPath(null);
     createMenuTriggerRef.current = null;
   }, []);
 
@@ -136,7 +149,26 @@ export function useDataCreateFlow({
 
   const handleMillerCreateClick = useCallback(
     (event: ReactMouseEvent<Element>, parentId: string | null) => {
+      setCreateMenuAccessOnly(false);
+      setAccessTargetPath(null);
       openCreateMenu(event, parentId);
+    },
+    [openCreateMenu],
+  );
+
+  // Per-folder plug-button entry point.  Same menu, but accessOnly
+  // mode → flat list of providers/agents/endpoints, no Create-Blank
+  // / Upload sections.  Stashes `folderPath` so the picker callbacks
+  // below can pre-bind it as the target resource on whichever
+  // provider the user picks.  The folder path is normalised the
+  // same way as in page.tsx's openSyncCreatePanelForFolder ('' for
+  // project root, raw path otherwise) so AgentContext's
+  // `setDraftResources` keys line up with `accessByPath`.
+  const handleAccessMenuClick = useCallback(
+    (event: ReactMouseEvent<Element>, folderPath: string) => {
+      setCreateMenuAccessOnly(true);
+      setAccessTargetPath(folderPath);
+      openCreateMenu(event, folderPath || null);
     },
     [openCreateMenu],
   );
@@ -240,6 +272,45 @@ export function useDataCreateFlow({
       }
     },
     [currentFolderId, openSyncCreatePanel, openSyncSetting, projectId],
+  );
+
+  // Provider-pick handler that branches on which menu launched it:
+  //
+  //   - plug menu (accessTargetPath !== null) → the user already
+  //     picked a target by clicking the folder's plug, so skip the
+  //     "create a node + bind it" dance.  Build the AccessResource
+  //     directly from the prefilled folder path and seed it via
+  //     `openSyncSetting`'s `preBindResource` argument.  The panel
+  //     auto-jumps to the provider's config view (because
+  //     pendingSyncProvider is set) with the target chip already
+  //     populated (because draftResources[0] is set).
+  //
+  //   - + menu (accessTargetPath === null) → the user is starting
+  //     from "create something new under this folder", so go through
+  //     the existing handleCreateAndSync, which mints a new node
+  //     (Notion / Gmail / etc. parent folder) and binds it as the
+  //     target.
+  //
+  // Same provider id strings flow into both branches, so the panel's
+  // pendingSyncProvider effect lights up the right config view either
+  // way.
+  const handleAccessSelect = useCallback(
+    (provider: string) => {
+      if (accessTargetPath !== null) {
+        const segs = accessTargetPath.split('/').filter(Boolean);
+        const nodeName = segs.length > 0 ? segs[segs.length - 1] : 'Root';
+        openSyncSetting(provider, {
+          path: accessTargetPath,
+          nodeName,
+          nodeType: 'folder',
+          readonly: false,
+        });
+        openSyncCreatePanel();
+      } else {
+        void handleCreateAndSync(provider);
+      }
+    },
+    [accessTargetPath, handleCreateAndSync, openSyncCreatePanel, openSyncSetting],
   );
 
   const createMenuActions = useMemo<DataCreateMenuActions>(() => {
@@ -366,52 +437,28 @@ export function useDataCreateFlow({
         openSyncSetting('_generic');
         openSyncCreatePanel();
       },
-      onImportNotion: () => {
-        void handleCreateAndSync('notion');
-      },
-      onImportGitHub: () => {
-        void handleCreateAndSync('github');
-      },
-      onImportGmail: () => {
-        void handleCreateAndSync('gmail');
-      },
-      onImportDocs: () => {
-        void handleCreateAndSync('docs');
-      },
-      onImportCalendar: () => {
-        void handleCreateAndSync('calendar');
-      },
-      onImportSheets: () => {
-        void handleCreateAndSync('sheets');
-      },
-      onConnectSupabase: () => {
-        void handleCreateAndSync('supabase');
-      },
-      onImportSearchConsole: () => {
-        void handleCreateAndSync('google_search_console');
-      },
-      onImportLocalFolder: () => {
-        openSyncSetting('filesystem');
-        openSyncCreatePanel();
-      },
-      onCreateAgent: () => {
-        openSyncSetting('chat');
-        openSyncCreatePanel();
-      },
-      onCreateMcp: () => {
-        openSyncSetting('mcp');
-        openSyncCreatePanel();
-      },
-      onCreateSandbox: () => {
-        openSyncSetting('sandbox');
-        openSyncCreatePanel();
-      },
+      // All concrete-provider entries route through handleAccessSelect,
+      // which decides — based on whether the menu was opened by the
+      // plug button or by `+` — whether to prefill the user's target
+      // folder or to mint a new sync node first.
+      onImportNotion: () => handleAccessSelect('notion'),
+      onImportGitHub: () => handleAccessSelect('github'),
+      onImportGmail: () => handleAccessSelect('gmail'),
+      onImportDocs: () => handleAccessSelect('docs'),
+      onImportCalendar: () => handleAccessSelect('calendar'),
+      onImportSheets: () => handleAccessSelect('sheets'),
+      onConnectSupabase: () => handleAccessSelect('supabase'),
+      onImportSearchConsole: () => handleAccessSelect('google_search_console'),
+      onImportLocalFolder: () => handleAccessSelect('filesystem'),
+      onCreateAgent: () => handleAccessSelect('chat'),
+      onCreateMcp: () => handleAccessSelect('mcp'),
+      onCreateSandbox: () => handleAccessSelect('sandbox'),
     };
   }, [
     closeCreateMenu,
     createInFolderId,
     currentFolderId,
-    handleCreateAndSync,
+    handleAccessSelect,
     highlightCreatedNode,
     navigateTo,
     openSyncCreatePanel,
@@ -430,11 +477,13 @@ export function useDataCreateFlow({
     createMenuOpen,
     createMenuOpenForId,
     createMenuPosition,
+    createMenuAccessOnly,
     createMenuRef,
     createMenuActions,
     highlightNodeId,
     handleCreateClick,
     handleMillerCreateClick,
+    handleAccessMenuClick,
     closeCreateTable,
   };
 }

--- a/frontend/app/(main)/projects/[projectId]/data/hooks/useDataCreateFlow.ts
+++ b/frontend/app/(main)/projects/[projectId]/data/hooks/useDataCreateFlow.ts
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { MouseEvent as ReactMouseEvent } from 'react';
-import { mkdir, writeFile } from '@/lib/contentTreeApi';
+import { mkdir, writeFile, treeList } from '@/lib/contentTreeApi';
 import { refreshAllContentNodes } from '@/lib/hooks/useData';
 import type { AccessResource } from '@/contexts/AgentContext';
 import { ensureExpanded } from '../components/explorer';
@@ -246,13 +246,65 @@ export function useDataCreateFlow({
     const getTargetFolderPath = () =>
       createInFolderId === undefined ? currentFolderId : createInFolderId;
 
+    // Pick a name that doesn't collide with an existing entry at the
+    // target folder.  We need this because creating a folder /
+    // Untitled file with a literal hardcoded name would silently
+    // no-op on the backend the second time around: mkdir writes
+    // `<path>/.keep` (empty bytes) and writeFile writes the same
+    // empty content, so MUT computes an identical commit hash and
+    // skips it as a no-op.  The UI then refreshes the tree, sees
+    // exactly the same nodes as before, and the user thinks the
+    // click "did nothing" or "overwrote" the previous one.
+    //
+    // Convention: `Base`, `Base (2)`, `Base (3)`, … — same pattern
+    // every native file manager uses, so users don't have to learn
+    // anything new.  We probe up to 999 to keep the loop bounded;
+    // in practice nobody creates 999 New Folders in one directory.
+    //
+    // For files we keep the extension contract intact: `Untitled`
+    // (extension-less, JSON adds it server-side via writeFile's
+    // `kind` parameter) and `Untitled Note` (markdown) get the
+    // suffix appended *before* any extension, so collisions still
+    // dedupe against bare names.
+    const pickAvailableName = async (
+      targetFolderPath: string | null,
+      baseName: string,
+    ): Promise<string> => {
+      let siblings: Awaited<ReturnType<typeof treeList>>;
+      try {
+        siblings = await treeList(projectId, targetFolderPath ?? '', 1);
+      } catch (err) {
+        // If we can't reach the tree endpoint, fall back to the
+        // base name and let the create call surface its own error.
+        // Worse than the dedup-aware path but no worse than the
+        // pre-fix behaviour.
+        console.warn('treeList lookup failed, skipping dedup:', err);
+        return baseName;
+      }
+      const existing = new Set(siblings.map((e) => e.name));
+      if (!existing.has(baseName)) return baseName;
+      for (let n = 2; n < 1000; n++) {
+        const candidate = `${baseName} (${n})`;
+        if (!existing.has(candidate)) return candidate;
+      }
+      // Outrageously unlikely fallback — append a timestamp so the
+      // user gets a unique name rather than an infinite hang.
+      return `${baseName} (${Date.now()})`;
+    };
+
     return {
       onClose: closeCreateMenu,
       onCreateFolder: async () => {
         const targetFolderPath = getTargetFolderPath();
 
         try {
-          const folderPath = targetFolderPath ? `${targetFolderPath}/New Folder` : 'New Folder';
+          const folderName = await pickAvailableName(
+            targetFolderPath,
+            'New Folder',
+          );
+          const folderPath = targetFolderPath
+            ? `${targetFolderPath}/${folderName}`
+            : folderName;
           await mkdir(projectId, folderPath);
           if (targetFolderPath) ensureExpanded(targetFolderPath);
           await refreshAllContentNodes(projectId);
@@ -266,7 +318,13 @@ export function useDataCreateFlow({
         const targetFolderPath = getTargetFolderPath();
 
         try {
-          const filePath = targetFolderPath ? `${targetFolderPath}/Untitled` : 'Untitled';
+          const fileName = await pickAvailableName(
+            targetFolderPath,
+            'Untitled',
+          );
+          const filePath = targetFolderPath
+            ? `${targetFolderPath}/${fileName}`
+            : fileName;
           await writeFile(projectId, filePath, {}, 'json');
           if (targetFolderPath) ensureExpanded(targetFolderPath);
           await refreshAllContentNodes(projectId);
@@ -280,7 +338,13 @@ export function useDataCreateFlow({
         const targetFolderPath = getTargetFolderPath();
 
         try {
-          const filePath = targetFolderPath ? `${targetFolderPath}/Untitled Note` : 'Untitled Note';
+          const fileName = await pickAvailableName(
+            targetFolderPath,
+            'Untitled Note',
+          );
+          const filePath = targetFolderPath
+            ? `${targetFolderPath}/${fileName}`
+            : fileName;
           await writeFile(projectId, filePath, '', 'markdown');
           if (targetFolderPath) ensureExpanded(targetFolderPath);
           await refreshAllContentNodes(projectId);

--- a/frontend/app/(main)/projects/[projectId]/home/components/AccessPointsListCard.tsx
+++ b/frontend/app/(main)/projects/[projectId]/home/components/AccessPointsListCard.tsx
@@ -1,12 +1,26 @@
 'use client';
 
-import { useState } from 'react';
+import React, { useState } from 'react';
 import type { useRouter } from 'next/navigation';
 import { ArrowRight, ArrowLeft, ArrowLeftRight } from 'lucide-react';
 import { T } from '../lib/tokens';
 import { PROVIDER_LABELS, getApDirection } from '../lib/constants';
 import type { DashboardConnection } from '../lib/types';
 import { ProviderAvatar } from './ProviderAvatar';
+
+// Normalize the three known "root scope" path representations the
+// backend may emit ('/' for `mut connect` bootstrap rows, null for
+// legacy rows, '' for early hand-bootstrapped rows) into a single
+// canonical key.  Used both for the lookup key in `accessByPath` and
+// for the hover-sync key here.  Keep this in step with the same
+// normalization in page.tsx — if they drift, the chip↔card hover
+// handshake silently breaks.
+function normalizeApPath(raw: string | null | undefined): string {
+  if (raw === null || raw === undefined || raw === '' || raw === '/') {
+    return '';
+  }
+  return raw;
+}
 
 // AccessPointsListCard — left-column primary surface that replaces the
 // previous ConnectionsCanvas slot.
@@ -203,10 +217,25 @@ export function AccessPointsListCard({
   projectId,
   router,
   connections,
+  hoveredPath,
+  onHoverPath,
 }: {
   projectId: string;
   router: ReturnType<typeof useRouter>;
   connections: DashboardConnection[];
+  // Path of the currently-hovered chip / AP row, normalized via
+  // `normalizeApPath`.  When this matches an AP's normalized path,
+  // that AP renders in its highlighted state.  `null` means nothing
+  // is hovered.  Lifted to page.tsx so a hover on a Data-card
+  // ApChip and a hover on this card's AP row share the same source
+  // of truth.
+  hoveredPath: string | null;
+  // Set when this card's row is hovered, cleared when the cursor
+  // leaves.  The Data card uses the same callback (via the chip's
+  // own onHover) so the hover state is reflexive — hovering the
+  // AP card highlights the matching tree row, hovering the tree
+  // row highlights the matching AP card.
+  onHoverPath: (path: string | null) => void;
 }) {
   const total = connections.length;
   const [copiedKey, setCopiedKey] = useState<string | null>(null);
@@ -305,12 +334,12 @@ export function AccessPointsListCard({
         </button>
       </div>
 
-      {/* Body — list of AP cards or the empty placeholder.  minHeight
-          keeps the card from collapsing when an empty project has
-          zero APs (rare in practice — `mut connect` bootstrap creates
-          one — but the layout floor matters for visual stability
-          when an AP gets revoked). */}
-      <div style={{ padding: '8px 8px', minHeight: 60 }}>
+      {/* Body — flat list of AP rows (sidebar AccessPointsCard
+          rhythm: avatar + name + status dot + direction + scope path
+          on a single line) with URL / `$` rows nested beneath each.
+          minHeight stays so revoke→empty doesn't collapse the card
+          shell. */}
+      <div style={{ padding: '4px 6px', minHeight: 60 }}>
         {total === 0 ? (
           <div
             style={{
@@ -325,73 +354,63 @@ export function AccessPointsListCard({
             No access points configured.
           </div>
         ) : (
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-            {connections.map((conn) => {
-              const direction = getApDirection(conn);
-              const label =
-                conn.name || PROVIDER_LABELS[conn.provider] || conn.provider;
-              // Normalize the three "root scope" representations the
-              // backend can produce ('/' for newer rows, null for
-              // legacy, '' for early hand-bootstrapped) into a single
-              // displayed string '/'.  Without this, a root AP would
-              // render as '//' here (the leading '/' we prepend below
-              // + the literal '/' coming out of conn.path) which reads
-              // as a typo.
-              const rawPath = conn.path;
-              const isRoot =
-                rawPath === null || rawPath === '' || rawPath === '/';
-              const displayScope = isRoot ? '/' : `/${rawPath}`;
-              const isError = conn.status === 'error';
-              const statusColor = isError
-                ? T.err
-                : conn.status === 'paused'
-                  ? T.warn
-                  : T.live;
-              const url = buildEndpointUrl(conn);
-              const cmd = buildCliCommand(conn, url);
+          connections.map((conn, idx) => {
+            const direction = getApDirection(conn);
+            const label =
+              conn.name || PROVIDER_LABELS[conn.provider] || conn.provider;
+            // displayScope: '/' for any of the three root-scope
+            // forms the backend may produce, '/<path>' otherwise.
+            // Without this, root APs render as '//' (template '/'
+            // prepended to a path value that's already '/').
+            const rawPath = conn.path;
+            const isRoot =
+              rawPath === null || rawPath === '' || rawPath === '/';
+            const displayScope = isRoot ? '/' : `/${rawPath}`;
+            const isError = conn.status === 'error';
+            const statusColor = isError
+              ? T.err
+              : conn.status === 'paused'
+                ? T.warn
+                : T.live;
+            const url = buildEndpointUrl(conn);
+            const cmd = buildCliCommand(conn, url);
 
-              return (
+            // Normalized path drives hover-sync between Data ApChip
+            // and this card.  When the user mouses over a chip in the
+            // tree, page.tsx sets hoveredPath to the chip's row path
+            // (already normalized via `accessByPath`'s key); when
+            // they mouse over an AP row here, we set hoveredPath to
+            // this AP's normalized path.  The matching side
+            // highlights — chip ↔ row — making "this card and that
+            // chip are the same thing" obvious without the user
+            // having to mentally connect colour cues.
+            const apPath = normalizeApPath(rawPath);
+            const isHovered = hoveredPath !== null && hoveredPath === apPath;
+
+            return (
+              <React.Fragment key={conn.id}>
+                {/* Per-AP block: identity row + URL + cmd, drawn flat
+                    (no individual card frame) — the section card is
+                    the only frame, the rows below sit inside its
+                    body like a directory listing.  Highlight on
+                    hover-sync is a soft cyan tint flush across the
+                    whole block (identity row + sub-rows) so the
+                    user sees the entire AP, not just one row. */}
                 <div
-                  key={conn.id}
+                  onMouseEnter={() => onHoverPath(apPath)}
+                  onMouseLeave={() => onHoverPath(null)}
                   style={{
                     display: 'flex',
                     flexDirection: 'column',
-                    gap: 10,
-                    // Asymmetric padding leaves room for the cyan
-                    // stripe on the left without crowding the
-                    // identity strip's content.
-                    padding: '12px 14px 12px 16px',
-                    borderRadius: 6,
-                    background: T.cardBg,
-                    border: `1px solid ${T.cardBorder}`,
-                    // Cyan stripe on the left edge — same hue as the
-                    // ApChip dot rendered next to AP-attached rows in
-                    // the Data card above.  The shared accent
-                    // is the visual handshake between the two views:
-                    // "this AP card and that tree-row chip are the
-                    // same thing."  A 3px stripe is wide enough to
-                    // register at scanning distance, narrow enough
-                    // to read as a left-edge accent rather than a
-                    // separate column.  Pinned to the cell-edge
-                    // background via box-shadow inset rather than
-                    // border-left so the rounded corners on
-                    // borderRadius stay clean.
-                    boxShadow: `inset 3px 0 0 0 ${T.live}`,
-                    transition: `background 160ms ${T.ease}, border-color 160ms ${T.ease}`,
-                  }}
-                  onMouseEnter={(e) => {
-                    e.currentTarget.style.background = T.cardBgH;
-                    e.currentTarget.style.borderColor = T.cardBorderH;
-                  }}
-                  onMouseLeave={(e) => {
-                    e.currentTarget.style.background = T.cardBg;
-                    e.currentTarget.style.borderColor = T.cardBorder;
+                    padding: '6px 8px',
+                    borderRadius: 4,
+                    background: isHovered ? T.rowHighlight : 'transparent',
+                    transition: `background 160ms ${T.ease}`,
                   }}
                 >
-                  {/* Identity strip — same layout rhythm as sidebar
-                      AccessPointsCard so the same AP reads consistently
-                      across the two views.  Whole strip is clickable
-                      to /access?ap=<id> for full management. */}
+                  {/* Identity row — sidebar AccessPointsCard layout
+                      verbatim so the same AP reads consistently
+                      across surfaces. */}
                   <button
                     type="button"
                     onClick={() =>
@@ -404,7 +423,7 @@ export function AccessPointsListCard({
                       background: 'none',
                       border: 'none',
                       cursor: 'pointer',
-                      padding: 0,
+                      padding: '4px 0',
                       width: '100%',
                       textAlign: 'left',
                       display: 'flex',
@@ -496,40 +515,62 @@ export function AccessPointsListCard({
                     </div>
                   </button>
 
-                  {/* Endpoint URL — every AP that has an access_key gets
-                      a copyable URL.  Sandbox provider returns null for
-                      now (its public route uses endpoint.id which the
-                      dashboard doesn't surface yet); we just don't
-                      render the line in that case rather than showing a
-                      partially-broken pill. */}
-                  {url && (
-                    <CopyableLine
-                      label="URL"
-                      value={url}
-                      copyKey={`url-${conn.id}`}
-                      copiedKey={copiedKey}
-                      onCopy={handleCopy}
-                    />
-                  )}
-
-                  {/* CLI command — filesystem only for now.  Other
-                      providers' invocation shapes (MCP server config,
-                      sandbox exec body, agent prompt etc.) are richer
-                      than a single command line and live on the
-                      /access detail page. */}
-                  {cmd && (
-                    <CopyableLine
-                      label="$"
-                      value={cmd}
-                      copyKey={`cmd-${conn.id}`}
-                      copiedKey={copiedKey}
-                      onCopy={handleCopy}
-                    />
+                  {/* URL + cmd nested rows.  Indented to align with
+                      the AP name (24px avatar + 10px gap = 34px) so
+                      they read as belonging to this AP without
+                      needing extra background chrome. */}
+                  {(url || cmd) && (
+                    <div
+                      style={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        gap: 6,
+                        marginTop: 6,
+                        marginLeft: 34,
+                        marginRight: 0,
+                      }}
+                    >
+                      {url && (
+                        <CopyableLine
+                          label="URL"
+                          value={url}
+                          copyKey={`url-${conn.id}`}
+                          copiedKey={copiedKey}
+                          onCopy={handleCopy}
+                        />
+                      )}
+                      {cmd && (
+                        <CopyableLine
+                          label="$"
+                          value={cmd}
+                          copyKey={`cmd-${conn.id}`}
+                          copiedKey={copiedKey}
+                          onCopy={handleCopy}
+                        />
+                      )}
+                    </div>
                   )}
                 </div>
-              );
-            })}
-          </div>
+
+                {/* Hairline divider between APs — only when there's
+                    a next AP after this one.  T.sectionDivider keeps
+                    it in the same family as other 1px rules on the
+                    page, so the dividers in the AP list read as part
+                    of the section card's structure rather than as
+                    decorative. */}
+                {idx < connections.length - 1 && (
+                  <div
+                    aria-hidden
+                    style={{
+                      height: 1,
+                      background: T.sectionDivider,
+                      margin: '4px 0',
+                    }}
+                  />
+                )}
+              </React.Fragment>
+            );
+          })
         )}
       </div>
     </div>

--- a/frontend/app/(main)/projects/[projectId]/home/components/AccessPointsListCard.tsx
+++ b/frontend/app/(main)/projects/[projectId]/home/components/AccessPointsListCard.tsx
@@ -46,13 +46,22 @@ function normalizeApPath(raw: string | null | undefined): string {
 //   ─ Both at once: self-hover wins; we don't double-paint.
 
 function DirectionGlyph({ direction }: { direction: 'inbound' | 'outbound' | 'bidirectional' }) {
-  if (direction === 'outbound') {
-    return <ArrowLeft size={11} strokeWidth={2} style={{ color: T.live, flexShrink: 0 }} />;
-  }
-  if (direction === 'bidirectional') {
-    return <ArrowLeftRight size={11} strokeWidth={2} style={{ color: T.live, flexShrink: 0 }} />;
-  }
-  return <ArrowRight size={11} strokeWidth={2} style={{ color: T.text3, flexShrink: 0 }} />;
+  // All three glyphs render in the neutral T.text3 grey.  The earlier
+  // version used T.live cyan for outbound + bidirectional with the
+  // intent of "outbound is a live wire", but that intent collided
+  // with the page-wide rule that cyan is reserved for active live-
+  // data signals.  Direction is *metadata* (which way data flows
+  // when this AP is used), not a status — the colour was over-
+  // promising and contributed to the "everything is cyan" feel.
+  // Status freshness is communicated by the dot next to the AP
+  // name, which keeps its statusColor mapping (live / error / paused).
+  const Icon =
+    direction === 'outbound'
+      ? ArrowLeft
+      : direction === 'bidirectional'
+        ? ArrowLeftRight
+        : ArrowRight;
+  return <Icon size={11} strokeWidth={2} style={{ color: T.text3, flexShrink: 0 }} />;
 }
 
 // Compose the public-facing endpoint URL for an AP, picking the right
@@ -303,19 +312,27 @@ export function AccessPointsListCard({
             No access points configured.
           </div>
         ) : (
-          connections.map((conn, idx) => (
-            <ApListRow
-              key={conn.id}
-              conn={conn}
-              isLast={idx === connections.length - 1}
-              projectId={projectId}
-              router={router}
-              hoveredPath={hoveredPath}
-              onHoverPath={onHoverPath}
-              copiedKey={copiedKey}
-              onCopy={handleCopy}
-            />
-          ))
+          // Flex column with generous vertical gap rather than 1px
+          // dividers.  When every AP is its own card-shaped row
+          // (with bg/padding when interactive), the gap between
+          // them naturally communicates "these are independent
+          // items" without an explicit hairline.  Hairline + bg
+          // both fighting for the "row separator" job was making
+          // the list look noisy.
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+            {connections.map((conn) => (
+              <ApListRow
+                key={conn.id}
+                conn={conn}
+                projectId={projectId}
+                router={router}
+                hoveredPath={hoveredPath}
+                onHoverPath={onHoverPath}
+                copiedKey={copiedKey}
+                onCopy={handleCopy}
+              />
+            ))}
+          </div>
         )}
       </div>
     </div>
@@ -329,7 +346,6 @@ export function AccessPointsListCard({
 // look different by design (see component-level comment).
 function ApListRow({
   conn,
-  isLast,
   projectId,
   router,
   hoveredPath,
@@ -338,7 +354,6 @@ function ApListRow({
   onCopy,
 }: {
   conn: DashboardConnection;
-  isLast: boolean;
   projectId: string;
   router: ReturnType<typeof useRouter>;
   hoveredPath: string | null;
@@ -417,21 +432,29 @@ function ApListRow({
             fontFamily: T.fontSans,
           }}
         >
+          {/* Provider avatar bumped 24 → 32 + radius 6 → 8 + icon
+              16 → 20.  Multi-AP differentiation now relies on
+              avatar shape (folder for filesystem, plug for mcp,
+              cube for sandbox) rather than colour, so the avatar
+              needs enough size to *be* the differentiator at
+              scanning distance.  Slightly stronger bg tint
+              (0.04 → 0.05) so the avatar reads as a plate the
+              icon sits on, not a flat dye behind it. */}
           <div
             style={{
-              width: 24,
-              height: 24,
-              borderRadius: 6,
+              width: 32,
+              height: 32,
+              borderRadius: 8,
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'center',
-              background: 'rgba(255,255,255,0.04)',
+              background: 'rgba(255,255,255,0.05)',
               flexShrink: 0,
             }}
           >
             <ProviderAvatar
               provider={conn.provider}
-              size={16}
+              size={20}
               icon={(conn as any).icon}
             />
           </div>
@@ -447,8 +470,12 @@ function ApListRow({
           >
             <span
               style={{
-                fontSize: 13,
-                fontWeight: 500,
+                // Name is the visual primary now (was a 13/500
+                // tertiary detail).  Multi-AP scan-the-list use
+                // case wants the name to be the column to read
+                // top-to-bottom, not the avatar or the URL row.
+                fontSize: 14,
+                fontWeight: 600,
                 color: T.text1,
                 whiteSpace: 'nowrap',
                 overflow: 'hidden',
@@ -497,8 +524,8 @@ function ApListRow({
           </div>
         </button>
 
-        {/* URL + cmd nested rows.  Indented 34px to align with the
-            AP name (24px avatar + 10px gap), so they read as
+        {/* URL + cmd nested rows.  Indented 42px to align with the
+            AP name (32px avatar + 10px gap), so they read as
             belonging to this AP without needing extra background
             chrome. */}
         {(url || cmd) && (
@@ -508,7 +535,7 @@ function ApListRow({
               flexDirection: 'column',
               gap: 6,
               marginTop: 8,
-              marginLeft: 34,
+              marginLeft: 42,
               marginRight: 0,
             }}
           >
@@ -534,22 +561,6 @@ function ApListRow({
         )}
       </div>
 
-      {/* Divider between adjacent APs.  Lifted from T.sectionDivider
-          (very faint hairline) to T.border (the app's standard 1px
-          rule) — the previous opacity wasn't pulling enough weight
-          for users to read multiple APs as distinct list items.
-          Slightly more vertical breathing room (8px → 10px each side)
-          for the same reason. */}
-      {!isLast && (
-        <div
-          aria-hidden
-          style={{
-            height: 1,
-            background: T.border,
-            margin: '6px 8px',
-          }}
-        />
-      )}
     </React.Fragment>
   );
 }

--- a/frontend/app/(main)/projects/[projectId]/home/components/AccessPointsListCard.tsx
+++ b/frontend/app/(main)/projects/[projectId]/home/components/AccessPointsListCard.tsx
@@ -1,0 +1,504 @@
+'use client';
+
+import { useState } from 'react';
+import type { useRouter } from 'next/navigation';
+import { ArrowRight, ArrowLeft, ArrowLeftRight } from 'lucide-react';
+import { T } from '../lib/tokens';
+import { PROVIDER_LABELS, getApDirection } from '../lib/constants';
+import type { DashboardConnection } from '../lib/types';
+import { ProviderAvatar } from './ProviderAvatar';
+
+// AccessPointsListCard — left-column primary surface that replaces the
+// previous ConnectionsCanvas slot.
+//
+// Why this exists
+//   The right-rail AccessPointsCard treated every AP as a one-line
+//   directory entry: provider chip, name, scope, click-to-manage.  But
+//   on Home the AP block is the user's *operational* surface — the
+//   thing they reach for when they need to paste a `mut connect` URL
+//   into a terminal, drop an MCP endpoint into Claude/Cursor, or grab
+//   an exec URL for a Sandbox.  280px of sidebar can't carry those
+//   strings + the Copy buttons users hit ten times a day.  Promoting
+//   the block to the main column gives each AP enough horizontal
+//   budget for an Endpoint URL row + a one-shot CLI command row +
+//   inline Copy buttons, removing the round-trip to /access for the
+//   common copy/paste actions.
+//
+// Visual contract
+//   ─ Section card matches Data / History card chrome (sectionBg +
+//     2px sectionBorder + sectionRadius + sectionHeaderBg strip) so
+//     it reads as the same family of "framed module" components.
+//   ─ Per-AP row is two visual layers stacked:
+//       1. Identity strip   — provider avatar, name, status dot,
+//                             direction glyph, scope path. Mirrors
+//                             the sidebar card's row layout so the
+//                             same AP reads as the same thing in
+//                             both views.
+//       2. Endpoint block   — monospaced URL (with Copy) + provider-
+//                             specific CLI command (with Copy) for
+//                             provider=filesystem.  Other providers
+//                             just get the endpoint URL; the
+//                             provider-specific config lives on the
+//                             /access detail page.
+//   ─ Empty state matches AccessPointsCard's literal copy ("No
+//     access points configured.") so users moving between page
+//     versions don't see different language for the same state.
+
+function DirectionGlyph({ direction }: { direction: 'inbound' | 'outbound' | 'bidirectional' }) {
+  if (direction === 'outbound') {
+    return <ArrowLeft size={11} strokeWidth={2} style={{ color: T.live, flexShrink: 0 }} />;
+  }
+  if (direction === 'bidirectional') {
+    return <ArrowLeftRight size={11} strokeWidth={2} style={{ color: T.live, flexShrink: 0 }} />;
+  }
+  return <ArrowRight size={11} strokeWidth={2} style={{ color: T.text3, flexShrink: 0 }} />;
+}
+
+// Compose the public-facing endpoint URL for an AP, picking the right
+// path shape per provider.  The host comes from NEXT_PUBLIC_API_URL
+// when set (build-time-baked backend host) and falls back to the
+// current page origin only when no env was provided — same pattern as
+// FilesystemDetailView / SyncDetailView / GetStartedPanel.  Without
+// NEXT_PUBLIC_API_URL on a multi-host deployment (frontend on app.*,
+// backend on api.*) the URL we render would point at the frontend
+// origin and 404 in any tool that tried to use it.
+function buildEndpointUrl(conn: DashboardConnection): string | null {
+  if (!conn.access_key) return null;
+  const apiBase =
+    typeof window !== 'undefined'
+      ? process.env.NEXT_PUBLIC_API_URL || window.location.origin
+      : '';
+
+  switch (conn.provider) {
+    case 'filesystem':
+      return `${apiBase}/api/v1/mut/ap/${conn.access_key}`;
+    case 'mcp':
+    case 'agent':
+      return `${apiBase}/api/v1/mcp/proxy/${conn.access_key}`;
+    case 'sandbox':
+      // Sandbox uses endpoint.id rather than access_key for the
+      // public exec route, but DashboardConnection only carries
+      // access_key.  The /access detail page composes the real
+      // exec URL; here we surface the access_key URL and let the
+      // detail page own the precise sandbox shape.  TODO: extend
+      // dashboard payload with `endpoint_id` if we want a sandbox
+      // exec URL to render directly in this card.
+      return null;
+    default:
+      return null;
+  }
+}
+
+// Shell command users would actually paste, scoped per provider.
+// `null` means we don't render a command row for this provider
+// (today: everything that isn't filesystem) — those providers'
+// invocation shapes (Claude config blob, MCP server entry, sandbox
+// exec body) live in their /access detail panels.
+function buildCliCommand(conn: DashboardConnection, url: string | null): string | null {
+  if (!url || !conn.access_key) return null;
+  if (conn.provider !== 'filesystem') return null;
+  return `mut connect ${url} --credential ${conn.access_key}`;
+}
+
+// Single-line copyable pill: monospaced text with a hover-only Copy
+// button on the right.  Used twice per AP row (URL + command) so the
+// horizontal rhythm stays predictable.
+function CopyableLine({
+  label,
+  value,
+  copyKey,
+  copiedKey,
+  onCopy,
+}: {
+  label: string;
+  value: string;
+  copyKey: string;
+  copiedKey: string | null;
+  onCopy: (text: string, key: string) => void;
+}) {
+  const isCopied = copiedKey === copyKey;
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 8,
+        padding: '6px 10px',
+        background: 'rgba(0,0,0,0.25)',
+        border: `1px solid ${T.cardBorder}`,
+        borderRadius: 4,
+      }}
+    >
+      <span
+        style={{
+          fontSize: 10,
+          fontWeight: 600,
+          color: T.text3,
+          letterSpacing: '0.05em',
+          flexShrink: 0,
+          minWidth: 28,
+          textTransform: 'uppercase',
+        }}
+      >
+        {label}
+      </span>
+      <code
+        style={{
+          flex: 1,
+          fontSize: 11,
+          color: T.text2,
+          fontFamily: T.fontMono,
+          whiteSpace: 'nowrap',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          minWidth: 0,
+        }}
+      >
+        {value}
+      </code>
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          onCopy(value, copyKey);
+        }}
+        style={{
+          flexShrink: 0,
+          padding: '2px 8px',
+          fontSize: 10,
+          fontWeight: 500,
+          color: isCopied ? T.live : T.text3,
+          background: 'rgba(255,255,255,0.04)',
+          border: `1px solid ${T.cardBorder}`,
+          borderRadius: 3,
+          cursor: 'pointer',
+          fontFamily: T.fontSans,
+          transition: `color 160ms ${T.ease}, background 160ms ${T.ease}`,
+        }}
+        onMouseEnter={(e) => {
+          if (isCopied) return;
+          e.currentTarget.style.background = 'rgba(255,255,255,0.08)';
+          e.currentTarget.style.color = T.text1;
+        }}
+        onMouseLeave={(e) => {
+          if (isCopied) return;
+          e.currentTarget.style.background = 'rgba(255,255,255,0.04)';
+          e.currentTarget.style.color = T.text3;
+        }}
+      >
+        {isCopied ? 'Copied' : 'Copy'}
+      </button>
+    </div>
+  );
+}
+
+export function AccessPointsListCard({
+  projectId,
+  router,
+  connections,
+}: {
+  projectId: string;
+  router: ReturnType<typeof useRouter>;
+  connections: DashboardConnection[];
+}) {
+  const total = connections.length;
+  const [copiedKey, setCopiedKey] = useState<string | null>(null);
+
+  const handleCopy = (text: string, key: string) => {
+    void navigator.clipboard.writeText(text);
+    setCopiedKey(key);
+    // 1500ms feedback window — long enough to register the affirmation
+    // ("yes, that copied"), short enough that consecutive Copy clicks
+    // don't feel laggy on the second tap.
+    window.setTimeout(() => setCopiedKey(null), 1500);
+  };
+
+  return (
+    <div
+      style={{
+        background: T.sectionBg,
+        border: `2px solid ${T.sectionBorder}`,
+        borderRadius: T.sectionRadius,
+        overflow: 'hidden',
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
+      {/* Header — matches Data / History card chrome.  Manage > is the
+          only header action; the AP creation / edit flow lives behind
+          the same chevron either way ("Manage" reads as the parent
+          verb that contains both add + edit). */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          padding: '10px 14px',
+          background: T.sectionHeaderBg,
+          borderBottom: `1px solid ${T.sectionDivider}`,
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span style={{ fontSize: 13, fontWeight: 500, color: T.text2 }}>
+            Access Points
+          </span>
+          <span
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              minWidth: 20,
+              height: 18,
+              padding: '0 6px',
+              borderRadius: 9,
+              background: 'rgba(255,255,255,0.08)',
+              fontSize: 11,
+              fontWeight: 600,
+              color: total > 0 ? T.text2 : T.text3,
+              fontVariantNumeric: 'tabular-nums',
+              lineHeight: 1,
+            }}
+          >
+            {total}
+          </span>
+        </div>
+        <button
+          onClick={() => router.push(`/projects/${projectId}/access`)}
+          title="Manage access points"
+          style={{
+            background: 'none',
+            border: 'none',
+            cursor: 'pointer',
+            padding: 0,
+            fontSize: 12,
+            color: T.text2,
+            fontFamily: T.fontSans,
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 4,
+            transition: `color 200ms ${T.ease}`,
+          }}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.color = T.text1;
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.color = T.text2;
+          }}
+        >
+          Manage
+          <svg width="10" height="10" viewBox="0 0 12 12" fill="none">
+            <path
+              d="M4 2l4 4-4 4"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </button>
+      </div>
+
+      {/* Body — list of AP cards or the empty placeholder.  minHeight
+          keeps the card from collapsing when an empty project has
+          zero APs (rare in practice — `mut connect` bootstrap creates
+          one — but the layout floor matters for visual stability
+          when an AP gets revoked). */}
+      <div style={{ padding: '8px 8px', minHeight: 60 }}>
+        {total === 0 ? (
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              padding: '32px 8px',
+              color: T.text3,
+              fontSize: 12,
+            }}
+          >
+            No access points configured.
+          </div>
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            {connections.map((conn) => {
+              const direction = getApDirection(conn);
+              const label =
+                conn.name || PROVIDER_LABELS[conn.provider] || conn.provider;
+              const scope = conn.path || '';
+              const isError = conn.status === 'error';
+              const statusColor = isError
+                ? T.err
+                : conn.status === 'paused'
+                  ? T.warn
+                  : T.live;
+              const url = buildEndpointUrl(conn);
+              const cmd = buildCliCommand(conn, url);
+
+              return (
+                <div
+                  key={conn.id}
+                  style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: 6,
+                    padding: 10,
+                    borderRadius: 6,
+                    background: T.cardBg,
+                    border: `1px solid ${T.cardBorder}`,
+                    transition: `background 160ms ${T.ease}, border-color 160ms ${T.ease}`,
+                  }}
+                  onMouseEnter={(e) => {
+                    e.currentTarget.style.background = T.cardBgH;
+                    e.currentTarget.style.borderColor = T.cardBorderH;
+                  }}
+                  onMouseLeave={(e) => {
+                    e.currentTarget.style.background = T.cardBg;
+                    e.currentTarget.style.borderColor = T.cardBorder;
+                  }}
+                >
+                  {/* Identity strip — same layout rhythm as sidebar
+                      AccessPointsCard so the same AP reads consistently
+                      across the two views.  Whole strip is clickable
+                      to /access?ap=<id> for full management. */}
+                  <button
+                    type="button"
+                    onClick={() =>
+                      router.push(
+                        `/projects/${projectId}/access?ap=${conn.id}`,
+                      )
+                    }
+                    title={`${label}${scope ? ` — /${scope}` : ''} (${conn.status})`}
+                    style={{
+                      background: 'none',
+                      border: 'none',
+                      cursor: 'pointer',
+                      padding: 0,
+                      width: '100%',
+                      textAlign: 'left',
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 10,
+                      color: T.text2,
+                      fontFamily: T.fontSans,
+                    }}
+                  >
+                    <div
+                      style={{
+                        width: 24,
+                        height: 24,
+                        borderRadius: 6,
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        background: 'rgba(255,255,255,0.04)',
+                        flexShrink: 0,
+                      }}
+                    >
+                      <ProviderAvatar
+                        provider={conn.provider}
+                        size={16}
+                        icon={(conn as any).icon}
+                      />
+                    </div>
+
+                    <div
+                      style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 6,
+                        minWidth: 0,
+                        flexShrink: 1,
+                      }}
+                    >
+                      <span
+                        style={{
+                          fontSize: 13,
+                          fontWeight: 500,
+                          color: T.text1,
+                          whiteSpace: 'nowrap',
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                        }}
+                      >
+                        {label}
+                      </span>
+                      <span
+                        aria-hidden
+                        style={{
+                          width: 5,
+                          height: 5,
+                          borderRadius: '50%',
+                          background: statusColor,
+                          boxShadow: isError
+                            ? 'none'
+                            : `0 0 0 2px ${T.liveSoft}`,
+                          flexShrink: 0,
+                        }}
+                      />
+                    </div>
+
+                    <div
+                      style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 4,
+                        marginLeft: 'auto',
+                        minWidth: 0,
+                        flexShrink: 1,
+                      }}
+                    >
+                      <DirectionGlyph direction={direction} />
+                      <span
+                        style={{
+                          fontFamily: T.fontMono,
+                          fontSize: 11,
+                          color: T.text3,
+                          whiteSpace: 'nowrap',
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                          maxWidth: 220,
+                        }}
+                      >
+                        {scope ? `/${scope}` : '/'}
+                      </span>
+                    </div>
+                  </button>
+
+                  {/* Endpoint URL — every AP that has an access_key gets
+                      a copyable URL.  Sandbox provider returns null for
+                      now (its public route uses endpoint.id which the
+                      dashboard doesn't surface yet); we just don't
+                      render the line in that case rather than showing a
+                      partially-broken pill. */}
+                  {url && (
+                    <CopyableLine
+                      label="URL"
+                      value={url}
+                      copyKey={`url-${conn.id}`}
+                      copiedKey={copiedKey}
+                      onCopy={handleCopy}
+                    />
+                  )}
+
+                  {/* CLI command — filesystem only for now.  Other
+                      providers' invocation shapes (MCP server config,
+                      sandbox exec body, agent prompt etc.) are richer
+                      than a single command line and live on the
+                      /access detail page. */}
+                  {cmd && (
+                    <CopyableLine
+                      label="$"
+                      value={cmd}
+                      copyKey={`cmd-${conn.id}`}
+                      copiedKey={copiedKey}
+                      onCopy={handleCopy}
+                    />
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/(main)/projects/[projectId]/home/components/AccessPointsListCard.tsx
+++ b/frontend/app/(main)/projects/[projectId]/home/components/AccessPointsListCard.tsx
@@ -323,7 +323,17 @@ export function AccessPointsListCard({
               const direction = getApDirection(conn);
               const label =
                 conn.name || PROVIDER_LABELS[conn.provider] || conn.provider;
-              const scope = conn.path || '';
+              // Normalize the three "root scope" representations the
+              // backend can produce ('/' for newer rows, null for
+              // legacy, '' for early hand-bootstrapped) into a single
+              // displayed string '/'.  Without this, a root AP would
+              // render as '//' here (the leading '/' we prepend below
+              // + the literal '/' coming out of conn.path) which reads
+              // as a typo.
+              const rawPath = conn.path;
+              const isRoot =
+                rawPath === null || rawPath === '' || rawPath === '/';
+              const displayScope = isRoot ? '/' : `/${rawPath}`;
               const isError = conn.status === 'error';
               const statusColor = isError
                 ? T.err
@@ -366,7 +376,7 @@ export function AccessPointsListCard({
                         `/projects/${projectId}/access?ap=${conn.id}`,
                       )
                     }
-                    title={`${label}${scope ? ` — /${scope}` : ''} (${conn.status})`}
+                    title={`${label} — ${displayScope} (${conn.status})`}
                     style={{
                       background: 'none',
                       border: 'none',
@@ -458,7 +468,7 @@ export function AccessPointsListCard({
                           maxWidth: 220,
                         }}
                       >
-                        {scope ? `/${scope}` : '/'}
+                        {displayScope}
                       </span>
                     </div>
                   </button>

--- a/frontend/app/(main)/projects/[projectId]/home/components/AccessPointsListCard.tsx
+++ b/frontend/app/(main)/projects/[projectId]/home/components/AccessPointsListCard.tsx
@@ -100,9 +100,15 @@ function buildCliCommand(conn: DashboardConnection, url: string | null): string 
   return `mut connect ${url} --credential ${conn.access_key}`;
 }
 
-// Single-line copyable pill: monospaced text with a hover-only Copy
-// button on the right.  Used twice per AP row (URL + command) so the
-// horizontal rhythm stays predictable.
+// Single-line copyable row.  Renders inline (no inset background, no
+// border) so it reads as first-class content of the AP card rather
+// than a nested "sub-card" — the inset treatment we tried earlier
+// produced too much visual nesting (AP card → boxed URL row → boxed
+// cmd row) and made the URL/command feel demoted.  Now the AP card
+// is the only frame; URL and `$` are just labelled rows inside it.
+//
+// Used twice per AP row (URL + command) so the horizontal rhythm
+// stays predictable.
 function CopyableLine({
   label,
   value,
@@ -122,11 +128,8 @@ function CopyableLine({
       style={{
         display: 'flex',
         alignItems: 'center',
-        gap: 8,
-        padding: '6px 10px',
-        background: 'rgba(0,0,0,0.25)',
-        border: `1px solid ${T.cardBorder}`,
-        borderRadius: 4,
+        gap: 12,
+        padding: 0,
       }}
     >
       <span
@@ -136,8 +139,12 @@ function CopyableLine({
           color: T.text3,
           letterSpacing: '0.05em',
           flexShrink: 0,
-          minWidth: 28,
+          // Fixed minWidth so URL and $ rows align column-wise — the
+          // value column starts at the same x in both lines, which
+          // makes "they're parallel things" read at a glance.
+          minWidth: 22,
           textTransform: 'uppercase',
+          fontFamily: T.fontMono,
         }}
       >
         {label}
@@ -145,7 +152,7 @@ function CopyableLine({
       <code
         style={{
           flex: 1,
-          fontSize: 11,
+          fontSize: 12,
           color: T.text2,
           fontFamily: T.fontMono,
           whiteSpace: 'nowrap',
@@ -164,7 +171,7 @@ function CopyableLine({
         }}
         style={{
           flexShrink: 0,
-          padding: '2px 8px',
+          padding: '2px 10px',
           fontSize: 10,
           fontWeight: 500,
           color: isCopied ? T.live : T.text3,
@@ -318,7 +325,7 @@ export function AccessPointsListCard({
             No access points configured.
           </div>
         ) : (
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
             {connections.map((conn) => {
               const direction = getApDirection(conn);
               const label =
@@ -349,11 +356,27 @@ export function AccessPointsListCard({
                   style={{
                     display: 'flex',
                     flexDirection: 'column',
-                    gap: 6,
-                    padding: 10,
+                    gap: 10,
+                    // Asymmetric padding leaves room for the cyan
+                    // stripe on the left without crowding the
+                    // identity strip's content.
+                    padding: '12px 14px 12px 16px',
                     borderRadius: 6,
                     background: T.cardBg,
                     border: `1px solid ${T.cardBorder}`,
+                    // Cyan stripe on the left edge — same hue as the
+                    // ApChip dot rendered next to AP-attached rows in
+                    // the Data card above.  The shared accent
+                    // is the visual handshake between the two views:
+                    // "this AP card and that tree-row chip are the
+                    // same thing."  A 3px stripe is wide enough to
+                    // register at scanning distance, narrow enough
+                    // to read as a left-edge accent rather than a
+                    // separate column.  Pinned to the cell-edge
+                    // background via box-shadow inset rather than
+                    // border-left so the rounded corners on
+                    // borderRadius stay clean.
+                    boxShadow: `inset 3px 0 0 0 ${T.live}`,
                     transition: `background 160ms ${T.ease}, border-color 160ms ${T.ease}`,
                   }}
                   onMouseEnter={(e) => {

--- a/frontend/app/(main)/projects/[projectId]/home/components/AccessPointsListCard.tsx
+++ b/frontend/app/(main)/projects/[projectId]/home/components/AccessPointsListCard.tsx
@@ -137,7 +137,11 @@ function CopyableLine({
           color: T.text3,
           letterSpacing: '0.05em',
           flexShrink: 0,
-          minWidth: 22,
+          // Wide enough to hold the longest label we ship today
+          // (`SETUP`).  All shorter labels (URL, $, etc.) align
+          // to the same right edge, which keeps the value column
+          // starting at the same x across rows.
+          minWidth: 40,
           textTransform: 'uppercase',
           fontFamily: T.fontMono,
         }}
@@ -410,21 +414,19 @@ function ApListRow({
           transition: `background 160ms ${T.ease}`,
         }}
       >
-        {/* Identity row — sidebar AccessPointsCard layout verbatim
-            so the same AP reads consistently across surfaces. */}
-        <button
-          type="button"
-          onClick={() =>
-            router.push(`/projects/${projectId}/access?ap=${conn.id}`)
-          }
+        {/* Identity row — used to be a clickable button that
+            navigated to /access?ap=<id>, but that meant any
+            mis-click on the avatar / name / scope path while
+            hovering Copy buttons below would yank the user off
+            the page mid-copy.  Now a plain div: nothing on the
+            row navigates by accident.  The explicit "Open" link
+            on the right is the single, deliberate management
+            entry point. */}
+        <div
           title={`${label} — ${displayScope} (${conn.status})`}
           style={{
-            background: 'none',
-            border: 'none',
-            cursor: 'pointer',
             padding: '4px 0',
             width: '100%',
-            textAlign: 'left',
             display: 'flex',
             alignItems: 'center',
             gap: 10,
@@ -522,21 +524,73 @@ function ApListRow({
               {displayScope}
             </span>
           </div>
-        </button>
 
-        {/* URL + cmd nested rows.  Indented 42px to align with the
-            AP name (32px avatar + 10px gap), so they read as
-            belonging to this AP without needing extra background
-            chrome. */}
+          {/* Explicit "Open" link — the only deliberate entry to
+              /access?ap=<id> from this card.  Visually quiet
+              (text2 → text1 on hover) so it doesn't compete with
+              the AP name; semantically loud because it's the only
+              navigable element on the identity row. */}
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              router.push(`/projects/${projectId}/access?ap=${conn.id}`);
+            }}
+            title="Open access point details"
+            style={{
+              flexShrink: 0,
+              marginLeft: 8,
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              padding: '2px 6px',
+              fontSize: 12,
+              color: T.text3,
+              fontFamily: T.fontSans,
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 4,
+              borderRadius: 4,
+              transition: `color 160ms ${T.ease}, background 160ms ${T.ease}`,
+            }}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.color = T.text1;
+              e.currentTarget.style.background = 'rgba(255,255,255,0.06)';
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.color = T.text3;
+              e.currentTarget.style.background = 'transparent';
+            }}
+          >
+            Open
+            <svg width="10" height="10" viewBox="0 0 12 12" fill="none">
+              <path
+                d="M4 2l4 4-4 4"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </button>
+        </div>
+
+        {/* Endpoint detail rows.  Drawn flush-left with the AP
+            row's own padding (no 42px indent) so they read as
+            primary content of this card, not a hanging detail
+            block.  A 1px hairline along the top separates them
+            from the identity row above — the divider is the
+            structural cue ("identity vs endpoint info") that the
+            old indent was trying and failing to communicate. */}
         {(url || cmd) && (
           <div
             style={{
               display: 'flex',
               flexDirection: 'column',
               gap: 6,
-              marginTop: 8,
-              marginLeft: 42,
-              marginRight: 0,
+              marginTop: 10,
+              paddingTop: 10,
+              borderTop: `1px solid ${T.cardBorder}`,
             }}
           >
             {url && (
@@ -548,9 +602,20 @@ function ApListRow({
                 onCopy={onCopy}
               />
             )}
+            {/* `mut connect` is the *one-time setup* command, not a
+                command the user runs daily.  Once the local folder
+                is connected, day-to-day work happens via local
+                `mut push` / `mut pull` and the user never needs to
+                touch the URL again.  The `SETUP` label makes that
+                lifecycle explicit so users who already connected
+                don't try to re-paste this every time they revisit
+                the page.  When the dashboard later surfaces use-
+                case-specific commands (Claude / Cursor / Cline
+                config snippets), this row's label can become a
+                segmented control between them. */}
             {cmd && (
               <CopyableLine
-                label="$"
+                label="SETUP"
                 value={cmd}
                 copyKey={`cmd-${conn.id}`}
                 copiedKey={copiedKey}

--- a/frontend/app/(main)/projects/[projectId]/home/components/AccessPointsListCard.tsx
+++ b/frontend/app/(main)/projects/[projectId]/home/components/AccessPointsListCard.tsx
@@ -25,38 +25,25 @@ function normalizeApPath(raw: string | null | undefined): string {
 // AccessPointsListCard — left-column primary surface that replaces the
 // previous ConnectionsCanvas slot.
 //
-// Why this exists
-//   The right-rail AccessPointsCard treated every AP as a one-line
-//   directory entry: provider chip, name, scope, click-to-manage.  But
-//   on Home the AP block is the user's *operational* surface — the
-//   thing they reach for when they need to paste a `mut connect` URL
-//   into a terminal, drop an MCP endpoint into Claude/Cursor, or grab
-//   an exec URL for a Sandbox.  280px of sidebar can't carry those
-//   strings + the Copy buttons users hit ten times a day.  Promoting
-//   the block to the main column gives each AP enough horizontal
-//   budget for an Endpoint URL row + a one-shot CLI command row +
-//   inline Copy buttons, removing the round-trip to /access for the
-//   common copy/paste actions.
+// Layout: section card with the same chrome as Data / History.  Body
+// is a flat list (sidebar AccessPointsCard rhythm verbatim: avatar +
+// name + status dot + direction + scope path) with URL / `$` rows
+// nested below each, indented to align with the AP name.  Adjacent
+// APs are separated by a 1px hairline divider so multi-AP lists
+// don't visually fuse.
 //
-// Visual contract
-//   ─ Section card matches Data / History card chrome (sectionBg +
-//     2px sectionBorder + sectionRadius + sectionHeaderBg strip) so
-//     it reads as the same family of "framed module" components.
-//   ─ Per-AP row is two visual layers stacked:
-//       1. Identity strip   — provider avatar, name, status dot,
-//                             direction glyph, scope path. Mirrors
-//                             the sidebar card's row layout so the
-//                             same AP reads as the same thing in
-//                             both views.
-//       2. Endpoint block   — monospaced URL (with Copy) + provider-
-//                             specific CLI command (with Copy) for
-//                             provider=filesystem.  Other providers
-//                             just get the endpoint URL; the
-//                             provider-specific config lives on the
-//                             /access detail page.
-//   ─ Empty state matches AccessPointsCard's literal copy ("No
-//     access points configured.") so users moving between page
-//     versions don't see different language for the same state.
+// Hover-sync: each AP row + the matching ApChip in the Data tree
+// share a single `hoveredPath` source of truth lifted to page.tsx.
+// Mousing over either side flips on a highlight on the other:
+//   ─ Self-hover (cursor on the AP row) → neutral grey wash
+//     (T.rowHover), the same affordance every clickable row in the
+//     app uses.  Cyan would over-promise here; the user is actively
+//     interacting with the row, not observing a relationship.
+//   ─ Synced highlight (chip in the tree above is hovered) → cyan
+//     wash (T.rowHighlight), matching the chip pill's accent.  This
+//     is the "we're the same thing" state — colour locked to the
+//     chip side of the handshake.
+//   ─ Both at once: self-hover wins; we don't double-paint.
 
 function DirectionGlyph({ direction }: { direction: 'inbound' | 'outbound' | 'bidirectional' }) {
   if (direction === 'outbound') {
@@ -72,10 +59,7 @@ function DirectionGlyph({ direction }: { direction: 'inbound' | 'outbound' | 'bi
 // path shape per provider.  The host comes from NEXT_PUBLIC_API_URL
 // when set (build-time-baked backend host) and falls back to the
 // current page origin only when no env was provided — same pattern as
-// FilesystemDetailView / SyncDetailView / GetStartedPanel.  Without
-// NEXT_PUBLIC_API_URL on a multi-host deployment (frontend on app.*,
-// backend on api.*) the URL we render would point at the frontend
-// origin and 404 in any tool that tried to use it.
+// FilesystemDetailView / SyncDetailView / GetStartedPanel.
 function buildEndpointUrl(conn: DashboardConnection): string | null {
   if (!conn.access_key) return null;
   const apiBase =
@@ -93,10 +77,7 @@ function buildEndpointUrl(conn: DashboardConnection): string | null {
       // Sandbox uses endpoint.id rather than access_key for the
       // public exec route, but DashboardConnection only carries
       // access_key.  The /access detail page composes the real
-      // exec URL; here we surface the access_key URL and let the
-      // detail page own the precise sandbox shape.  TODO: extend
-      // dashboard payload with `endpoint_id` if we want a sandbox
-      // exec URL to render directly in this card.
+      // exec URL; here we surface no URL rather than a broken one.
       return null;
     default:
       return null;
@@ -104,10 +85,10 @@ function buildEndpointUrl(conn: DashboardConnection): string | null {
 }
 
 // Shell command users would actually paste, scoped per provider.
-// `null` means we don't render a command row for this provider
-// (today: everything that isn't filesystem) — those providers'
-// invocation shapes (Claude config blob, MCP server entry, sandbox
-// exec body) live in their /access detail panels.
+// `null` means we don't render a command row for this provider —
+// today everything that isn't filesystem; their richer invocation
+// shapes (MCP server config blob, sandbox exec body, etc.) live on
+// the /access detail page.
 function buildCliCommand(conn: DashboardConnection, url: string | null): string | null {
   if (!url || !conn.access_key) return null;
   if (conn.provider !== 'filesystem') return null;
@@ -115,14 +96,8 @@ function buildCliCommand(conn: DashboardConnection, url: string | null): string 
 }
 
 // Single-line copyable row.  Renders inline (no inset background, no
-// border) so it reads as first-class content of the AP card rather
-// than a nested "sub-card" — the inset treatment we tried earlier
-// produced too much visual nesting (AP card → boxed URL row → boxed
-// cmd row) and made the URL/command feel demoted.  Now the AP card
-// is the only frame; URL and `$` are just labelled rows inside it.
-//
-// Used twice per AP row (URL + command) so the horizontal rhythm
-// stays predictable.
+// border) so it reads as first-class content of the AP body rather
+// than a nested "sub-card".  Label + value + Copy in a row.
 function CopyableLine({
   label,
   value,
@@ -153,9 +128,6 @@ function CopyableLine({
           color: T.text3,
           letterSpacing: '0.05em',
           flexShrink: 0,
-          // Fixed minWidth so URL and $ rows align column-wise — the
-          // value column starts at the same x in both lines, which
-          // makes "they're parallel things" read at a glance.
           minWidth: 22,
           textTransform: 'uppercase',
           fontFamily: T.fontMono,
@@ -223,18 +195,7 @@ export function AccessPointsListCard({
   projectId: string;
   router: ReturnType<typeof useRouter>;
   connections: DashboardConnection[];
-  // Path of the currently-hovered chip / AP row, normalized via
-  // `normalizeApPath`.  When this matches an AP's normalized path,
-  // that AP renders in its highlighted state.  `null` means nothing
-  // is hovered.  Lifted to page.tsx so a hover on a Data-card
-  // ApChip and a hover on this card's AP row share the same source
-  // of truth.
   hoveredPath: string | null;
-  // Set when this card's row is hovered, cleared when the cursor
-  // leaves.  The Data card uses the same callback (via the chip's
-  // own onHover) so the hover state is reflexive — hovering the
-  // AP card highlights the matching tree row, hovering the tree
-  // row highlights the matching AP card.
   onHoverPath: (path: string | null) => void;
 }) {
   const total = connections.length;
@@ -243,9 +204,6 @@ export function AccessPointsListCard({
   const handleCopy = (text: string, key: string) => {
     void navigator.clipboard.writeText(text);
     setCopiedKey(key);
-    // 1500ms feedback window — long enough to register the affirmation
-    // ("yes, that copied"), short enough that consecutive Copy clicks
-    // don't feel laggy on the second tap.
     window.setTimeout(() => setCopiedKey(null), 1500);
   };
 
@@ -260,10 +218,6 @@ export function AccessPointsListCard({
         flexDirection: 'column',
       }}
     >
-      {/* Header — matches Data / History card chrome.  Manage > is the
-          only header action; the AP creation / edit flow lives behind
-          the same chevron either way ("Manage" reads as the parent
-          verb that contains both add + edit). */}
       <div
         style={{
           display: 'flex',
@@ -334,12 +288,7 @@ export function AccessPointsListCard({
         </button>
       </div>
 
-      {/* Body — flat list of AP rows (sidebar AccessPointsCard
-          rhythm: avatar + name + status dot + direction + scope path
-          on a single line) with URL / `$` rows nested beneath each.
-          minHeight stays so revoke→empty doesn't collapse the card
-          shell. */}
-      <div style={{ padding: '4px 6px', minHeight: 60 }}>
+      <div style={{ padding: '6px 8px', minHeight: 60 }}>
         {total === 0 ? (
           <div
             style={{
@@ -354,225 +303,253 @@ export function AccessPointsListCard({
             No access points configured.
           </div>
         ) : (
-          connections.map((conn, idx) => {
-            const direction = getApDirection(conn);
-            const label =
-              conn.name || PROVIDER_LABELS[conn.provider] || conn.provider;
-            // displayScope: '/' for any of the three root-scope
-            // forms the backend may produce, '/<path>' otherwise.
-            // Without this, root APs render as '//' (template '/'
-            // prepended to a path value that's already '/').
-            const rawPath = conn.path;
-            const isRoot =
-              rawPath === null || rawPath === '' || rawPath === '/';
-            const displayScope = isRoot ? '/' : `/${rawPath}`;
-            const isError = conn.status === 'error';
-            const statusColor = isError
-              ? T.err
-              : conn.status === 'paused'
-                ? T.warn
-                : T.live;
-            const url = buildEndpointUrl(conn);
-            const cmd = buildCliCommand(conn, url);
-
-            // Normalized path drives hover-sync between Data ApChip
-            // and this card.  When the user mouses over a chip in the
-            // tree, page.tsx sets hoveredPath to the chip's row path
-            // (already normalized via `accessByPath`'s key); when
-            // they mouse over an AP row here, we set hoveredPath to
-            // this AP's normalized path.  The matching side
-            // highlights — chip ↔ row — making "this card and that
-            // chip are the same thing" obvious without the user
-            // having to mentally connect colour cues.
-            const apPath = normalizeApPath(rawPath);
-            const isHovered = hoveredPath !== null && hoveredPath === apPath;
-
-            return (
-              <React.Fragment key={conn.id}>
-                {/* Per-AP block: identity row + URL + cmd, drawn flat
-                    (no individual card frame) — the section card is
-                    the only frame, the rows below sit inside its
-                    body like a directory listing.  Highlight on
-                    hover-sync is a soft cyan tint flush across the
-                    whole block (identity row + sub-rows) so the
-                    user sees the entire AP, not just one row. */}
-                <div
-                  onMouseEnter={() => onHoverPath(apPath)}
-                  onMouseLeave={() => onHoverPath(null)}
-                  style={{
-                    display: 'flex',
-                    flexDirection: 'column',
-                    padding: '6px 8px',
-                    borderRadius: 4,
-                    background: isHovered ? T.rowHighlight : 'transparent',
-                    transition: `background 160ms ${T.ease}`,
-                  }}
-                >
-                  {/* Identity row — sidebar AccessPointsCard layout
-                      verbatim so the same AP reads consistently
-                      across surfaces. */}
-                  <button
-                    type="button"
-                    onClick={() =>
-                      router.push(
-                        `/projects/${projectId}/access?ap=${conn.id}`,
-                      )
-                    }
-                    title={`${label} — ${displayScope} (${conn.status})`}
-                    style={{
-                      background: 'none',
-                      border: 'none',
-                      cursor: 'pointer',
-                      padding: '4px 0',
-                      width: '100%',
-                      textAlign: 'left',
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: 10,
-                      color: T.text2,
-                      fontFamily: T.fontSans,
-                    }}
-                  >
-                    <div
-                      style={{
-                        width: 24,
-                        height: 24,
-                        borderRadius: 6,
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        background: 'rgba(255,255,255,0.04)',
-                        flexShrink: 0,
-                      }}
-                    >
-                      <ProviderAvatar
-                        provider={conn.provider}
-                        size={16}
-                        icon={(conn as any).icon}
-                      />
-                    </div>
-
-                    <div
-                      style={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: 6,
-                        minWidth: 0,
-                        flexShrink: 1,
-                      }}
-                    >
-                      <span
-                        style={{
-                          fontSize: 13,
-                          fontWeight: 500,
-                          color: T.text1,
-                          whiteSpace: 'nowrap',
-                          overflow: 'hidden',
-                          textOverflow: 'ellipsis',
-                        }}
-                      >
-                        {label}
-                      </span>
-                      <span
-                        aria-hidden
-                        style={{
-                          width: 5,
-                          height: 5,
-                          borderRadius: '50%',
-                          background: statusColor,
-                          boxShadow: isError
-                            ? 'none'
-                            : `0 0 0 2px ${T.liveSoft}`,
-                          flexShrink: 0,
-                        }}
-                      />
-                    </div>
-
-                    <div
-                      style={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: 4,
-                        marginLeft: 'auto',
-                        minWidth: 0,
-                        flexShrink: 1,
-                      }}
-                    >
-                      <DirectionGlyph direction={direction} />
-                      <span
-                        style={{
-                          fontFamily: T.fontMono,
-                          fontSize: 11,
-                          color: T.text3,
-                          whiteSpace: 'nowrap',
-                          overflow: 'hidden',
-                          textOverflow: 'ellipsis',
-                          maxWidth: 220,
-                        }}
-                      >
-                        {displayScope}
-                      </span>
-                    </div>
-                  </button>
-
-                  {/* URL + cmd nested rows.  Indented to align with
-                      the AP name (24px avatar + 10px gap = 34px) so
-                      they read as belonging to this AP without
-                      needing extra background chrome. */}
-                  {(url || cmd) && (
-                    <div
-                      style={{
-                        display: 'flex',
-                        flexDirection: 'column',
-                        gap: 6,
-                        marginTop: 6,
-                        marginLeft: 34,
-                        marginRight: 0,
-                      }}
-                    >
-                      {url && (
-                        <CopyableLine
-                          label="URL"
-                          value={url}
-                          copyKey={`url-${conn.id}`}
-                          copiedKey={copiedKey}
-                          onCopy={handleCopy}
-                        />
-                      )}
-                      {cmd && (
-                        <CopyableLine
-                          label="$"
-                          value={cmd}
-                          copyKey={`cmd-${conn.id}`}
-                          copiedKey={copiedKey}
-                          onCopy={handleCopy}
-                        />
-                      )}
-                    </div>
-                  )}
-                </div>
-
-                {/* Hairline divider between APs — only when there's
-                    a next AP after this one.  T.sectionDivider keeps
-                    it in the same family as other 1px rules on the
-                    page, so the dividers in the AP list read as part
-                    of the section card's structure rather than as
-                    decorative. */}
-                {idx < connections.length - 1 && (
-                  <div
-                    aria-hidden
-                    style={{
-                      height: 1,
-                      background: T.sectionDivider,
-                      margin: '4px 0',
-                    }}
-                  />
-                )}
-              </React.Fragment>
-            );
-          })
+          connections.map((conn, idx) => (
+            <ApListRow
+              key={conn.id}
+              conn={conn}
+              isLast={idx === connections.length - 1}
+              projectId={projectId}
+              router={router}
+              hoveredPath={hoveredPath}
+              onHoverPath={onHoverPath}
+              copiedKey={copiedKey}
+              onCopy={handleCopy}
+            />
+          ))
         )}
       </div>
     </div>
+  );
+}
+
+// Single AP row — hoisted out of the .map so we can keep an
+// `isMouseOver` local state that distinguishes "the user actually
+// has the cursor on this row" from "this row got highlighted because
+// the matching chip in the tree above is hovered".  The two states
+// look different by design (see component-level comment).
+function ApListRow({
+  conn,
+  isLast,
+  projectId,
+  router,
+  hoveredPath,
+  onHoverPath,
+  copiedKey,
+  onCopy,
+}: {
+  conn: DashboardConnection;
+  isLast: boolean;
+  projectId: string;
+  router: ReturnType<typeof useRouter>;
+  hoveredPath: string | null;
+  onHoverPath: (path: string | null) => void;
+  copiedKey: string | null;
+  onCopy: (text: string, key: string) => void;
+}) {
+  const [isMouseOver, setIsMouseOver] = useState(false);
+
+  const direction = getApDirection(conn);
+  const label = conn.name || PROVIDER_LABELS[conn.provider] || conn.provider;
+  const rawPath = conn.path;
+  const isRoot = rawPath === null || rawPath === '' || rawPath === '/';
+  const displayScope = isRoot ? '/' : `/${rawPath}`;
+  const isError = conn.status === 'error';
+  const statusColor = isError
+    ? T.err
+    : conn.status === 'paused'
+      ? T.warn
+      : T.live;
+  const url = buildEndpointUrl(conn);
+  const cmd = buildCliCommand(conn, url);
+
+  const apPath = normalizeApPath(rawPath);
+  const isSyncHighlighted =
+    !isMouseOver && hoveredPath !== null && hoveredPath === apPath;
+
+  // Background priority: self-hover (grey, "you can click me") wins
+  // over sync (cyan, "we're the same thing as the hovered chip"),
+  // wins over rest (transparent).
+  const background = isMouseOver
+    ? T.rowHover
+    : isSyncHighlighted
+      ? T.rowHighlight
+      : 'transparent';
+
+  return (
+    <React.Fragment>
+      <div
+        onMouseEnter={() => {
+          setIsMouseOver(true);
+          onHoverPath(apPath);
+        }}
+        onMouseLeave={() => {
+          setIsMouseOver(false);
+          onHoverPath(null);
+        }}
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          padding: '10px 10px',
+          borderRadius: 6,
+          background,
+          transition: `background 160ms ${T.ease}`,
+        }}
+      >
+        {/* Identity row — sidebar AccessPointsCard layout verbatim
+            so the same AP reads consistently across surfaces. */}
+        <button
+          type="button"
+          onClick={() =>
+            router.push(`/projects/${projectId}/access?ap=${conn.id}`)
+          }
+          title={`${label} — ${displayScope} (${conn.status})`}
+          style={{
+            background: 'none',
+            border: 'none',
+            cursor: 'pointer',
+            padding: '4px 0',
+            width: '100%',
+            textAlign: 'left',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 10,
+            color: T.text2,
+            fontFamily: T.fontSans,
+          }}
+        >
+          <div
+            style={{
+              width: 24,
+              height: 24,
+              borderRadius: 6,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              background: 'rgba(255,255,255,0.04)',
+              flexShrink: 0,
+            }}
+          >
+            <ProviderAvatar
+              provider={conn.provider}
+              size={16}
+              icon={(conn as any).icon}
+            />
+          </div>
+
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 6,
+              minWidth: 0,
+              flexShrink: 1,
+            }}
+          >
+            <span
+              style={{
+                fontSize: 13,
+                fontWeight: 500,
+                color: T.text1,
+                whiteSpace: 'nowrap',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+              }}
+            >
+              {label}
+            </span>
+            <span
+              aria-hidden
+              style={{
+                width: 5,
+                height: 5,
+                borderRadius: '50%',
+                background: statusColor,
+                boxShadow: isError ? 'none' : `0 0 0 2px ${T.liveSoft}`,
+                flexShrink: 0,
+              }}
+            />
+          </div>
+
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 4,
+              marginLeft: 'auto',
+              minWidth: 0,
+              flexShrink: 1,
+            }}
+          >
+            <DirectionGlyph direction={direction} />
+            <span
+              style={{
+                fontFamily: T.fontMono,
+                fontSize: 11,
+                color: T.text3,
+                whiteSpace: 'nowrap',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                maxWidth: 220,
+              }}
+            >
+              {displayScope}
+            </span>
+          </div>
+        </button>
+
+        {/* URL + cmd nested rows.  Indented 34px to align with the
+            AP name (24px avatar + 10px gap), so they read as
+            belonging to this AP without needing extra background
+            chrome. */}
+        {(url || cmd) && (
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 6,
+              marginTop: 8,
+              marginLeft: 34,
+              marginRight: 0,
+            }}
+          >
+            {url && (
+              <CopyableLine
+                label="URL"
+                value={url}
+                copyKey={`url-${conn.id}`}
+                copiedKey={copiedKey}
+                onCopy={onCopy}
+              />
+            )}
+            {cmd && (
+              <CopyableLine
+                label="$"
+                value={cmd}
+                copyKey={`cmd-${conn.id}`}
+                copiedKey={copiedKey}
+                onCopy={onCopy}
+              />
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Divider between adjacent APs.  Lifted from T.sectionDivider
+          (very faint hairline) to T.border (the app's standard 1px
+          rule) — the previous opacity wasn't pulling enough weight
+          for users to read multiple APs as distinct list items.
+          Slightly more vertical breathing room (8px → 10px each side)
+          for the same reason. */}
+      {!isLast && (
+        <div
+          aria-hidden
+          style={{
+            height: 1,
+            background: T.border,
+            margin: '6px 8px',
+          }}
+        />
+      )}
+    </React.Fragment>
   );
 }

--- a/frontend/app/(main)/projects/[projectId]/home/components/AccessPointsListCard.tsx
+++ b/frontend/app/(main)/projects/[projectId]/home/components/AccessPointsListCard.tsx
@@ -104,23 +104,19 @@ function buildCliCommand(conn: DashboardConnection, url: string | null): string 
   return `mut connect ${url} --credential ${conn.access_key}`;
 }
 
-// Vertical copyable block.  At the new 280px sidebar width a single-
-// row layout (label + value + Copy on one line) couldn't carry the
-// monospaced URL — it got truncated to "http://localho..." with no
-// useful information visible.  Two-row layout instead:
+// Single-line "label + Copy" row.  Earlier versions also rendered
+// the monospaced value below — but at 280px column width, a 50-char
+// access_key wraps to 3-4 lines and the AP card balloons vertically
+// without delivering any useful read.  The user pastes the value
+// into a terminal / config editor; they don't need to *see* it
+// inline.  The label ("URL" / "SETUP") already tells them what
+// they're copying, and the full string is on the /access detail
+// page if they ever want to inspect it.
 //
-//   ┌────────────────────────┐
-//   │ URL              [Copy]│   ← header strip: label + Copy
-//   │ http://localhost:9090/ │   ← value: monospaced, wrapped
-//   │   api/v1/mut/ap/cli_…  │     with break-all so even a long
-//   └────────────────────────┘     access_key never truncates
-//                                  invisibly
-//
-// `whiteSpace: pre-wrap` + `wordBreak: break-all` is the pair we use
-// elsewhere for "must-be-paste-runnable strings in a narrow column"
-// (see /access page's CopyField).  break-all lets us wrap *anywhere*
-// in a hash-like token; without it, the browser refuses to break a
-// 50-char access_key and the row pushes the column wider than 280px.
+// Net effect: an AP card with URL + SETUP rows is now ~80px tall
+// instead of ~280px, which is what 4 separate APs would have looked
+// like stacked.  Multi-AP scrolls reasonably; single-AP doesn't
+// dwarf the History card below it.
 function CopyableLine({
   label,
   value,
@@ -139,79 +135,55 @@ function CopyableLine({
     <div
       style={{
         display: 'flex',
-        flexDirection: 'column',
-        gap: 4,
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: 8,
       }}
     >
-      <div
+      <span
         style={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-          gap: 8,
-        }}
-      >
-        <span
-          style={{
-            fontSize: 10,
-            fontWeight: 600,
-            color: T.text3,
-            letterSpacing: '0.05em',
-            textTransform: 'uppercase',
-            fontFamily: T.fontMono,
-          }}
-        >
-          {label}
-        </span>
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation();
-            onCopy(value, copyKey);
-          }}
-          style={{
-            flexShrink: 0,
-            padding: '2px 10px',
-            fontSize: 10,
-            fontWeight: 500,
-            color: isCopied ? T.live : T.text3,
-            background: 'rgba(255,255,255,0.04)',
-            border: `1px solid ${T.cardBorder}`,
-            borderRadius: 3,
-            cursor: 'pointer',
-            fontFamily: T.fontSans,
-            transition: `color 160ms ${T.ease}, background 160ms ${T.ease}`,
-          }}
-          onMouseEnter={(e) => {
-            if (isCopied) return;
-            e.currentTarget.style.background = 'rgba(255,255,255,0.08)';
-            e.currentTarget.style.color = T.text1;
-          }}
-          onMouseLeave={(e) => {
-            if (isCopied) return;
-            e.currentTarget.style.background = 'rgba(255,255,255,0.04)';
-            e.currentTarget.style.color = T.text3;
-          }}
-        >
-          {isCopied ? 'Copied' : 'Copy'}
-        </button>
-      </div>
-      <code
-        style={{
-          fontSize: 11,
-          color: T.text2,
+          fontSize: 10,
+          fontWeight: 600,
+          color: T.text3,
+          letterSpacing: '0.05em',
+          textTransform: 'uppercase',
           fontFamily: T.fontMono,
-          whiteSpace: 'pre-wrap',
-          wordBreak: 'break-all',
-          lineHeight: 1.5,
-          padding: '4px 6px',
-          background: 'rgba(0,0,0,0.25)',
-          borderRadius: 3,
-          border: `1px solid ${T.cardBorder}`,
         }}
       >
-        {value}
-      </code>
+        {label}
+      </span>
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          onCopy(value, copyKey);
+        }}
+        style={{
+          flexShrink: 0,
+          padding: '2px 10px',
+          fontSize: 10,
+          fontWeight: 500,
+          color: isCopied ? T.live : T.text3,
+          background: 'rgba(255,255,255,0.04)',
+          border: `1px solid ${T.cardBorder}`,
+          borderRadius: 3,
+          cursor: 'pointer',
+          fontFamily: T.fontSans,
+          transition: `color 160ms ${T.ease}, background 160ms ${T.ease}`,
+        }}
+        onMouseEnter={(e) => {
+          if (isCopied) return;
+          e.currentTarget.style.background = 'rgba(255,255,255,0.08)';
+          e.currentTarget.style.color = T.text1;
+        }}
+        onMouseLeave={(e) => {
+          if (isCopied) return;
+          e.currentTarget.style.background = 'rgba(255,255,255,0.04)';
+          e.currentTarget.style.color = T.text3;
+        }}
+      >
+        {isCopied ? 'Copied' : 'Copy'}
+      </button>
     </div>
   );
 }

--- a/frontend/app/(main)/projects/[projectId]/home/components/AccessPointsListCard.tsx
+++ b/frontend/app/(main)/projects/[projectId]/home/components/AccessPointsListCard.tsx
@@ -104,9 +104,23 @@ function buildCliCommand(conn: DashboardConnection, url: string | null): string 
   return `mut connect ${url} --credential ${conn.access_key}`;
 }
 
-// Single-line copyable row.  Renders inline (no inset background, no
-// border) so it reads as first-class content of the AP body rather
-// than a nested "sub-card".  Label + value + Copy in a row.
+// Vertical copyable block.  At the new 280px sidebar width a single-
+// row layout (label + value + Copy on one line) couldn't carry the
+// monospaced URL — it got truncated to "http://localho..." with no
+// useful information visible.  Two-row layout instead:
+//
+//   ┌────────────────────────┐
+//   │ URL              [Copy]│   ← header strip: label + Copy
+//   │ http://localhost:9090/ │   ← value: monospaced, wrapped
+//   │   api/v1/mut/ap/cli_…  │     with break-all so even a long
+//   └────────────────────────┘     access_key never truncates
+//                                  invisibly
+//
+// `whiteSpace: pre-wrap` + `wordBreak: break-all` is the pair we use
+// elsewhere for "must-be-paste-runnable strings in a narrow column"
+// (see /access page's CopyField).  break-all lets us wrap *anywhere*
+// in a hash-like token; without it, the browser refuses to break a
+// 50-char access_key and the row pushes the column wider than 280px.
 function CopyableLine({
   label,
   value,
@@ -125,75 +139,79 @@ function CopyableLine({
     <div
       style={{
         display: 'flex',
-        alignItems: 'center',
-        gap: 12,
-        padding: 0,
+        flexDirection: 'column',
+        gap: 4,
       }}
     >
-      <span
+      <div
         style={{
-          fontSize: 10,
-          fontWeight: 600,
-          color: T.text3,
-          letterSpacing: '0.05em',
-          flexShrink: 0,
-          // Wide enough to hold the longest label we ship today
-          // (`SETUP`).  All shorter labels (URL, $, etc.) align
-          // to the same right edge, which keeps the value column
-          // starting at the same x across rows.
-          minWidth: 40,
-          textTransform: 'uppercase',
-          fontFamily: T.fontMono,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: 8,
         }}
       >
-        {label}
-      </span>
+        <span
+          style={{
+            fontSize: 10,
+            fontWeight: 600,
+            color: T.text3,
+            letterSpacing: '0.05em',
+            textTransform: 'uppercase',
+            fontFamily: T.fontMono,
+          }}
+        >
+          {label}
+        </span>
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onCopy(value, copyKey);
+          }}
+          style={{
+            flexShrink: 0,
+            padding: '2px 10px',
+            fontSize: 10,
+            fontWeight: 500,
+            color: isCopied ? T.live : T.text3,
+            background: 'rgba(255,255,255,0.04)',
+            border: `1px solid ${T.cardBorder}`,
+            borderRadius: 3,
+            cursor: 'pointer',
+            fontFamily: T.fontSans,
+            transition: `color 160ms ${T.ease}, background 160ms ${T.ease}`,
+          }}
+          onMouseEnter={(e) => {
+            if (isCopied) return;
+            e.currentTarget.style.background = 'rgba(255,255,255,0.08)';
+            e.currentTarget.style.color = T.text1;
+          }}
+          onMouseLeave={(e) => {
+            if (isCopied) return;
+            e.currentTarget.style.background = 'rgba(255,255,255,0.04)';
+            e.currentTarget.style.color = T.text3;
+          }}
+        >
+          {isCopied ? 'Copied' : 'Copy'}
+        </button>
+      </div>
       <code
         style={{
-          flex: 1,
-          fontSize: 12,
+          fontSize: 11,
           color: T.text2,
           fontFamily: T.fontMono,
-          whiteSpace: 'nowrap',
-          overflow: 'hidden',
-          textOverflow: 'ellipsis',
-          minWidth: 0,
+          whiteSpace: 'pre-wrap',
+          wordBreak: 'break-all',
+          lineHeight: 1.5,
+          padding: '4px 6px',
+          background: 'rgba(0,0,0,0.25)',
+          borderRadius: 3,
+          border: `1px solid ${T.cardBorder}`,
         }}
       >
         {value}
       </code>
-      <button
-        type="button"
-        onClick={(e) => {
-          e.stopPropagation();
-          onCopy(value, copyKey);
-        }}
-        style={{
-          flexShrink: 0,
-          padding: '2px 10px',
-          fontSize: 10,
-          fontWeight: 500,
-          color: isCopied ? T.live : T.text3,
-          background: 'rgba(255,255,255,0.04)',
-          border: `1px solid ${T.cardBorder}`,
-          borderRadius: 3,
-          cursor: 'pointer',
-          fontFamily: T.fontSans,
-          transition: `color 160ms ${T.ease}, background 160ms ${T.ease}`,
-        }}
-        onMouseEnter={(e) => {
-          if (isCopied) return;
-          e.currentTarget.style.background = 'rgba(255,255,255,0.08)';
-          e.currentTarget.style.color = T.text1;
-        }}
-        onMouseLeave={(e) => {
-          if (isCopied) return;
-          e.currentTarget.style.background = 'rgba(255,255,255,0.04)';
-          e.currentTarget.style.color = T.text3;
-        }}
-      >
-        {isCopied ? 'Copied' : 'Copy'}
-      </button>
     </div>
   );
 }
@@ -434,19 +452,17 @@ function ApListRow({
             fontFamily: T.fontSans,
           }}
         >
-          {/* Provider avatar bumped 24 → 32 + radius 6 → 8 + icon
-              16 → 20.  Multi-AP differentiation now relies on
-              avatar shape (folder for filesystem, plug for mcp,
-              cube for sandbox) rather than colour, so the avatar
-              needs enough size to *be* the differentiator at
-              scanning distance.  Slightly stronger bg tint
-              (0.04 → 0.05) so the avatar reads as a plate the
-              icon sits on, not a flat dye behind it. */}
+          {/* Provider avatar — 28 (was 32) to fit the 280px sidebar
+              width without crowding the name + Open button on the
+              same row.  Icon stays 18 (was 20) for the same reason.
+              Avatar shape is still the primary multi-AP
+              differentiator, but at this scale the name does more
+              of the work and the avatar plays a supporting role. */}
           <div
             style={{
-              width: 32,
-              height: 32,
-              borderRadius: 8,
+              width: 28,
+              height: 28,
+              borderRadius: 7,
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'center',
@@ -456,7 +472,7 @@ function ApListRow({
           >
             <ProviderAvatar
               provider={conn.provider}
-              size={20}
+              size={18}
               icon={(conn as any).icon}
             />
           </div>
@@ -499,6 +515,12 @@ function ApListRow({
             />
           </div>
 
+          {/* Direction + scope — pinned to the right, with scope
+              capped at 90px so a long path can't push the Open
+              button off-screen.  Truncates with ellipsis when
+              that happens; the full path is still readable in
+              the row's `title` attribute (browser tooltip on
+              hover). */}
           <div
             style={{
               display: 'flex',
@@ -518,18 +540,21 @@ function ApListRow({
                 whiteSpace: 'nowrap',
                 overflow: 'hidden',
                 textOverflow: 'ellipsis',
-                maxWidth: 220,
+                maxWidth: 90,
               }}
             >
               {displayScope}
             </span>
           </div>
 
-          {/* Explicit "Open" link — the only deliberate entry to
-              /access?ap=<id> from this card.  Visually quiet
-              (text2 → text1 on hover) so it doesn't compete with
-              the AP name; semantically loud because it's the only
-              navigable element on the identity row. */}
+          {/* Open — chevron-only at this width.  At 280px we don't
+              have horizontal budget for both the AP identity
+              (avatar + name + status + scope) AND a labelled "Open"
+              button.  The chevron alone reads as "go further" and
+              the title attribute provides the affordance text for
+              accessibility tooling.  Keeps the deliberate-only
+              navigation handle the previous "Open" labelled
+              button established. */}
           <button
             type="button"
             onClick={(e) => {
@@ -537,19 +562,17 @@ function ApListRow({
               router.push(`/projects/${projectId}/access?ap=${conn.id}`);
             }}
             title="Open access point details"
+            aria-label="Open access point details"
             style={{
               flexShrink: 0,
-              marginLeft: 8,
+              marginLeft: 4,
               background: 'none',
               border: 'none',
               cursor: 'pointer',
-              padding: '2px 6px',
-              fontSize: 12,
+              padding: '4px 6px',
               color: T.text3,
-              fontFamily: T.fontSans,
               display: 'inline-flex',
               alignItems: 'center',
-              gap: 4,
               borderRadius: 4,
               transition: `color 160ms ${T.ease}, background 160ms ${T.ease}`,
             }}
@@ -562,7 +585,6 @@ function ApListRow({
               e.currentTarget.style.background = 'transparent';
             }}
           >
-            Open
             <svg width="10" height="10" viewBox="0 0 12 12" fill="none">
               <path
                 d="M4 2l4 4-4 4"

--- a/frontend/app/(main)/projects/[projectId]/home/components/ApChip.tsx
+++ b/frontend/app/(main)/projects/[projectId]/home/components/ApChip.tsx
@@ -88,24 +88,23 @@ export function ApChip({
         marginRight: 12,
         padding: '3px 7px',
         borderRadius: 10,
-        // Default-state pill: faint cyan tint + a thin cyan border so
-        // the chip reads as a small "wired" badge instead of a naked
-        // dot.  The Link2 icon inside is the visual marker — a chain
-        // link communicates "connected to something external" the
-        // moment a user glances at the row, without forcing them to
-        // decode an abstract coloured shape.
+        // Rest state is grayscale on purpose.  The page-wide rule
+        // (T.live cyan reserved for *live data signals*) means a
+        // chip that's cyan-by-default while no interaction is
+        // happening dilutes the colour's job — multi-AP layouts
+        // ended up reading as a wash of cyan everywhere.  Default
+        // pill now uses the same neutral cardBg / cardBorder we
+        // use elsewhere for "this is a labeled chip", and the
+        // Link2 icon inside drops to T.text3.
         //
-        // Active state (hover-sync from chip itself or from the
-        // matching AP row in the card below) bumps the bg to
-        // `rowHighlightRoot` (the brighter cyan) and the border to
-        // saturated `T.live` — same handshake intensity as the AP
-        // row picks up so the user sees them light up together.
-        background: isActive
-          ? T.rowHighlightRoot
-          : 'rgba(34, 211, 238, 0.06)',
-        border: `1px solid ${
-          isActive ? T.live : 'rgba(34, 211, 238, 0.18)'
-        }`,
+        // Sync-active state (chip↔AP-row handshake firing) is the
+        // ONLY time the chip lights up cyan.  Switching from grey
+        // → saturated cyan against a still-grey rest is the
+        // strongest contrast we can buy without redesigning the
+        // palette, which is exactly what a transient highlight
+        // wants.
+        background: isActive ? T.rowHighlightRoot : T.cardBg,
+        border: `1px solid ${isActive ? T.live : T.cardBorder}`,
         color: T.text3,
         fontSize: 11,
         fontVariantNumeric: 'tabular-nums',
@@ -117,7 +116,11 @@ export function ApChip({
       <Link2
         size={11}
         strokeWidth={2.2}
-        style={{ color: T.live, flexShrink: 0 }}
+        style={{
+          color: isActive ? T.live : T.text3,
+          flexShrink: 0,
+          transition: `color 160ms ${T.ease}`,
+        }}
       />
       {aps.length > 1 && (
         <span style={{ color: T.text2, fontWeight: 500 }}>{aps.length}</span>

--- a/frontend/app/(main)/projects/[projectId]/home/components/ApChip.tsx
+++ b/frontend/app/(main)/projects/[projectId]/home/components/ApChip.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link2 } from 'lucide-react';
 import { T } from '../lib/tokens';
 import type { DashboardConnection } from '../lib/types';
 
@@ -85,33 +86,38 @@ export function ApChip({
         flexShrink: 0,
         marginLeft: 8,
         marginRight: 12,
-        // padding gives the hover-state pill a body to wear (without
-        // it the cyan tint would clip tight to the dot+number, which
-        // looks cramped at the row scale).
-        padding: '2px 6px',
+        padding: '3px 7px',
         borderRadius: 10,
-        // Active pill picks up the same `T.rowHighlightRoot` tint the
-        // AccessPointsListCard uses on its hover row — so the chip
-        // and the card light up *in the same colour at the same
-        // intensity*.  That visual handshake is the whole point of
-        // hover-sync.
-        background: isActive ? T.rowHighlightRoot : 'transparent',
+        // Default-state pill: faint cyan tint + a thin cyan border so
+        // the chip reads as a small "wired" badge instead of a naked
+        // dot.  The Link2 icon inside is the visual marker — a chain
+        // link communicates "connected to something external" the
+        // moment a user glances at the row, without forcing them to
+        // decode an abstract coloured shape.
+        //
+        // Active state (hover-sync from chip itself or from the
+        // matching AP row in the card below) bumps the bg to
+        // `rowHighlightRoot` (the brighter cyan) and the border to
+        // saturated `T.live` — same handshake intensity as the AP
+        // row picks up so the user sees them light up together.
+        background: isActive
+          ? T.rowHighlightRoot
+          : 'rgba(34, 211, 238, 0.06)',
+        border: `1px solid ${
+          isActive ? T.live : 'rgba(34, 211, 238, 0.18)'
+        }`,
         color: T.text3,
         fontSize: 11,
         fontVariantNumeric: 'tabular-nums',
         lineHeight: 1,
-        transition: `background 160ms ${T.ease}`,
+        transition: `background 160ms ${T.ease}, border-color 160ms ${T.ease}`,
+        cursor: 'default',
       }}
     >
-      <span
-        aria-hidden
-        style={{
-          width: 6,
-          height: 6,
-          borderRadius: '50%',
-          background: T.live,
-          flexShrink: 0,
-        }}
+      <Link2
+        size={11}
+        strokeWidth={2.2}
+        style={{ color: T.live, flexShrink: 0 }}
       />
       {aps.length > 1 && (
         <span style={{ color: T.text2, fontWeight: 500 }}>{aps.length}</span>

--- a/frontend/app/(main)/projects/[projectId]/home/components/ApChip.tsx
+++ b/frontend/app/(main)/projects/[projectId]/home/components/ApChip.tsx
@@ -2,6 +2,18 @@ import React from 'react';
 import { T } from '../lib/tokens';
 import type { DashboardConnection } from '../lib/types';
 
+// Same path-normalization rule used in page.tsx's `accessByPath`
+// builder and AccessPointsListCard.  The chip needs to broadcast its
+// row's path when hovered, but the row's path coming out of the
+// dataCardView is already normalized to '' for project root, so this
+// is just a defensive identity for chip's expected inputs.  Kept
+// here as a small named helper so hover-sync intent reads at the
+// callsite below.
+function normalizeChipPath(raw: string | null | undefined): string {
+  if (raw === null || raw === undefined || raw === '/') return '';
+  return raw;
+}
+
 // Right-aligned chip rendered alongside any tree row that has one or
 // more Access Points attached to it (per `accessByPath`).  Read it as
 // "this row is wired to N agents/tools" — the tiny visual that lets a
@@ -31,7 +43,25 @@ import type { DashboardConnection } from '../lib/types';
 // dots already crowd the right margin, three is illegible.  A single
 // dot + count delivers "this row is wired" in 12px with no clipping.
 
-export function ApChip({ aps }: { aps: DashboardConnection[] }) {
+export function ApChip({
+  aps,
+  rowPath,
+  hoveredPath,
+  onHoverPath,
+}: {
+  aps: DashboardConnection[];
+  // Path of the tree row this chip lives on.  Used as the
+  // hover-sync key so AccessPointsListCard can match against an
+  // AP's normalized path and highlight the corresponding card.
+  rowPath: string;
+  // Currently hovered path (anywhere — chip OR AP card).  Lifted
+  // in page.tsx so chip and card share one source of truth.
+  hoveredPath: string | null;
+  // Notifier — chip sets this on mouseenter (with its row path) and
+  // clears it on mouseleave.  Same callback the AP card uses, so
+  // the relationship is reflexive.
+  onHoverPath: (path: string | null) => void;
+}) {
   if (!aps || aps.length === 0) return null;
 
   const label =
@@ -39,10 +69,15 @@ export function ApChip({ aps }: { aps: DashboardConnection[] }) {
       ? '1 access point'
       : `${aps.length} access points`;
 
+  const myPath = normalizeChipPath(rowPath);
+  const isActive = hoveredPath !== null && hoveredPath === myPath;
+
   return (
     <div
       title={label}
       aria-label={label}
+      onMouseEnter={() => onHoverPath(myPath)}
+      onMouseLeave={() => onHoverPath(null)}
       style={{
         display: 'inline-flex',
         alignItems: 'center',
@@ -50,14 +85,22 @@ export function ApChip({ aps }: { aps: DashboardConnection[] }) {
         flexShrink: 0,
         marginLeft: 8,
         marginRight: 12,
-        // Quiet by default — the chip should read as a small
-        // informational marker, not a CTA.  Lifted to text2 on the
-        // count keeps the number legible without competing with the
-        // file/folder name to its left.
+        // padding gives the hover-state pill a body to wear (without
+        // it the cyan tint would clip tight to the dot+number, which
+        // looks cramped at the row scale).
+        padding: '2px 6px',
+        borderRadius: 10,
+        // Active pill picks up the same `T.rowHighlightRoot` tint the
+        // AccessPointsListCard uses on its hover row — so the chip
+        // and the card light up *in the same colour at the same
+        // intensity*.  That visual handshake is the whole point of
+        // hover-sync.
+        background: isActive ? T.rowHighlightRoot : 'transparent',
         color: T.text3,
         fontSize: 11,
         fontVariantNumeric: 'tabular-nums',
         lineHeight: 1,
+        transition: `background 160ms ${T.ease}`,
       }}
     >
       <span

--- a/frontend/app/(main)/projects/[projectId]/home/components/ApChip.tsx
+++ b/frontend/app/(main)/projects/[projectId]/home/components/ApChip.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { T } from '../lib/tokens';
+import type { DashboardConnection } from '../lib/types';
+
+// Right-aligned chip rendered alongside any tree row that has one or
+// more Access Points attached to it (per `accessByPath`).  Read it as
+// "this row is wired to N agents/tools" — the tiny visual that lets a
+// user scanning the Data card see the project's external surface area
+// inline, instead of having to cross-reference the ConnectionsCanvas
+// below.
+//
+// Visual contract (intentionally muted):
+//   ─ One cyan dot                        — uses T.live, the page's
+//                                            single chromatic accent.
+//                                            Same hue as the
+//                                            ConnectionsCanvas edges
+//                                            so users connect the two
+//                                            views by colour.
+//   ─ Optional count number (only > 1)    — fan-out indicator;
+//                                            invisible when there's
+//                                            just one AP so the
+//                                            common case stays calm.
+//   ─ No background, no border, no hover  — the chip belongs to the
+//                                            row, not floating ON it;
+//                                            the row's own hover wash
+//                                            already provides
+//                                            interactive feedback.
+//
+// Why not multiple dots (one per AP, or per provider)?  Tested in
+// design — at row height 32px and ~5 char of horizontal budget, two
+// dots already crowd the right margin, three is illegible.  A single
+// dot + count delivers "this row is wired" in 12px with no clipping.
+
+export function ApChip({ aps }: { aps: DashboardConnection[] }) {
+  if (!aps || aps.length === 0) return null;
+
+  const label =
+    aps.length === 1
+      ? '1 access point'
+      : `${aps.length} access points`;
+
+  return (
+    <div
+      title={label}
+      aria-label={label}
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 4,
+        flexShrink: 0,
+        marginLeft: 8,
+        marginRight: 12,
+        // Quiet by default — the chip should read as a small
+        // informational marker, not a CTA.  Lifted to text2 on the
+        // count keeps the number legible without competing with the
+        // file/folder name to its left.
+        color: T.text3,
+        fontSize: 11,
+        fontVariantNumeric: 'tabular-nums',
+        lineHeight: 1,
+      }}
+    >
+      <span
+        aria-hidden
+        style={{
+          width: 6,
+          height: 6,
+          borderRadius: '50%',
+          background: T.live,
+          flexShrink: 0,
+        }}
+      />
+      {aps.length > 1 && (
+        <span style={{ color: T.text2, fontWeight: 500 }}>{aps.length}</span>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/(main)/projects/[projectId]/home/components/ConnectionsCanvas.tsx
+++ b/frontend/app/(main)/projects/[projectId]/home/components/ConnectionsCanvas.tsx
@@ -797,6 +797,18 @@ export function ConnectionsCanvas({
     setHoveredApId(id);
   }, []);
 
+  // Collapsed by default.  The Data card above now renders an inline
+  // ApChip on every AP-attached row, so for the common case (a project
+  // with 1-3 root- or top-level APs) a user already sees "what's
+  // wired to what" without needing the graph view.  The graph still
+  // earns its keep for complex wiring (multi-AP fan-out, mixed
+  // providers, deeply-scoped APs) and for "I want to see edge
+  // direction" — both unlocked by clicking the header to expand.
+  // Initial-collapsed also keeps first paint lighter on dense
+  // projects: ReactFlow + xyflow's layout engine don't run until the
+  // user opts in.
+  const [collapsed, setCollapsed] = useState(true);
+
   // Pruned view of the tree — primary chains (path-to-AP) + a
   // single per-level "X more files" placeholder summarizing what's
   // hidden.  Drives both what the tree renders AND which paths get
@@ -876,17 +888,40 @@ export function ConnectionsCanvas({
       }}
     >
       {/* Header — same rhythm as the Data / History / APs cards.
-          Right-side hint teaches the two key affordances (zoom,
-          drag) since the dotted background only suggests
-          interactivity, doesn't spell it out. */}
-      <div
+          Now a TOGGLE: clicking anywhere on the header flips the
+          collapsed state.  When collapsed the right-side text reads
+          as a "expand to view" cue; when expanded it surfaces the
+          two interactive affordances (hover, drag) the dotted
+          background can't communicate on its own. */}
+      <button
+        type="button"
+        onClick={() => setCollapsed((c) => !c)}
+        aria-expanded={!collapsed}
+        aria-controls="connections-canvas-body"
         style={{
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'space-between',
           padding: '10px 14px',
           background: T.sectionHeaderBg,
-          borderBottom: `1px solid ${T.sectionDivider}`,
+          borderBottom: collapsed ? 'none' : `1px solid ${T.sectionDivider}`,
+          // Reset native button styling so the header still reads as
+          // a section header, not a CTA pill.  Cursor flips to
+          // pointer to communicate "this is interactive" — the only
+          // affordance change vs. the previous static header.
+          border: 'none',
+          width: '100%',
+          textAlign: 'left',
+          cursor: 'pointer',
+          fontFamily: 'inherit',
+          color: 'inherit',
+          transition: `background 200ms ${T.ease}`,
+        }}
+        onMouseEnter={(e) => {
+          e.currentTarget.style.background = 'rgba(255,255,255,0.05)';
+        }}
+        onMouseLeave={(e) => {
+          e.currentTarget.style.background = T.sectionHeaderBg;
         }}
       >
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
@@ -915,12 +950,41 @@ export function ConnectionsCanvas({
             {connections.length}
           </span>
         </div>
-        <span style={{ fontSize: 11, color: T.text3 }}>
-          {connections.length === 0
-            ? 'No access points yet'
-            : 'Hover an access point to highlight · Drag to rearrange'}
-        </span>
-      </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <span style={{ fontSize: 11, color: T.text3 }}>
+            {collapsed
+              ? connections.length === 0
+                ? 'No access points yet'
+                : 'View as graph'
+              : 'Hover an access point to highlight · Drag to rearrange'}
+          </span>
+          {/* Caret — flips down when expanded.  Slow rotation
+              transitions read as "panel opening" instead of an
+              instant snap.  aria-hidden because the button itself
+              already exposes aria-expanded for AT users. */}
+          <svg
+            aria-hidden
+            width="10"
+            height="10"
+            viewBox="0 0 12 12"
+            fill="none"
+            style={{
+              color: T.text3,
+              flexShrink: 0,
+              transform: collapsed ? 'rotate(0deg)' : 'rotate(180deg)',
+              transition: `transform 200ms ${T.ease}`,
+            }}
+          >
+            <path
+              d="M3 4.5l3 3 3-3"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </div>
+      </button>
 
       {/* xyflow Controls dark-theme override.  The default Controls
           ship with white panel + dark glyph styling (built for
@@ -973,8 +1037,18 @@ export function ConnectionsCanvas({
           sits below the Data card's body floor (320), and the
           extra 60px gives fitView at 0.75 enough viewport room to
           seat a slightly bigger tree + AP rail without crunching
-          everything tight against the dot grid edges. */}
-      <div style={{ height: 300, position: 'relative' }}>
+          everything tight against the dot grid edges.
+
+          Conditionally rendered (defaults collapsed): when collapsed
+          we don't mount ReactFlow at all, so the xyflow layout pass
+          never runs on a freshly-loaded /home — initial render is
+          just the section header strip.  Expanding flips
+          `collapsed` to false and ReactFlow mounts inline; the
+          drag-position memory in the `setNodes` effect above will
+          honour any positions the user previously dragged within
+          the same session, so collapse → expand isn't destructive. */}
+      {!collapsed && (
+      <div id="connections-canvas-body" style={{ height: 300, position: 'relative' }}>
         <HoverContext.Provider value={hoverValue}>
           <ReactFlow
             nodes={nodes}
@@ -1070,6 +1144,7 @@ export function ConnectionsCanvas({
           </div>
         )}
       </div>
+      )}
     </div>
   );
 }

--- a/frontend/app/(main)/projects/[projectId]/home/page.tsx
+++ b/frontend/app/(main)/projects/[projectId]/home/page.tsx
@@ -2,7 +2,6 @@
 
 import { use, useMemo, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import dynamic from 'next/dynamic';
 import { useOnboarding } from '@/lib/hooks/useOnboarding';
 import { get } from '@/lib/apiClient';
 import useSWR from 'swr';
@@ -18,33 +17,19 @@ import type {
 
 import { TreeRows, type RowVariant } from './components/TreeRows';
 import { HistoryCard } from './components/HistoryCard';
-import { AccessPointsCard } from './components/AccessPointsCard';
 import { GetStartedPanel } from './components/GetStartedPanel';
 import { ApChip } from './components/ApChip';
+import { AccessPointsListCard } from './components/AccessPointsListCard';
 
-const ConnectionsCanvas = dynamic(
-  () => import('./components/ConnectionsCanvas').then((mod) => mod.ConnectionsCanvas),
-  {
-    ssr: false,
-    loading: () => (
-      <div
-        style={{
-          height: 300,
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          color: T.text3,
-          fontSize: 12,
-          background: T.sectionBg,
-          border: `2px solid ${T.sectionBorder}`,
-          borderRadius: T.sectionRadius,
-        }}
-      >
-        Loading connection graph...
-      </div>
-    ),
-  },
-);
+// ConnectionsCanvas (the old xyflow wiring board) used to mount here.
+// Home now surfaces Access Points directly under the Data card via
+// AccessPointsListCard — that's a denser, copy-driven surface that
+// replaces the supplementary graph view (which was already collapsed
+// by default and rarely opened in practice).  ConnectionsCanvas.tsx
+// itself stays in the tree for now in case we want to bring the graph
+// back as a toggle on the AP card; this just stops importing it from
+// /home, so the bundle that ships for this route no longer pulls in
+// xyflow / @xyflow/react.
 
 // Vitals-strip interpunct separator.  A single `·` glyph rendered in
 // the faint `text4` token with a small horizontal rhythm so the strip
@@ -958,24 +943,23 @@ export default function HomePage({
               </div>
             </div>
 
-              {/* Connections canvas — xyflow-powered wiring board
-                  that re-renders the same file tree INSIDE the
-                  canvas as a single big node, with AP cards on the
-                  right wired to the SPECIFIC tree row each one is
-                  scoped to.  Inherits the OLD TopologyCanvas's
-                  spine (tree-as-block + APs-as-leaves + per-row
-                  edges) and adds pan / zoom / dotted background
-                  via xyflow.  Same width as the Data card above
-                  (both inside this flex-column wrapper) so it
-                  reads as a SUPPLEMENT — "the same data, viewed
-                  structurally" — not a separate band. */}
-              <ConnectionsCanvas
-                connections={connections}
-                tree={tree}
-                accessByPath={accessByPath}
+              {/* Access Points — primary operational surface.  Was a
+                  one-line-per-AP card on the right rail (sidebar
+                  width), but the operational read of an AP — its
+                  endpoint URL and the `mut connect` / similar CLI
+                  command — needed real horizontal budget for the
+                  monospaced strings + Copy buttons users hit
+                  constantly.  Moving the block to the left main
+                  column (replacing the old ConnectionsCanvas slot)
+                  gives each AP enough room for an Endpoint URL row
+                  + a CLI command row inline, removing the round
+                  trip to /access for the most common copy-paste
+                  flow.  See AccessPointsListCard for the per-row
+                  layout. */}
+              <AccessPointsListCard
                 projectId={projectId}
                 router={router}
-                nodesTotal={dashboard?.nodes?.total ?? null}
+                connections={connections}
               />
             </div>
 
@@ -1001,11 +985,14 @@ export default function HomePage({
                 commits={commits}
                 buckets={commitBuckets}
               />
-              <AccessPointsCard
-                projectId={projectId}
-                router={router}
-                connections={connections}
-              />
+              {/* AccessPointsCard used to live here as the sidebar
+                  one-liner.  Promoted to the main column under Data
+                  via AccessPointsListCard so it can carry the
+                  endpoint URL + CLI command + Copy buttons inline.
+                  The right rail is now History-only on /home; if a
+                  future right-rail consumer comes along (recent
+                  uploads, agent activity, etc.) it can slot in here
+                  without the AP block fighting it for space. */}
             </div>
           </div>
             </>

--- a/frontend/app/(main)/projects/[projectId]/home/page.tsx
+++ b/frontend/app/(main)/projects/[projectId]/home/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { use, useMemo, useEffect } from 'react';
+import { use, useMemo, useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useOnboarding } from '@/lib/hooks/useOnboarding';
 import { get } from '@/lib/apiClient';
@@ -99,6 +99,16 @@ export default function HomePage({
 }) {
   const { projectId } = use(params);
   const router = useRouter();
+
+  // Shared hover key for the Data ApChip ↔ AccessPointsListCard
+  // handshake.  When the user mouses over either side, this stores
+  // the matching path (project-root chip uses '', a folder/file chip
+  // uses its tree path, an AP card uses its `normalizeApPath`-d
+  // value).  Both sides then highlight when their own path matches.
+  // Lifted to page-level state because the chip and the card live in
+  // sibling components — there's no parent below this point that
+  // owns both.
+  const [hoveredPath, setHoveredPath] = useState<string | null>(null);
 
   // ── Data ─────────────────────────────────────────────────────────
 
@@ -954,7 +964,12 @@ export default function HomePage({
                     renderRowExtras={(path) => {
                       const aps = accessByPath.get(path);
                       return aps && aps.length > 0 ? (
-                        <ApChip aps={aps} />
+                        <ApChip
+                          aps={aps}
+                          rowPath={path}
+                          hoveredPath={hoveredPath}
+                          onHoverPath={setHoveredPath}
+                        />
                       ) : null;
                     }}
                   />
@@ -979,6 +994,8 @@ export default function HomePage({
                 projectId={projectId}
                 router={router}
                 connections={connections}
+                hoveredPath={hoveredPath}
+                onHoverPath={setHoveredPath}
               />
             </div>
 

--- a/frontend/app/(main)/projects/[projectId]/home/page.tsx
+++ b/frontend/app/(main)/projects/[projectId]/home/page.tsx
@@ -20,6 +20,7 @@ import { TreeRows, type RowVariant } from './components/TreeRows';
 import { HistoryCard } from './components/HistoryCard';
 import { AccessPointsCard } from './components/AccessPointsCard';
 import { GetStartedPanel } from './components/GetStartedPanel';
+import { ApChip } from './components/ApChip';
 
 const ConnectionsCanvas = dynamic(
   () => import('./components/ConnectionsCanvas').then((mod) => mod.ConnectionsCanvas),
@@ -895,6 +896,29 @@ export default function HomePage({
                   // one click on any row, which routes into the
                   // data explorer's recursive view.
                   //
+                  // Wrapped in a synthetic ROOT node (`path: ''`,
+                  // matching the convention `accessByPath` uses
+                  // for project-root APs in ConnectionsCanvas).
+                  // Two reasons:
+                  //   1.  AP visibility — root-attached access points
+                  //       (the default `mut connect` filesystem AP at
+                  //       `/`) had no anchor row in the Data card, so
+                  //       their presence was visible only in the
+                  //       Connections canvas below.  Now the chip
+                  //       renders directly on the root row, making
+                  //       "this whole project is exposed via X APs"
+                  //       legible at the top of the tree.
+                  //   2.  Visual parity with /data — that page's
+                  //       sidebar already renders a "root" entry as
+                  //       the parent of all top-level files; mirroring
+                  //       that here removes a "where am I?" mismatch
+                  //       when users move between Home and Data.
+                  //
+                  // `renderRowExtras` injects a tiny <ApChip /> on the
+                  // right of any row that has APs attached.  Reuses
+                  // the slot ConnectionsCanvas already uses for its
+                  // xyflow Handles — same protocol, different payload.
+                  //
                   // No cross-section hover sync — `highlightedPaths`
                   // is null so TreeRows renders only its quiet rest
                   // state (rowAttached tint where APs touch, no cyan
@@ -902,7 +926,20 @@ export default function HomePage({
                   // "which AP touches what" job, freeing the tree
                   // to stay a quiet file listing.
                   <TreeRows
-                    nodes={dataCardView.tree}
+                    nodes={[
+                      {
+                        entry: {
+                          name: 'Project root',
+                          path: '',
+                          type: 'folder',
+                          content_hash: null,
+                          size_bytes: 0,
+                          mime_type: null,
+                          children_count: dataCardView.tree.length,
+                        },
+                        children: dataCardView.tree,
+                      },
+                    ]}
                     depth={0}
                     projectId={projectId}
                     router={router}
@@ -910,6 +947,12 @@ export default function HomePage({
                     highlightedPaths={null}
                     highlightAnchorDepth={-1}
                     rowVariants={dataCardView.variants}
+                    renderRowExtras={(path) => {
+                      const aps = accessByPath.get(path);
+                      return aps && aps.length > 0 ? (
+                        <ApChip aps={aps} />
+                      ) : null;
+                    }}
                   />
                 )}
               </div>

--- a/frontend/app/(main)/projects/[projectId]/home/page.tsx
+++ b/frontend/app/(main)/projects/[projectId]/home/page.tsx
@@ -205,7 +205,26 @@ export default function HomePage({
   const accessByPath = useMemo(() => {
     const map = new Map<string, DashboardConnection[]>();
     for (const conn of connections) {
-      const key = conn.path || '';
+      // Normalize the three "root scope" path representations the
+      // backend can produce into a single key — '' — so downstream
+      // consumers only have to look in one place:
+      //
+      //   path === '/'   — what `mut connect` bootstrap stores today
+      //                    (filesystem service.bootstrap is called
+      //                    with path='/' from the home onboarding
+      //                    panel and the access page's "root scope"
+      //                    button)
+      //   path === null  — legacy rows from before path-NOT-NULL was
+      //                    enforced; still in some long-lived projects
+      //   path === ''    — early hand-bootstrapped rows
+      //
+      // Without this, the root TreeRow's ApChip lookup
+      // (`accessByPath.get('')`) misses the AP entirely because its
+      // path was '/' under the previous `conn.path || ''` pass-through
+      // (truthy → key stays '/'), so the chip silently doesn't render
+      // even though a real root-scope AP is wired.
+      const raw = conn.path;
+      const key = raw === null || raw === '' || raw === '/' ? '' : raw;
       if (!map.has(key)) map.set(key, []);
       map.get(key)!.push(conn);
     }

--- a/frontend/app/(main)/projects/[projectId]/home/page.tsx
+++ b/frontend/app/(main)/projects/[projectId]/home/page.tsx
@@ -708,16 +708,23 @@ export default function HomePage({
             <>
           {/* ============================================================
               BAND 2 — TWO-COLUMN.
-                LEFT  (flex 1) — Data card stacked over the
-                                ConnectionsCanvas (xyflow wiring
-                                board).  Both sit in the same wide
-                                column because they're complementary
-                                views of the same data: "what files"
-                                + "which APs are wired to them".
-                RIGHT (280px) — History + Access Points stacked.
-                                Fixed-width so the rail reads at a
-                                consistent width regardless of
-                                viewport.
+                LEFT  (flex 1) — Data card.  Just the file tree;
+                                the AP / wiring view used to live
+                                here too but moved to the right rail
+                                so the page reads left → right as
+                                "data → external connections" (data
+                                is the project's *content*, AP is
+                                its external *exposure*; spatially
+                                pairing them across columns is the
+                                most direct visual representation of
+                                that "data flows out via these
+                                endpoints" relationship).
+                RIGHT (280px) — Access Points + History stacked.
+                                Access Points goes first because the
+                                user's typical work is "look at
+                                Data, then act on it via an AP";
+                                History sits below as supporting
+                                time-series context.
               32px gap between columns; 16px gap between stacked
               cards within each column.
               ============================================================ */}
@@ -1010,35 +1017,22 @@ export default function HomePage({
               </div>
             </div>
 
-              {/* Access Points — primary operational surface.  Was a
-                  one-line-per-AP card on the right rail (sidebar
-                  width), but the operational read of an AP — its
-                  endpoint URL and the `mut connect` / similar CLI
-                  command — needed real horizontal budget for the
-                  monospaced strings + Copy buttons users hit
-                  constantly.  Moving the block to the left main
-                  column (replacing the old ConnectionsCanvas slot)
-                  gives each AP enough room for an Endpoint URL row
-                  + a CLI command row inline, removing the round
-                  trip to /access for the most common copy-paste
-                  flow.  See AccessPointsListCard for the per-row
-                  layout. */}
-              <AccessPointsListCard
-                projectId={projectId}
-                router={router}
-                connections={connections}
-                hoveredPath={hoveredPath}
-                onHoverPath={setHoveredPath}
-              />
             </div>
 
-            {/* RIGHT — stacked rail.  280px so HistoryCard's vertical
-                timeline + commit messages have enough room to read,
-                while still leaving the Data card the dominant share
-                of width (~2:1 ratio from the GitHub-style reference).
-                Was 320 (too wide → Data crowded), then 260 (too
-                narrow → History card crushed); 280 splits the
-                difference. */}
+            {/* RIGHT — stacked rail.  Now hosts AccessPointsListCard
+                + HistoryCard, in that order.  The reorder is a
+                spatial-semantic move: the page reads left → right
+                as "data → external connections", so the AP block
+                has to sit *to the right of* Data, not below it.
+                With AP underneath Data the visual chain was broken
+                — the user had to scroll down + back up to map
+                which row maps to which AP — and the right rail
+                was busy holding History alone, which doesn't need
+                that much space.  Now: Data | (AP + History).
+                Width was 280 — kept, even though AP pulled in,
+                because AccessPointsListCard reflows internally to
+                a vertical CopyableLine layout when the parent is
+                narrow. */}
             <div
               style={{
                 width: 280,
@@ -1048,20 +1042,23 @@ export default function HomePage({
                 gap: 16,
               }}
             >
+              {/* Access Points first — top of the rail because the
+                  user's typical work is "look at Data, then act on
+                  it via an AP".  Putting AP above History honors
+                  that reading order. */}
+              <AccessPointsListCard
+                projectId={projectId}
+                router={router}
+                connections={connections}
+                hoveredPath={hoveredPath}
+                onHoverPath={setHoveredPath}
+              />
               <HistoryCard
                 projectId={projectId}
                 router={router}
                 commits={commits}
                 buckets={commitBuckets}
               />
-              {/* AccessPointsCard used to live here as the sidebar
-                  one-liner.  Promoted to the main column under Data
-                  via AccessPointsListCard so it can carry the
-                  endpoint URL + CLI command + Copy buttons inline.
-                  The right rail is now History-only on /home; if a
-                  future right-rail consumer comes along (recent
-                  uploads, agent activity, etc.) it can slot in here
-                  without the AP block fighting it for space. */}
             </div>
           </div>
             </>

--- a/frontend/app/(main)/projects/[projectId]/home/page.tsx
+++ b/frontend/app/(main)/projects/[projectId]/home/page.tsx
@@ -958,8 +958,33 @@ export default function HomePage({
                     projectId={projectId}
                     router={router}
                     accessByPath={accessByPath}
-                    highlightedPaths={null}
-                    highlightAnchorDepth={-1}
+                    // Single-row highlight driven by the shared
+                    // hoveredPath.  When the user mouses over the
+                    // matching ApChip in this tree OR an AP row in
+                    // the AccessPointsListCard below, the whole
+                    // matching Data row gets the rest-state cyan
+                    // band — not just the chip pill, which would be
+                    // too small a target for the user's eye to
+                    // catch.  Anchor depth is computed from the
+                    // path's own depth (root '' → 0, top-level
+                    // 'foo.md' → 1, 'docs/foo.md' → 2 …) so the
+                    // band's left edge sits at the right indent
+                    // for that row's visual depth.  No descendant
+                    // sweep here on purpose: we want exactly one
+                    // row to light up, matching the chip↔card
+                    // symmetry.
+                    highlightedPaths={
+                      hoveredPath !== null
+                        ? new Set([hoveredPath])
+                        : null
+                    }
+                    highlightAnchorDepth={
+                      hoveredPath === null
+                        ? -1
+                        : hoveredPath === ''
+                          ? 0
+                          : hoveredPath.split('/').length
+                    }
                     rowVariants={dataCardView.variants}
                     renderRowExtras={(path) => {
                       const aps = accessByPath.get(path);

--- a/frontend/app/(main)/projects/[projectId]/home/page.tsx
+++ b/frontend/app/(main)/projects/[projectId]/home/page.tsx
@@ -943,7 +943,15 @@ export default function HomePage({
                     nodes={[
                       {
                         entry: {
-                          name: 'Project root',
+                          // Synthetic root row name kept in step with
+                          // /data's ExplorerSidebar root entry
+                          // ("Root").  Two renders of the same
+                          // semantic node should read with the same
+                          // word — earlier we rendered "Project root"
+                          // here while /data renders "Root", which
+                          // made users moving between the two pages
+                          // wonder if they were the same node.
+                          name: 'Root',
                           path: '',
                           type: 'folder',
                           content_hash: null,


### PR DESCRIPTION
## Why

Home page was splitting a project's "what data exists / what's wired" story across two cards (Data tree + ConnectionsCanvas below) and forcing the user to mentally cross-reference them:

1. **Root-attached APs were invisible in the Data card.** The default \`mut connect\` flow registers a filesystem AP at \`/\` — a real AP that scopes the entire project — but the Data card only rendered top-level entries, never a "project root" row. The AP showed up as a chip in the canvas below, but the cross-reference between the two cards was the user's job.

2. **The graph duplicated information for the common case.** A project with 1-3 APs at root or a couple of top-level folders doesn't need a wiring diagram; the user already knows where the APs sit. The graph earns its keep for fan-out, mixed providers, and edge direction — not the basic "is this folder wired?" question.

## What

Three coordinated changes:

### 1. New \`ApChip\` component

Tiny cyan dot (\`T.live\`, same hue as the graph edges) + optional count number, rendered on the right of any tree row that has 1+ APs attached.

- Single dot, no border, no background — quiet enough to belong to the row
- Count shown only when AP count > 1 (common case stays calm)
- Tooltip: "1 access point" / "3 access points"

### 2. Data card wraps in synthetic root TreeNode

\`dataCardView.tree\` is now wrapped in \`{ entry: { path: '', name: 'Project root', type: 'folder', ... }, children: [...] }\` — \`path: ''\` is the convention \`accessByPath\` already uses for project-root APs in ConnectionsCanvas.

Two wins:
- Root-attached APs anchor on a visible row in the Data card instead of living only in the canvas
- Mirrors the \`/data\` sidebar layout (which already renders a root entry as the parent of all top-level files) — moving between Home and Data is now a consistent mental model

\`renderRowExtras\` slot (already exists, used by ConnectionsCanvas to inject xyflow Handles) carries the chip into the row. Same protocol, different payload.

### 3. ConnectionsCanvas collapsed by default

Header is now an aria-expanded button with a caret. Clicking expands inline.

- When collapsed, ReactFlow body doesn't mount at all — xyflow layout pass never runs on a freshly-loaded /home, initial render is just the section header strip
- Drag-positions persist across collapse → expand within the same session via the existing \`setNodes\` position-memory effect

## Verification

- ESLint: 0 errors
- \`npm run build\`: succeeds, all 27 routes generated, no warnings
- Manual: empty-state branch still renders "Empty project" placeholder; populated tree renders chip on AP-attached rows; collapse / expand toggles cleanly

## Test plan

- [ ] CI Frontend Build passes
- [ ] After merge + redeploy, on a project home page:
  - [ ] Root-attached APs (the default \`mut connect\` filesystem AP) show up as a chip on the "Project root" row in Data card
  - [ ] Top-level entries with their own AP attach show a chip on their row
  - [ ] Connections section is collapsed by default — only header strip visible
  - [ ] Clicking Connections header expands the graph; clicking again collapses
  - [ ] Empty-state Data card behaviour unchanged (no chip for path with 0 APs)

Made with [Cursor](https://cursor.com)