### PR TITLE
fix(deploy): add --force-reinstall so mut git override actually applies

### DIFF
--- a/backend/nixpacks.toml
+++ b/backend/nixpacks.toml
@@ -74,11 +74,21 @@ cmds = [
     # ``branch``, ``messages`` and ``ws_client`` (verified by inspecting
     # the wheel). 11 backend files have module-level imports of
     # ``mut.foundation.git_format`` (server_repo, object_gc, tree_objects,
-    # git_commit, …), so without this override FastAPI fails at startup
-    # with ``ImportError: No module named 'mut.foundation.git_format'``.
+    # git_commit, …), so without this override FastAPI / arq workers
+    # fail at startup with
+    # ``ModuleNotFoundError: No module named 'mut.foundation.git_format'``.
+    #
+    # ``--force-reinstall`` is REQUIRED: the previous step's
+    # ``pip install -r requirements.lock.txt`` already installed
+    # ``mutai 0.1.6`` from PyPI, and the git URL's pyproject also reports
+    # version 0.1.6. Without --force-reinstall, pip reports "Requirement
+    # already satisfied" and silently keeps the PyPI wheel (the one
+    # missing git_format). This was the cause of the May 16 16:08 deploy
+    # failure even after the branch pin was corrected.
+    #
     # The previously pinned ``fix/mut-scope-design-bug`` branch ALSO
     # lacked git_format — it predates the git-format-storage work.
     # Remove this override once a mutai release with git_format is on PyPI
     # and ``[project.dependencies]`` is bumped to that version.
-    ". /opt/venv/bin/activate && pip install --no-deps git+https://github.com/puppyone-ai/mut.git@feat/git-format-storage",
+    ". /opt/venv/bin/activate && pip install --no-deps --force-reinstall git+https://github.com/puppyone-ai/mut.git@feat/git-format-storage",
 ]


### PR DESCRIPTION
The first fix re-pointed the override branch from
fix/mut-scope-design-bug → feat/git-format-storage, but the deploy still failed with ModuleNotFoundError because pip silently skipped the git install: requirements.lock.txt had already installed mutai 0.1.6 from PyPI, the git branch's pyproject also reports 0.1.6, so pip reported "Requirement already satisfied" and the PyPI wheel (missing git_format) was never replaced. --force-reinstall forces the install regardless of installed version.

<!--
Thanks for the PR! Please fill in the sections below so reviewers can move fast.
See CONTRIBUTING.md for the full workflow:
https://github.com/puppyone-ai/puppyone/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- One or two sentences: what does this PR change and why? -->

## Target branch

<!--
Default target should be `qubits` (staging). Only two PR types should target
`main`:
- release PRs from `qubits`
- same-repo urgent hotfix PRs from `hotfix/*`

All other PRs targeting `main` are blocked by the "Main Release Gate" CI job.
-->

- [ ] Base branch is **`qubits`** (or this is a `qubits` → `main` release PR / same-repo `hotfix/*` → `main` hotfix PR)

## Type of change

- [ ] feat — new feature
- [ ] fix — bug fix
- [ ] perf — performance improvement
- [ ] refactor — code change that is neither a fix nor a feature
- [ ] docs — documentation only
- [ ] chore — tooling, build, CI, deps
- [ ] hotfix — urgent production fix targeted at `main`

## Test plan

<!--
How did you verify this change? Examples:
- Ran `uv run pytest -m "unit"` locally — all green
- Manually tested the new endpoint with `curl ...`
- Verified UI in `npm run dev` at http://localhost:3000/foo
-->

## Linked issues

<!-- Use `Fixes #123` to auto-close, or `Refs #123` to reference. -->

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] My code follows the existing style (frontend: ESLint via `npm run lint`; backend: ruff via `uv run ruff format`)
- [ ] I have not committed any secrets, `.env` files, or credentials
- [ ] I have updated docs / comments where behaviour changed
- [ ] I have added or updated tests when adding logic that should be covered
