### PR TITLE
fix(deploy): re-point nixpacks mut override to feat/git-format-storage

### DIFF
--- a/backend/nixpacks.toml
+++ b/backend/nixpacks.toml
@@ -69,6 +69,16 @@ cmds = [
     # NOT spin up its own short-lived env that re-downloads them.
     ". /opt/venv/bin/activate && pip install --retries 5 'setuptools>=61.0' wheel || pip install --retries 5 'setuptools>=61.0' wheel",
     ". /opt/venv/bin/activate && pip install -e . --no-deps --no-build-isolation",
-    # Override mut with latest branch build (remove after mutai 0.1.8 is on PyPI)
-    ". /opt/venv/bin/activate && pip install --no-deps git+https://github.com/puppyone-ai/mut.git@fix/mut-scope-design-bug",
+    # Override mut with the git-format-storage branch — the published
+    # ``mutai 0.1.6`` on PyPI is missing ``mut.foundation.git_format``,
+    # ``branch``, ``messages`` and ``ws_client`` (verified by inspecting
+    # the wheel). 11 backend files have module-level imports of
+    # ``mut.foundation.git_format`` (server_repo, object_gc, tree_objects,
+    # git_commit, …), so without this override FastAPI fails at startup
+    # with ``ImportError: No module named 'mut.foundation.git_format'``.
+    # The previously pinned ``fix/mut-scope-design-bug`` branch ALSO
+    # lacked git_format — it predates the git-format-storage work.
+    # Remove this override once a mutai release with git_format is on PyPI
+    # and ``[project.dependencies]`` is bumped to that version.
+    ". /opt/venv/bin/activate && pip install --no-deps git+https://github.com/puppyone-ai/mut.git@feat/git-format-storage",
 ]


### PR DESCRIPTION
The previously pinned `fix/mut-scope-design-bug` branch lacks mut.foundation.git_format (and branch/messages/ws_client). With the editable local override removed in 2a0892d6, the deployed backend pulled mutai 0.1.6 from PyPI (also missing git_format) and tried to backfill from the git URL — but neither source had the module. 11 backend files have module-level imports of `mut.foundation.git_format`, so FastAPI fails at startup.

The `feat/git-format-storage` branch is the only mut branch that contains all required modules. Pin to it until a mutai release with git_format lands on PyPI.

<!--
Thanks for the PR! Please fill in the sections below so reviewers can move fast.
See CONTRIBUTING.md for the full workflow:
https://github.com/puppyone-ai/puppyone/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- One or two sentences: what does this PR change and why? -->

## Target branch

<!--
Default target should be `qubits` (staging). Only two PR types should target
`main`:
- release PRs from `qubits`
- same-repo urgent hotfix PRs from `hotfix/*`

All other PRs targeting `main` are blocked by the "Main Release Gate" CI job.
-->

- [ ] Base branch is **`qubits`** (or this is a `qubits` → `main` release PR / same-repo `hotfix/*` → `main` hotfix PR)

## Type of change

- [ ] feat — new feature
- [ ] fix — bug fix
- [ ] perf — performance improvement
- [ ] refactor — code change that is neither a fix nor a feature
- [ ] docs — documentation only
- [ ] chore — tooling, build, CI, deps
- [ ] hotfix — urgent production fix targeted at `main`

## Test plan

<!--
How did you verify this change? Examples:
- Ran `uv run pytest -m "unit"` locally — all green
- Manually tested the new endpoint with `curl ...`
- Verified UI in `npm run dev` at http://localhost:3000/foo
-->

## Linked issues

<!-- Use `Fixes #123` to auto-close, or `Refs #123` to reference. -->

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] My code follows the existing style (frontend: ESLint via `npm run lint`; backend: ruff via `uv run ruff format`)
- [ ] I have not committed any secrets, `.env` files, or credentials
- [ ] I have updated docs / comments where behaviour changed
- [ ] I have added or updated tests when adding logic that should be covered
