### PR TITLE
Fix qubits uv lock mutai source

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -80,16 +80,3 @@ asyncio_mode = "auto"
 markers = [
     "e2e: end-to-end tests that may call real external services",
 ]
-
-[tool.uv.sources]
-# Until the mut-git wire-format work lands on PyPI, every developer on the
-# ``mut-git`` branch needs the local ``../../mut`` source — the published
-# ``mutai 0.1.6`` is missing ``mut.foundation.git_format`` and the loose-
-# object ObjectStore. ``editable = true`` so changes to mut/ are picked up
-# without a re-sync.
-#
-# This dev-time override does NOT change public package metadata: the
-# regular ``mutai>=0.1.6`` entry in ``[project.dependencies]`` is what the
-# project's published wheel advertises.  Drop this section once the
-# git-format-storage release is on PyPI.
-mutai = { path = "../../mut", editable = true }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -507,7 +507,7 @@ requires-dist = [
     { name = "loguru", specifier = ">=0.7.2" },
     { name = "lxml", specifier = ">=5.0.0" },
     { name = "moto", extras = ["s3"], specifier = ">=5.0.0" },
-    { name = "mutai", editable = "../../mut" },
+    { name = "mutai", specifier = ">=0.1.6" },
     { name = "openai", specifier = ">=2.8.0" },
     { name = "pydantic", specifier = ">=2.12.4" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
@@ -1737,7 +1737,11 @@ wheels = [
 [[package]]
 name = "mutai"
 version = "0.1.6"
-source = { editable = "../../mut" }
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/80/1a/adcd9eb80e2cbf28aa5cd458412387afcd306441188df35dd76f6b7368e7/mutai-0.1.6.tar.gz", hash = "sha256:6b090859cd59d9b91d888d249aa91c76168f84a13fff1b84ada142c39b20a649", size = 118081, upload-time = "2026-04-17T13:34:17.325Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/69/e41fbd192f004173ee3967dc8a2fc2c28a23b66e8fa002040a09f12c2908/mutai-0.1.6-py3-none-any.whl", hash = "sha256:bd9bc18a973cc115e828841b0b5afcfa7ff632f8b1ffff6a42b2c795fc2cc7e5", size = 88931, upload-time = "2026-04-17T13:34:15.841Z" },
+]
 
 [[package]]
 name = "nest-asyncio"


### PR DESCRIPTION
<!--
Thanks for the PR! Please fill in the sections below so reviewers can move fast.
See CONTRIBUTING.md for the full workflow:
https://github.com/puppyone-ai/puppyone/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- One or two sentences: what does this PR change and why? -->

## Target branch

<!--
Default target should be `qubits` (staging). Only two PR types should target
`main`:
- release PRs from `qubits`
- same-repo urgent hotfix PRs from `hotfix/*`

All other PRs targeting `main` are blocked by the "Main Release Gate" CI job.
-->

- [ ] Base branch is **`qubits`** (or this is a `qubits` → `main` release PR / same-repo `hotfix/*` → `main` hotfix PR)

## Type of change

- [ ] feat — new feature
- [ ] fix — bug fix
- [ ] perf — performance improvement
- [ ] refactor — code change that is neither a fix nor a feature
- [ ] docs — documentation only
- [ ] chore — tooling, build, CI, deps
- [ ] hotfix — urgent production fix targeted at `main`

## Test plan

<!--
How did you verify this change? Examples:
- Ran `uv run pytest -m "unit"` locally — all green
- Manually tested the new endpoint with `curl ...`
- Verified UI in `npm run dev` at http://localhost:3000/foo
-->

## Linked issues

<!-- Use `Fixes #123` to auto-close, or `Refs #123` to reference. -->

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] My code follows the existing style (frontend: ESLint via `npm run lint`; backend: ruff via `uv run ruff format`)
- [ ] I have not committed any secrets, `.env` files, or credentials
- [ ] I have updated docs / comments where behaviour changed
- [ ] I have added or updated tests when adding logic that should be covered
