### PR TITLE
fix(repo-redesign): post-access_points-drop legacy 500s + UI polish

### DIFF
--- a/backend/src/connectors/datasource/repository.py
+++ b/backend/src/connectors/datasource/repository.py
@@ -15,13 +15,40 @@ from src.infra.supabase.client import SupabaseClient
 from src.connectors.datasource.schemas import Sync
 
 
+def _is_table_missing(exc: Exception) -> bool:
+    """Detect the postgrest 'table not in schema cache' error.
+
+    `access_points` was dropped post-redesign by 20260502000700_drop_access_points.sql.
+    Until every legacy caller has been migrated to repo_scopes/connectors, the
+    safe behaviour for read paths is to return empty rather than 500. Writes
+    still raise — they're either dead code or genuine bugs to surface.
+    """
+    return "PGRST205" in str(exc) or "schema cache" in str(exc).lower()
+
+
 class SyncRepository:
-    """CRUD for sync bindings in the `access_points` table (provider != 'agent')."""
+    """CRUD for sync bindings in the `access_points` table (provider != 'agent').
+
+    NOTE: this table was dropped post-redesign. All read methods here now
+    return empty when the table is missing; the new model lives in
+    repo_scopes + connectors (see src/repo/). Callers that still depend on
+    SyncRepository should be migrated; this layer's tolerance is a transition
+    safety net, not a permanent contract.
+    """
 
     TABLE = "access_points"
 
     def __init__(self, supabase_client: SupabaseClient):
         self.client = supabase_client.client
+
+    def _safe_list(self, build_query) -> list:
+        """Execute a list query, returning [] if the legacy table was dropped."""
+        try:
+            return build_query().execute().data or []
+        except Exception as e:
+            if _is_table_missing(e):
+                return []
+            raise
 
     @staticmethod
     def _now() -> str:
@@ -164,41 +191,40 @@ class SyncRepository:
     # ============================================================
 
     def list_by_project(self, project_id: str) -> List[Sync]:
-        response = (
-            self.client.table(self.TABLE)
+        rows = self._safe_list(
+            lambda: self.client.table(self.TABLE)
             .select("*")
             .eq("project_id", project_id)
             .neq("provider", "agent")
-            .execute()
         )
-        return [self._to_model(r) for r in response.data]
+        return [self._to_model(r) for r in rows]
 
     def list_by_path(self, path: str) -> List[Sync]:
         """All sync bindings for a given path."""
-        response = (
-            self.client.table(self.TABLE)
-            .select("*").eq("path", path).execute()
+        rows = self._safe_list(
+            lambda: self.client.table(self.TABLE).select("*").eq("path", path)
         )
-        return [self._to_model(r) for r in response.data]
+        return [self._to_model(r) for r in rows]
 
     def list_active(self, provider: Optional[str] = None) -> List[Sync]:
-        query = self.client.table(self.TABLE).select("*").eq("status", "active").neq("provider", "agent")
-        if provider:
-            query = query.eq("provider", provider)
-        return [self._to_model(r) for r in query.execute().data]
+        def build():
+            q = self.client.table(self.TABLE).select("*").eq("status", "active").neq("provider", "agent")
+            if provider:
+                q = q.eq("provider", provider)
+            return q
+        return [self._to_model(r) for r in self._safe_list(build)]
 
     def list_by_provider(
         self, project_id: str, provider: str,
     ) -> List[Sync]:
         """All syncs for a project + provider combination."""
-        response = (
-            self.client.table(self.TABLE)
+        rows = self._safe_list(
+            lambda: self.client.table(self.TABLE)
             .select("*")
             .eq("project_id", project_id)
             .eq("provider", provider)
-            .execute()
         )
-        return [self._to_model(r) for r in response.data]
+        return [self._to_model(r) for r in rows]
 
     # ============================================================
     # Update

--- a/backend/src/platform/project/router.py
+++ b/backend/src/platform/project/router.py
@@ -86,15 +86,19 @@ async def list_projects(
     for oid in oids:
         all_projects.extend(project_service.get_by_org_id(oid))
 
-    # Batch-fetch connection counts for all projects
+    # Batch-fetch connection counts for all projects. The legacy
+    # access_points table was dropped post-redesign — count user-configured
+    # connectors instead, excluding the auto-created cli/agent built-ins
+    # so the "connections" badge reflects actual user-set integrations.
     conn_counts: dict[str, int] = {}
     project_ids = [str(p.id) for p in all_projects]
     if project_ids:
         sb = get_supabase_client()
         rows = (
-            sb.table("access_points")
-            .select("project_id")
+            sb.table("connectors")
+            .select("project_id, provider")
             .in_("project_id", project_ids)
+            .not_.in_("provider", ["cli", "agent"])
             .execute()
         ).data
         for row in rows:

--- a/frontend/app/(main)/projects/[projectId]/data/components/SyncConfigPanel.tsx
+++ b/frontend/app/(main)/projects/[projectId]/data/components/SyncConfigPanel.tsx
@@ -129,7 +129,7 @@ export function SyncConfigPanel({ mode, syncId, projectId, onClose, onBack, onSy
     );
   }
 
-  return <CreateView projectId={projectId} onClose={onClose} onSyncCreated={onSyncCreated} />;
+  return <CreateView projectId={projectId} onClose={onClose} onBack={onBack} onSyncCreated={onSyncCreated} />;
 }
 
 /* ================================================================
@@ -140,9 +140,10 @@ export function SyncConfigPanel({ mode, syncId, projectId, onClose, onBack, onSy
    CreateView — unified creation panel for agents & syncs
    ================================================================ */
 
-function CreateView({ projectId, onClose, onSyncCreated }: {
+function CreateView({ projectId, onClose, onBack, onSyncCreated }: {
   projectId: string;
   onClose: () => void;
+  onBack?: () => void;
   onSyncCreated?: (nodeId: string) => void;
 }) {
   const {
@@ -678,7 +679,7 @@ function CreateView({ projectId, onClose, onSyncCreated }: {
 
   // Default: show provider picker
   return (
-    <PanelShell title="New access" onClose={onClose}>
+    <PanelShell title="New access" onClose={onClose} onBack={onBack}>
       <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
         <div style={{ flex: 1, overflowY: 'auto', padding: '12px 12px 24px', display: 'flex', flexDirection: 'column', gap: 16 }}>
           

--- a/frontend/app/(main)/projects/[projectId]/data/components/access-points/ScopedConnectorsListPanel.tsx
+++ b/frontend/app/(main)/projects/[projectId]/data/components/access-points/ScopedConnectorsListPanel.tsx
@@ -91,69 +91,326 @@ function directionLabel(direction: string): string {
   return direction || '—';
 }
 
-function ConnectorCard({
-  connector,
-  providerIcons,
-  onClick,
-  builtin,
-}: {
-  readonly connector: Connector;
-  readonly providerIcons: ProviderIconLookup;
-  readonly onClick: () => void;
-  readonly builtin: boolean;
-}) {
-  const [hovered, setHovered] = useState(false);
-  const iconEp = useMemo(() => connectorAsEndpointShape(connector), [connector]);
+function getApiBase(): string {
+  if (globalThis.window === undefined) return process.env.NEXT_PUBLIC_API_URL || '';
+  return process.env.NEXT_PUBLIC_API_URL || globalThis.location.origin;
+}
+
+function profileSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9]+/g, '-')
+    .replaceAll(/^-+|-+$/g, '') || 'folder';
+}
+
+interface SnippetBlock {
+  title: string;
+  description: string;
+  prompt: string;
+  tone?: 'green' | 'blue' | 'neutral';
+}
+
+function buildCliSnippets(scope: RepoScope, displayName: string): SnippetBlock[] {
+  const apiBase = getApiBase();
+  const accessKey = scope.access_key || '';
+  if (!accessKey) {
+    return [{
+      title: 'No access key',
+      description: 'This scope has no access_key issued. Regenerate it from scope settings to enable CLI access.',
+      prompt: '',
+      tone: 'neutral',
+    }];
+  }
+  const cloneUrl = `${apiBase}/mut/ap/${accessKey}`;
+  const profileName = profileSlug(scope.name || scope.path || 'root');
+  const scopeLabel = scope.path === '' ? 'root' : scope.path;
+
+  const cliPrompt = [
+    `Use this PuppyOne folder Access Point from terminal.`,
+    ``,
+    `Connector: ${displayName}`,
+    `Scope: ${scopeLabel}`,
+    ``,
+    `Recommended: direct remote filesystem commands (no local clone needed).`,
+    `printf '%s' '${accessKey}' | puppyone ap login ${profileName} --api-url ${apiBase} --access-key-stdin`,
+    `puppyone fs ls`,
+    `puppyone fs cat <file.md>`,
+    `echo "hello" | puppyone fs write notes/hello.md --type markdown`,
+    ``,
+    `Use MUT when you want a local folder backup or ongoing two-way sync.`,
+    `mut connect ${cloneUrl} --credential ${accessKey}`,
+    ``,
+    `Endpoint URL: ${cloneUrl}`,
+    `Credential: ${accessKey}`,
+    ``,
+    `Do not create a new access point unless I ask for one.`,
+  ].join('\n');
+
+  const mutPrompt = [
+    `Sync this PuppyOne Access Point with a local folder using the MUT CLI.`,
+    ``,
+    `Connector: ${displayName}`,
+    `Scope: ${scopeLabel}`,
+    ``,
+    `From the local folder that should sync with PuppyOne, run:`,
+    `mut connect ${cloneUrl} --credential ${accessKey}`,
+    ``,
+    `Endpoint URL: ${cloneUrl}`,
+    `Credential: ${accessKey}`,
+    ``,
+    `After connecting, use MUT for ongoing syncs. Do not create a new access point unless I ask for one.`,
+  ].join('\n');
+
+  return [
+    {
+      title: 'PuppyOne CLI',
+      description: 'Directly read and write this cloud folder. No local clone.',
+      prompt: cliPrompt,
+      tone: 'green',
+    },
+    {
+      title: 'MUT Sync',
+      description: 'Use when you want a local folder copy and ongoing two-way sync.',
+      prompt: mutPrompt,
+      tone: 'blue',
+    },
+  ];
+}
+
+function buildAgentSnippets(connector: Connector, scope: RepoScope, displayName: string): SnippetBlock[] {
+  const apiBase = getApiBase();
+  const mcpKey = (connector.config?.mcp_api_key as string | undefined) || '';
+  const scopeLabel = scope.path === '' ? 'root' : scope.path;
+
+  if (!mcpKey) {
+    return [{
+      title: 'Agent not yet activated',
+      description: 'No mcp_api_key on this agent connector. Open the agent in chat once to provision its MCP key.',
+      prompt: '',
+      tone: 'neutral',
+    }];
+  }
+
+  const serverName = profileSlug(displayName) || 'puppyone-agent';
+  const serverUrl = `${apiBase}/api/v1/mcp/proxy/${mcpKey}`;
+  const config = `{\n  "mcpServers": {\n    "${serverName}": {\n      "url": "${serverUrl}",\n      "headers": { "X-API-KEY": "${mcpKey}" }\n    }\n  }\n}`;
+  const prompt = [
+    `Configure this PuppyOne Chat Agent for an MCP-compatible client.`,
+    ``,
+    `Connector: ${displayName}`,
+    `Scope: ${scopeLabel}`,
+    `MCP Server URL: ${serverUrl}`,
+    `API Key: ${mcpKey}`,
+    ``,
+    `Use this MCP config:`,
+    config,
+    ``,
+    `After configuring it, use the MCP tools against the scoped PuppyOne workspace data.`,
+  ].join('\n');
+  return [{
+    title: 'MCP',
+    description: 'Configure this agent for an MCP-compatible client (Claude Desktop, Cursor, …).',
+    prompt,
+    tone: 'blue',
+  }];
+}
+
+function CopyPromptButton({ block }: { readonly block: SnippetBlock }) {
+  const [copied, setCopied] = useState(false);
+  const tone = block.tone || 'neutral';
+  let color: string;
+  if (tone === 'green') color = '#34d399';
+  else if (tone === 'blue') color = '#93c5fd';
+  else color = '#a3a3a3';
+
+  const handleCopy = async () => {
+    if (!block.prompt) return;
+    await navigator.clipboard.writeText(block.prompt);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1800);
+  };
 
   return (
     <button
       type="button"
-      onClick={onClick}
-      onMouseEnter={() => setHovered(true)}
-      onMouseLeave={() => setHovered(false)}
+      onClick={handleCopy}
+      disabled={!block.prompt}
       style={{
         width: '100%',
         textAlign: 'left',
-        display: 'flex',
-        alignItems: 'center',
-        gap: 10,
-        padding: '10px 12px',
         borderRadius: 8,
-        border: `1px solid ${hovered ? COLOR_BORDER_HOVER : COLOR_BORDER}`,
-        background: hovered ? COLOR_BG_HOVER : COLOR_BG_CARD,
-        color: COLOR_FG,
-        cursor: 'pointer',
+        border: `1px solid ${copied ? 'rgba(52,211,153,0.35)' : 'rgba(255,255,255,0.08)'}`,
+        background: copied ? 'rgba(52,211,153,0.08)' : 'rgba(255,255,255,0.03)',
+        padding: '10px 12px',
+        cursor: block.prompt ? 'pointer' : 'default',
+        transition: 'border-color 0.2s',
+        opacity: block.prompt ? 1 : 0.6,
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10 }}>
+        <div style={{ minWidth: 0 }}>
+          <div style={{ color, fontSize: 12, fontWeight: 600, lineHeight: 1.35 }}>{block.title}</div>
+          <div style={{ color: '#8b8b8b', fontSize: 11, lineHeight: 1.45, marginTop: 2 }}>
+            {block.description}
+          </div>
+        </div>
+        {block.prompt && (
+          <span style={{
+            flexShrink: 0,
+            color: copied ? '#34d399' : '#a3a3a3',
+            fontSize: 11,
+            fontWeight: 500,
+            border: `1px solid ${copied ? 'rgba(52,211,153,0.24)' : 'rgba(255,255,255,0.08)'}`,
+            borderRadius: 999,
+            padding: '4px 8px',
+            background: copied ? 'rgba(52,211,153,0.08)' : 'rgba(255,255,255,0.04)',
+          }}>
+            {copied ? 'Copied' : 'Copy Prompt'}
+          </span>
+        )}
+      </div>
+    </button>
+  );
+}
+
+function BuiltinExpansion({
+  connector,
+  scope,
+  displayName,
+}: {
+  readonly connector: Connector;
+  readonly scope: RepoScope;
+  readonly displayName: string;
+}) {
+  const blocks = useMemo(() => {
+    if (connector.provider === 'cli') return buildCliSnippets(scope, displayName);
+    if (connector.provider === 'agent') return buildAgentSnippets(connector, scope, displayName);
+    return [];
+  }, [connector, scope, displayName]);
+
+  if (blocks.length === 0) return null;
+  return (
+    <div
+      style={{
+        borderTop: `1px solid ${COLOR_BORDER}`,
+        padding: '10px 10px 10px',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 8,
+      }}
+    >
+      {blocks.map((block) => (
+        <CopyPromptButton key={block.title} block={block} />
+      ))}
+    </div>
+  );
+}
+
+function Chevron({ expanded }: { readonly expanded: boolean }) {
+  return (
+    <span
+      aria-hidden
+      style={{
+        fontSize: 10,
+        color: COLOR_FG_DIM,
+        transform: expanded ? 'rotate(90deg)' : 'rotate(0deg)',
+        transition: 'transform 0.15s',
+        display: 'inline-block',
+        width: 10,
+        textAlign: 'center',
+      }}
+    >
+      ▶
+    </span>
+  );
+}
+
+function ConnectorCard({
+  connector,
+  scope,
+  providerIcons,
+  onThirdPartyClick,
+  builtin,
+}: {
+  readonly connector: Connector;
+  readonly scope: RepoScope;
+  readonly providerIcons: ProviderIconLookup;
+  readonly onThirdPartyClick: () => void;
+  readonly builtin: boolean;
+}) {
+  const [hovered, setHovered] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+  const iconEp = useMemo(() => connectorAsEndpointShape(connector), [connector]);
+  const displayName = connector.name || providerLabel(connector.provider);
+
+  // Builtin (cli/agent): inline-expand to show setup snippets.
+  // Third-party: bubble click to parent for detail-panel routing.
+  const handleClick = () => {
+    if (builtin) setExpanded((v) => !v);
+    else onThirdPartyClick();
+  };
+
+  return (
+    <div
+      style={{
+        borderRadius: 8,
+        border: `1px solid ${hovered || expanded ? COLOR_BORDER_HOVER : COLOR_BORDER}`,
+        background: hovered || expanded ? COLOR_BG_HOVER : COLOR_BG_CARD,
+        overflow: 'hidden',
         transition: 'all 0.15s',
       }}
     >
-      <AccessPointProviderIcon ep={iconEp} providerIcons={providerIcons} />
-      <div style={{ flex: 1, minWidth: 0 }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-          <span style={{ fontSize: 13, fontWeight: 500, color: COLOR_FG, lineHeight: 1.3 }}>
-            {connector.name || providerLabel(connector.provider)}
-          </span>
-          {builtin && (
-            <span
-              style={{
-                fontSize: 10,
-                fontWeight: 500,
-                color: COLOR_FG_MUTED,
-                padding: '1px 6px',
-                borderRadius: 4,
-                background: 'rgba(255,255,255,0.06)',
-                border: '1px solid rgba(255,255,255,0.08)',
-              }}
-            >
-              Default
+      <button
+        type="button"
+        onClick={handleClick}
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+        style={{
+          width: '100%',
+          textAlign: 'left',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 10,
+          padding: '10px 12px',
+          background: 'transparent',
+          border: 'none',
+          color: COLOR_FG,
+          cursor: 'pointer',
+        }}
+      >
+        <AccessPointProviderIcon ep={iconEp} providerIcons={providerIcons} />
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <span style={{ fontSize: 13, fontWeight: 500, color: COLOR_FG, lineHeight: 1.3 }}>
+              {displayName}
             </span>
-          )}
+            {builtin && (
+              <span
+                style={{
+                  fontSize: 10,
+                  fontWeight: 500,
+                  color: COLOR_FG_MUTED,
+                  padding: '1px 6px',
+                  borderRadius: 4,
+                  background: 'rgba(255,255,255,0.06)',
+                  border: '1px solid rgba(255,255,255,0.08)',
+                }}
+              >
+                Default
+              </span>
+            )}
+          </div>
+          <div style={{ fontSize: 11, color: COLOR_FG_DIM, lineHeight: 1.4, marginTop: 2 }}>
+            {providerLabel(connector.provider)} · {directionLabel(connector.direction)}
+          </div>
         </div>
-        <div style={{ fontSize: 11, color: COLOR_FG_DIM, lineHeight: 1.4, marginTop: 2 }}>
-          {providerLabel(connector.provider)} · {directionLabel(connector.direction)}
-        </div>
-      </div>
-      <StatusDot status={connector.status} />
-    </button>
+        <StatusDot status={connector.status} />
+        {builtin && <Chevron expanded={expanded} />}
+      </button>
+      {builtin && expanded && (
+        <BuiltinExpansion connector={connector} scope={scope} displayName={displayName} />
+      )}
+    </div>
   );
 }
 
@@ -272,7 +529,7 @@ export function ScopedConnectorsListPanel({
                   Path: {scope.path === '' ? '/ (root)' : scope.path}
                 </div>
                 <div style={{ marginTop: 2 }}>
-                  Mode: {scope.mode === 'rw' ? 'Read &amp; Write' : 'Read-only'}
+                  Mode: {scope.mode === 'rw' ? 'Read & Write' : 'Read-only'}
                   {scope.is_root && ' · Root scope'}
                 </div>
               </div>
@@ -300,8 +557,9 @@ export function ScopedConnectorsListPanel({
                     <ConnectorCard
                       key={c.id}
                       connector={c}
+                      scope={scope}
                       providerIcons={providerIcons}
-                      onClick={() => onConnectorClick(c)}
+                      onThirdPartyClick={() => onConnectorClick(c)}
                       builtin
                     />
                   ))
@@ -331,8 +589,9 @@ export function ScopedConnectorsListPanel({
                     <ConnectorCard
                       key={c.id}
                       connector={c}
+                      scope={scope}
                       providerIcons={providerIcons}
-                      onClick={() => onConnectorClick(c)}
+                      onThirdPartyClick={() => onConnectorClick(c)}
                       builtin={false}
                     />
                   ))

--- a/frontend/app/(main)/projects/[projectId]/data/components/right-panel/DataPageRightPanel.tsx
+++ b/frontend/app/(main)/projects/[projectId]/data/components/right-panel/DataPageRightPanel.tsx
@@ -200,6 +200,7 @@ export function DataPageRightPanel({
           syncId={null}
           projectId={projectId}
           onClose={onClose}
+          onBack={backToAccessList}
           onSyncCreated={onSyncCreated}
         />
       )}


### PR DESCRIPTION
After the data migration completed and 20260502000700_drop_access_points.sql fired on the next deploy, several legacy code paths that still hit the dropped table started returning 500 (PGRST205 "table not in schema cache"). Plus three UI bugs caught from screenshots after the first scoped-panel deploy.

Backend
- platform/project/router.py:list_projects — was counting connections via access_points; switched to connectors (excluding cli/agent built-ins so the badge reflects user-set integrations, not the auto-created defaults). Without this, GET /api/v1/projects/ 500s and the entire dashboard / data-page layout fails to load.
- connectors/datasource/repository.py — SyncRepository now tolerates the missing access_points table for read paths via a _safe_list helper that catches PGRST205 and returns []. /api/v1/sync/status now degrades to empty rather than 500. Writes still raise (they're either dead code or legitimate bugs to surface). The new ScopedConnectorsListPanel doesn't consume sync_status anyway; this is a transition safety net.

Frontend (the 3 bugs from screenshots)
- ScopedConnectorsListPanel: clicking Local CLI / Chat Agent (the per-scope defaults) is now an inline expand instead of a no-op. cli row reveals "PuppyOne CLI" and "MUT Sync" copy-prompt blocks (mut connect URL + full agent prompt with the scope's access_key); agent row reveals an "MCP" copy-prompt block built from connector.config.mcp_api_key. Third- party connectors continue to route to the detail panel via onThirdPartyClick. Chevron indicates expandable rows.
- "+ Add" → "New access" panel was missing a back arrow. SyncConfigPanel's CreateView now accepts onBack and DataPageRightPanel passes backToAccessList in the sync_create branch.
- "Mode: Read &amp; Write" was rendering the literal &amp; (JSX string-literal trap, not text content). Replaced with a plain ampersand.

tsc --noEmit clean. Backend pytest mut_engine + security + sync + connect: 233 passed / 23 skipped.

<!--
Thanks for the PR! Please fill in the sections below so reviewers can move fast.
See CONTRIBUTING.md for the full workflow:
https://github.com/puppyone-ai/puppyone/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- One or two sentences: what does this PR change and why? -->

## Target branch

<!--
Default target should be `qubits` (staging). Only two PR types should target
`main`:
- release PRs from `qubits`
- same-repo urgent hotfix PRs from `hotfix/*`

All other PRs targeting `main` are blocked by the "Main Release Gate" CI job.
-->

- [ ] Base branch is **`qubits`** (or this is a `qubits` → `main` release PR / same-repo `hotfix/*` → `main` hotfix PR)

## Type of change

- [ ] feat — new feature
- [ ] fix — bug fix
- [ ] perf — performance improvement
- [ ] refactor — code change that is neither a fix nor a feature
- [ ] docs — documentation only
- [ ] chore — tooling, build, CI, deps
- [ ] hotfix — urgent production fix targeted at `main`

## Test plan

<!--
How did you verify this change? Examples:
- Ran `uv run pytest -m "unit"` locally — all green
- Manually tested the new endpoint with `curl ...`
- Verified UI in `npm run dev` at http://localhost:3000/foo
-->

## Linked issues

<!-- Use `Fixes #123` to auto-close, or `Refs #123` to reference. -->

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] My code follows the existing style (frontend: ESLint via `npm run lint`; backend: ruff via `uv run ruff format`)
- [ ] I have not committed any secrets, `.env` files, or credentials
- [ ] I have updated docs / comments where behaviour changed
- [ ] I have added or updated tests when adding logic that should be covered
