### PR TITLE
fix(ingest): import HASH_LEN from mut.foundation.config not .hash

### DIFF
--- a/backend/src/ingest/file/jobs/jobs.py
+++ b/backend/src/ingest/file/jobs/jobs.py
@@ -15,7 +15,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-from mut.foundation.hash import HASH_LEN
+from mut.foundation.config import HASH_LEN
 from mut.foundation.hash import hash_bytes as mut_hash
 
 from src.infra.supabase.client import SupabaseClient


### PR DESCRIPTION
HASH_LEN is defined in mut.foundation.config (constant block alongside GIT_DIR / MUT_DIR / etc.), not in mut.foundation.hash. The wrong import path made the file_worker container fail at startup with:

  ImportError: cannot import name 'HASH_LEN' from 'mut.foundation.hash'

This appeared after the deploy started picking up the feat/git-format-storage branch via the nixpacks override — both branches put HASH_LEN in config; the .hash path never existed in mainline mut and was likely a typo masked locally by a previous editable install that had a different layout.

<!--
Thanks for the PR! Please fill in the sections below so reviewers can move fast.
See CONTRIBUTING.md for the full workflow:
https://github.com/puppyone-ai/puppyone/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- One or two sentences: what does this PR change and why? -->

## Target branch

<!--
Default target should be `qubits` (staging). Only two PR types should target
`main`:
- release PRs from `qubits`
- same-repo urgent hotfix PRs from `hotfix/*`

All other PRs targeting `main` are blocked by the "Main Release Gate" CI job.
-->

- [ ] Base branch is **`qubits`** (or this is a `qubits` → `main` release PR / same-repo `hotfix/*` → `main` hotfix PR)

## Type of change

- [ ] feat — new feature
- [ ] fix — bug fix
- [ ] perf — performance improvement
- [ ] refactor — code change that is neither a fix nor a feature
- [ ] docs — documentation only
- [ ] chore — tooling, build, CI, deps
- [ ] hotfix — urgent production fix targeted at `main`

## Test plan

<!--
How did you verify this change? Examples:
- Ran `uv run pytest -m "unit"` locally — all green
- Manually tested the new endpoint with `curl ...`
- Verified UI in `npm run dev` at http://localhost:3000/foo
-->

## Linked issues

<!-- Use `Fixes #123` to auto-close, or `Refs #123` to reference. -->

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] My code follows the existing style (frontend: ESLint via `npm run lint`; backend: ruff via `uv run ruff format`)
- [ ] I have not committed any secrets, `.env` files, or credentials
- [ ] I have updated docs / comments where behaviour changed
- [ ] I have added or updated tests when adding logic that should be covered
