### PR TITLE
docs: add getting-started guide for contributors

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@ PuppyOne is a Git-native cloud filesystem for AI agents and teams.
 
 Read in this order:
 
+0. [Getting Started (developers & contributors)](getting-started.md)
 1. [Architecture Vision](architecture/00-vision.md)
 2. [Version Engine](architecture/01-version-engine.md)
 3. [Access Points](architecture/02-access-points.md)
@@ -12,6 +13,8 @@ Read in this order:
 6. [Git Remote Access Point Flow](architecture/05-git-remote-accesspoint.md)
 7. [Gateway And Access Boundary](architecture/06-gateway-access-point-split.md)
 8. [Shadow Snapshots](architecture/08-shadow-snapshots.md)
+
+For product onboarding (install CLI, first project), see the [root README](../README.md).
 
 The current source of truth for versioning is `backend/src/version_engine/`.
 Old protocol-era architecture notes were removed from the active docs so they

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,117 @@
+# Getting Started (Developers & Contributors)
+
+This guide is for people who clone the repo to **run PuppyOne locally** or **open a pull request**. For product onboarding (CLI, first project, connectors), see the [README](../README.md).
+
+## Prerequisites
+
+| Path | What you need |
+|------|----------------|
+| **Docker (recommended)** | [Docker](https://www.docker.com/) only — full stack via Compose |
+| **Native dev** | Python 3.12+, [uv](https://docs.astral.sh/uv/), Node.js 18+, npm |
+
+## Option A: Self-hosted stack (Docker)
+
+Fastest way to run everything without wiring cloud services manually:
+
+```bash
+git clone https://github.com/puppyone-ai/puppyone.git
+cd puppyone/docker
+cp .env.example .env
+docker compose up -d
+```
+
+| Service | URL |
+|---------|-----|
+| Frontend | http://localhost:3000 |
+| Backend API | http://localhost:9090 |
+| Supabase API | http://localhost:8000 |
+
+First startup can take 1–2 minutes. Optional: add `ANTHROPIC_API_KEY` and OAuth provider keys to `docker/.env` for agent chat and SaaS connectors (see [README](../README.md#3-optional-enable-more-features)).
+
+## Option B: Native backend + frontend
+
+Use this when you are changing application code and want hot reload.
+
+### 1. Environment files
+
+```bash
+cp backend/.env.example backend/.env
+cp frontend/.env.example frontend/.env
+```
+
+Fill in Supabase, S3/LocalStack, and other values described in the example files. **Never commit `.env`.**
+
+For a minimal local API without full cloud deps, some teams use `SKIP_AUTH=true` in `backend/.env` during development — only on trusted machines.
+
+### 2. Backend
+
+```bash
+cd backend
+uv sync
+uv run uvicorn src.main:app --host 0.0.0.0 --port 9090 --reload --log-level info --no-access-log
+```
+
+### 3. Frontend
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+Open http://localhost:3000. Set `NEXT_PUBLIC_API_URL=http://localhost:9090` in `frontend/.env` if it is not already the default.
+
+### 4. CLI (optional)
+
+```bash
+npm install -g puppyone
+puppyone auth login
+# Self-hosted API: choose Local or pass -u http://localhost:9090
+```
+
+## Run tests
+
+From `backend/`:
+
+```bash
+uv run pytest -m "unit"          # fast, no external services
+uv run pytest -m "not e2e"       # exclude full-stack e2e
+```
+
+See [CONTRIBUTING.md](../CONTRIBUTING.md#testing) for unit / integration / contract / e2e layers.
+
+## Repository layout (active code)
+
+| Directory | Role |
+|-----------|------|
+| `backend/` | FastAPI API, MUT engine, connectors |
+| `frontend/` | Next.js web app |
+| `cli/` | `puppyone` CLI |
+| `docs/` | Architecture and design docs |
+| `docker/` | Local Compose stack |
+
+**Do not modify** deprecated trees: `PuppyEngine/`, `PuppyFlow/`, `PuppyStorage/`, `tools/` (see root [AGENTS.md](../AGENTS.md)).
+
+## Next steps
+
+| Goal | Document |
+|------|----------|
+| Architecture & module map | [AGENTS.md](../AGENTS.md) |
+| Branch model, PR target, CI | [CONTRIBUTING.md](../CONTRIBUTING.md) |
+| MUT / Access Point / CLI design | [docs/README.md](README.md) |
+| End-user product flow | [README](../README.md) |
+
+## Opening your first PR
+
+1. Fork `puppyone-ai/puppyone` on GitHub (if you are an external contributor).
+2. Branch from **`qubits`**, not `main`:
+
+   ```bash
+   git fetch origin
+   git checkout -b docs/my-change origin/qubits
+   ```
+
+3. Keep the PR small (docs-only PRs are a good first contribution).
+4. Open the PR with **base branch `qubits`** and fill in the [PR template](../.github/PULL_REQUEST_TEMPLATE.md).
+
+Production (`main`) only receives changes through maintainer release PRs; contributor PRs to `qubits` do not deploy to production directly.


### PR DESCRIPTION
Fixes the broken link from CONTRIBUTING.md and documents local setup paths (Docker vs native), tests, and first PR workflow.

<!--
Thanks for the PR! Please fill in the sections below so reviewers can move fast.
See CONTRIBUTING.md for the full workflow:
https://github.com/puppyone-ai/puppyone/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- One or two sentences: what does this PR change and why? -->

## Target branch

<!--
Default target should be `qubits` (staging). Only two PR types should target
`main`:
- release PRs from `qubits`
- same-repo urgent hotfix PRs from `hotfix/*`

All other PRs targeting `main` are blocked by the "Main Release Gate" CI job.
-->

- [ ] Base branch is **`qubits`** (or this is a `qubits` → `main` release PR / same-repo `hotfix/*` → `main` hotfix PR)

## Type of change

- [ ] feat — new feature
- [ ] fix — bug fix
- [ ] perf — performance improvement
- [ ] refactor — code change that is neither a fix nor a feature
- [ ] docs — documentation only
- [ ] chore — tooling, build, CI, deps
- [ ] hotfix — urgent production fix targeted at `main`

## Test plan

<!--
How did you verify this change? Examples:
- Ran `uv run pytest -m "unit"` locally — all green
- Manually tested the new endpoint with `curl ...`
- Verified UI in `npm run dev` at http://localhost:3000/foo
-->

## Linked issues

<!-- Use `Fixes #123` to auto-close, or `Refs #123` to reference. -->

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] My code follows the existing style (frontend: ESLint via `npm run lint`; backend: ruff via `uv run ruff format`)
- [ ] I have not committed any secrets, `.env` files, or credentials
- [ ] I have updated docs / comments where behaviour changed
- [ ] I have added or updated tests when adding logic that should be covered
