### PR TITLE
fix: puppyone login, file upload, members invaite issues

### DIFF
--- a/backend/scripts/railway_today_features.py
+++ b/backend/scripts/railway_today_features.py
@@ -256,9 +256,10 @@ class TodaySmoke:
         the response. If the caller's org has reached its seat limit
         (the most common test-account state — free plan default is 1
         seat, user is their own owner = limit already met), the
-        endpoint returns the proper FORBIDDEN 403 instead. We accept
-        either outcome and skip downstream tests in the 403 case so
-        the rest of the suite isn't blocked by a product limit."""
+        endpoint returns ``HTTP 400`` with ``code=1003`` (FORBIDDEN
+        domain code, with AppException's default status_code=400) and
+        a "Seat limit reached" message. We accept that outcome as a
+        PASS for this step and skip the downstream tests."""
         org_id = self._resolve_org_id()
         self._org_id = org_id
         target = f"pup4-test+{uuid.uuid4().hex[:8]}@example.invalid"
@@ -267,19 +268,17 @@ class TodaySmoke:
             f"/api/v1/organizations/{org_id}/invite",
             json={"email": target, "role": "member"},
         )
-        # 200 = success path, 403 = seat-limit gate. Anything else is a bug.
-        assert r.status_code in (200, 403), (
+        # 200 = success path; 400/403 with a seat-limit message = gate
+        # fired. Anything else is a real bug.
+        assert r.status_code in (200, 400, 403), (
             f"unexpected HTTP {r.status_code}: {r.text[:300]}"
         )
         body = r.json()
-        if r.status_code == 403:
-            # Accept the proper seat-limit message as PASS for this
-            # step. The downstream tests that need a real invitation
-            # check ``self.invitation_id`` and self-skip.
-            assert "seat limit" in body.get("message", "").lower(), (
-                f"unexpected 403 message: {body}"
-            )
-            return f"seat limit hit (expected on free plan): {body['message']!r}"
+        if r.status_code in (400, 403):
+            msg = (body.get("message") or "").lower()
+            if "seat limit" in msg:
+                return f"seat limit hit (expected on free plan): {body['message']!r}"
+            raise AssertionError(f"unexpected {r.status_code} message: {body}")
         data = body["data"]
         assert data.get("token"), f"no token in response: {data}"
         assert data.get("invite_url"), f"no invite_url: {data}"
@@ -358,8 +357,10 @@ class TodaySmoke:
             f"/api/v1/organizations/{self._org_id}/invite",
             json={"email": target, "role": "member"},
         )
-        if r.status_code == 403:
-            return "SKIP (seat limit gate — accept needs a fresh invite)"
+        if r.status_code in (400, 403):
+            msg = (r.json().get("message") or "").lower()
+            if "seat limit" in msg:
+                return "SKIP (seat limit gate — accept needs a fresh invite)"
         body = self._expect(r, 200, hint="invite for accept test")
         token = body["data"]["token"]
         inv_id = body["data"]["id"]
@@ -381,6 +382,70 @@ class TodaySmoke:
                 )
             except Exception:
                 pass
+
+    # ── Project share link (today's MVP, deployed alongside PUP-4) ──
+
+    def project_share_info_returns_token(self):
+        """GET /projects/{pid}/share returns a non-empty token for the
+        owner. The migration backfills tokens onto every existing row,
+        and ``create()`` generates a fresh one for new rows — so any
+        project should answer cleanly."""
+        r = self.client.get(f"/api/v1/projects/{self.project_id}/share")
+        body = self._expect(r, 200, hint="get share info")
+        data = body["data"]
+        assert data.get("can_share") is True, f"expected can_share=True: {data}"
+        token = data.get("share_token") or ""
+        assert len(token) >= 16, f"share_token looks bogus: {token!r}"
+        self._initial_share_token = token
+        return f"got token (len={len(token)}) can_share=True"
+
+    def project_share_rotate_invalidates_old(self):
+        """Rotate should replace the token; the new value must differ
+        from the previous one (cryptographic regen, not idempotent)."""
+        prev = getattr(self, "_initial_share_token", "")
+        r = self.client.post(f"/api/v1/projects/{self.project_id}/share/rotate")
+        body = self._expect(r, 200, hint="rotate share token")
+        new_token = body["data"]["share_token"]
+        assert new_token, f"rotate returned empty token: {body}"
+        assert new_token != prev, (
+            f"rotate didn't change the token (prev={prev[:8]} new={new_token[:8]})"
+        )
+        self._current_share_token = new_token
+        return f"rotated: prev={prev[:8]}… new={new_token[:8]}…"
+
+    def project_share_join_idempotent_for_owner(self):
+        """Joining via the current token when you're already the
+        project owner is a no-op — the service returns the existing
+        membership with ``newly_joined=False``. Verifies the
+        idempotency path works."""
+        token = getattr(self, "_current_share_token", "")
+        if not token:
+            return "SKIP (no token captured — earlier rotate failed)"
+        r = self.client.post(f"/api/v1/projects/share/{token}/join")
+        body = self._expect(r, 200, hint="join via share token")
+        data = body["data"]
+        assert data["project_id"] == self.project_id
+        assert data["newly_joined"] is False, (
+            f"owner shouldn't be 'newly joined': {data}"
+        )
+        assert data["role"], f"role should be set: {data}"
+        return (
+            f"owner already member; role={data['role']!r} project_name={data['project_name']!r}"
+        )
+
+    def project_share_join_rejects_old_token(self):
+        """The token captured BEFORE the rotate must now 404. This is
+        the revoke-by-rotation semantics — anyone holding the previous
+        link sees the same 'invalid' error as someone who never had a
+        token, so the link doesn't leak existence after revocation."""
+        old = getattr(self, "_initial_share_token", "")
+        if not old:
+            return "SKIP (no pre-rotate token)"
+        r = self.client.post(f"/api/v1/projects/share/{old}/join")
+        assert r.status_code == 404, (
+            f"expected 404 on rotated-out token, got {r.status_code}: {r.text[:200]}"
+        )
+        return "rotated-out token correctly returns 404"
 
     # ── Bulk-push regression (shadow path is a stand-in for full
     #    multipart upload, since the deep test can't easily do the
@@ -457,6 +522,12 @@ class TodaySmoke:
         self.step("PUP-4. DELETE /invitations/{id} revokes", self.revoke_invitation)
         self.step("PUP-4. revoke is idempotent (second call → 200)", self.revoke_idempotent)
         self.step("PUP-4. /invitations/{token}/accept returns org payload", self.accept_returns_org_payload)
+
+        # Project share link (today's MVP)
+        self.step("Share. GET /projects/{pid}/share returns token", self.project_share_info_returns_token)
+        self.step("Share. POST /share/rotate produces new token", self.project_share_rotate_invalidates_old)
+        self.step("Share. Owner join via new token is idempotent", self.project_share_join_idempotent_for_owner)
+        self.step("Share. Rotated-out token returns 404", self.project_share_join_rejects_old_token)
 
         # Bulk push regression (real content path)
         self.step("Regression. Shadow promote with >500-char content", self.shadow_promote_with_real_content)

--- a/backend/src/version_engine/infrastructure/s3/object_storage.py
+++ b/backend/src/version_engine/infrastructure/s3/object_storage.py
@@ -828,7 +828,21 @@ class S3StorageBackend(StorageBackend):
                     object_id=h[:12],
                 ):
                     data = _run_async(self._s3.download_file(key))
-                _verify_loose_hash(h, data)
+                try:
+                    _verify_loose_hash(h, data)
+                except StorageWriteError as verify_err:
+                    # Stale entry in the deferred-read namespace —
+                    # the bytes here aren't a valid Git loose object,
+                    # which can happen when pre-Git-native code wrote
+                    # raw payloads under what is now a loose-object
+                    # key. Self-heal: treat exactly like 404 so the
+                    # engine falls through to the next read path, and
+                    # best-effort delete the stale object so the next
+                    # request doesn't trip the same wire (a manual
+                    # ``aws s3 rm`` per affected blob is the wrong
+                    # ops contract — every user must auto-recover).
+                    self._auto_delete_stale_deferred(key, h, verify_err)
+                    continue
                 self._mark_deferred_namespace_read(h, kind="loose")
                 return data
             except ObjectNotFoundError:
@@ -838,6 +852,34 @@ class S3StorageBackend(StorageBackend):
                     continue
                 raise
         return None
+
+    def _auto_delete_stale_deferred(
+        self,
+        key: str,
+        object_id: str,
+        cause: Exception,
+    ) -> None:
+        """Best-effort delete of a deferred-namespace key whose bytes
+        failed loose-object verification.
+
+        Failures here are swallowed. The cleanup is purely
+        opportunistic — if S3 won't let us delete (permissions, eventual
+        consistency, etc.) the next read will still treat the same key
+        as "stale, skip" because verification will fail again. The
+        long-running cost of leaving the row is one extra GET+verify
+        per read; the cost of failing the user's request is unbounded,
+        so silent recovery wins.
+        """
+        log_warning(
+            f"[VersionS3] stale deferred-namespace blob at {key} "
+            f"(hash={object_id[:12]}): {cause}. Auto-cleaning.",
+        )
+        try:
+            _run_async(self._s3.delete_file(key))
+        except Exception as del_err:
+            log_warning(
+                f"[VersionS3] failed to clean stale {key}: {del_err}",
+            )
 
     def _deferred_loose_exists(self, h: str) -> bool:
         for key in self._deferred_keys_for(h):
@@ -905,7 +947,15 @@ class S3StorageBackend(StorageBackend):
                     object_id=h[:12],
                 ):
                     data = await self._s3.download_file(key)
-                _verify_loose_hash(h, data)
+                try:
+                    _verify_loose_hash(h, data)
+                except StorageWriteError as verify_err:
+                    # See ``_get_deferred_loose`` for the rationale —
+                    # this is the async mirror of the same self-heal.
+                    await self._auto_delete_stale_deferred_async(
+                        key, h, verify_err,
+                    )
+                    continue
                 self._mark_deferred_namespace_read(h, kind="loose")
                 return data
             except ObjectNotFoundError:
@@ -915,6 +965,25 @@ class S3StorageBackend(StorageBackend):
                     continue
                 raise
         return None
+
+    async def _auto_delete_stale_deferred_async(
+        self,
+        key: str,
+        object_id: str,
+        cause: Exception,
+    ) -> None:
+        """Async counterpart of ``_auto_delete_stale_deferred``.
+        Same opportunistic, swallow-failures semantics."""
+        log_warning(
+            f"[VersionS3] stale deferred-namespace blob at {key} "
+            f"(hash={object_id[:12]}): {cause}. Auto-cleaning (async).",
+        )
+        try:
+            await self._s3.delete_file(key)
+        except Exception as del_err:
+            log_warning(
+                f"[VersionS3] failed to clean stale {key}: {del_err}",
+            )
 
     async def _async_deferred_loose_exists(self, h: str) -> bool:
         for key in self._deferred_keys_for(h):

--- a/backend/tests/version_engine/test_deferred_loose_self_heal.py
+++ b/backend/tests/version_engine/test_deferred_loose_self_heal.py
@@ -1,0 +1,246 @@
+"""Self-heal for stale bytes in the deferred-read namespace.
+
+The legacy pre-Git-native finalize path (server-side ``copy_object``
+from the upload staging key) wrote **raw** user/tree payloads under
+keys that the current Git-native object store reads as loose Git
+objects. When the store falls back to the deferred namespace and
+zlib-decompresses those bytes, ``_verify_loose_hash`` raises
+``StorageWriteError("invalid git loose object …")`` and the user-
+facing bulk push surface dies with:
+
+    Bulk push failed: invalid git loose object for {hash}:
+    Error -3 while decompressing data: incorrect header check
+
+We cannot ask every affected user to ``aws s3 rm`` the orphan bytes —
+those keys must self-heal at read time. The behavior contract being
+asserted here:
+
+  1. Reading a hash whose ONLY presence is stale deferred-namespace
+     bytes must NOT raise ``StorageWriteError`` (or any other zlib
+     surfaced error). The engine treats it as 404 so callers can
+     fall through to a clean "missing blob" error path.
+  2. The stale S3 object is best-effort deleted as a side-effect, so
+     the next read of the same hash takes the 404 fast path
+     instead of re-paying the GET + verify dance.
+  3. Both the sync ``get()`` and ``async_get()`` paths self-heal.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.version_engine.domain.errors import ObjectNotFoundError
+from src.version_engine.infrastructure.s3.object_storage import (
+    S3StorageBackend,
+    _DEFERRED_STORAGE_NAMESPACE,
+)
+
+
+class _StubS3:
+    """In-memory S3 stub keyed by full S3 key.
+
+    Tracks every ``download_file`` and ``delete_file`` call so tests
+    can assert (a) what the engine fetched and (b) what got cleaned up.
+    """
+
+    def __init__(self) -> None:
+        self.bytes_by_key: dict[str, bytes] = {}
+        self.download_calls: list[str] = []
+        self.delete_calls: list[str] = []
+        self.bucket_name = "test-bucket"
+
+    async def download_file(self, key: str) -> bytes:
+        self.download_calls.append(key)
+        if key not in self.bytes_by_key:
+            # Match the production not-found detection (see
+            # ``_is_not_found_error``): the message has to contain one
+            # of "not found" / "nosuchkey" / "404" / "does not exist"
+            # so the engine treats it as a 404 fall-through rather
+            # than a fatal error.
+            from src.infra.s3.exceptions import S3FileNotFoundError
+            raise S3FileNotFoundError(key)
+        return self.bytes_by_key[key]
+
+    async def file_exists(self, key: str) -> bool:
+        return key in self.bytes_by_key
+
+    async def delete_file(self, key: str) -> None:
+        self.delete_calls.append(key)
+        self.bytes_by_key.pop(key, None)
+
+    async def upload_file(self, key: str, data: bytes, content_type: str = "") -> None:
+        self.bytes_by_key[key] = data
+
+
+def _supabase_wrapper():
+    """Return a no-op Supabase wrapper. The deferred-loose read path
+    doesn't touch ``mut_object_locations``, but the backend constructor
+    expects something with the right shape."""
+    wrap = MagicMock()
+    wrap.client.table.return_value.select.return_value.eq.return_value.in_.return_value.execute.return_value.data = []
+    return wrap
+
+
+# ── Fixtures ─────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def stub_s3() -> _StubS3:
+    return _StubS3()
+
+
+@pytest.fixture
+def project_id() -> str:
+    return "test-proj-019"
+
+
+@pytest.fixture
+def backend(stub_s3: _StubS3, project_id: str) -> S3StorageBackend:
+    """A backend with deferred-namespace reads ON — that's the read
+    path under test."""
+    return S3StorageBackend(
+        stub_s3,
+        project_id=project_id,
+        supabase=_supabase_wrapper(),
+        allow_deferred_namespace_reads=True,
+    )
+
+
+# ── Helpers ──────────────────────────────────────────────────────
+
+
+def _stale_deferred_key(project_id: str, hash_hex: str) -> str:
+    """The same key shape the production code uses for deferred-namespace
+    reads: ``{namespace}/{project_id}/objects/{shard}/{rest}``."""
+    return (
+        f"{_DEFERRED_STORAGE_NAMESPACE}/{project_id}/objects/"
+        f"{hash_hex[:2]}/{hash_hex[2:]}"
+    )
+
+
+def _primary_loose_key(backend: S3StorageBackend, hash_hex: str) -> str:
+    """The current-namespace loose key the backend would write to."""
+    return backend._key_for(hash_hex)
+
+
+# ── Tests ────────────────────────────────────────────────────────
+
+
+class TestDeferredLooseSelfHeal:
+    """Sync path."""
+
+    def test_stale_deferred_bytes_do_not_propagate_zlib_error(
+        self, backend: S3StorageBackend, stub_s3: _StubS3, project_id: str,
+    ) -> None:
+        """``get(h)`` for a hash whose ONLY presence is stale raw bytes
+        in the deferred namespace must NOT raise ``StorageWriteError``
+        — that's what surfaces as ``Bulk push failed: invalid git
+        loose object``. Instead the engine should report a clean
+        ``ObjectNotFoundError`` so the caller knows the blob is
+        genuinely missing.
+        """
+        # Same hash + same kind of bytes the production bug exposed:
+        # a JSON tree payload from the pre-Git protocol that happens
+        # to live under what the current code reads as a loose-object
+        # key.
+        h = "520885e2ece1037b" + "0" * 24  # 40-char hex sha1
+        stale_bytes = b'{".trash": ["T", "garbage"], "Note.md": ["B", "..."]}'
+        stub_s3.bytes_by_key[_stale_deferred_key(project_id, h)] = stale_bytes
+
+        with pytest.raises(ObjectNotFoundError):
+            backend.get(h)
+
+    def test_stale_deferred_bytes_auto_delete_on_first_read(
+        self, backend: S3StorageBackend, stub_s3: _StubS3, project_id: str,
+    ) -> None:
+        """The stale entry must be best-effort deleted so subsequent
+        reads short-circuit on 404 rather than re-paying the GET +
+        verify dance.
+        """
+        h = "5" + "a" * 39
+        stale_key = _stale_deferred_key(project_id, h)
+        stub_s3.bytes_by_key[stale_key] = b"not zlib"
+
+        # First read self-heals.
+        with pytest.raises(ObjectNotFoundError):
+            backend.get(h)
+        assert stale_key in stub_s3.delete_calls, (
+            f"expected auto-delete of {stale_key}; saw deletes={stub_s3.delete_calls}"
+        )
+        # And the stub really applied the delete.
+        assert stale_key not in stub_s3.bytes_by_key
+
+    def test_valid_loose_in_primary_namespace_is_preferred(
+        self, backend: S3StorageBackend, stub_s3: _StubS3, project_id: str,
+    ) -> None:
+        """Even if a stale entry exists in the deferred namespace, a
+        valid loose object in the PRIMARY namespace must be returned
+        without ever touching the stale key (production order:
+        primary loose → deferred loose → packed)."""
+        import hashlib
+        import zlib
+
+        content = b"hello world"
+        framed = b"blob " + str(len(content)).encode() + b"\0" + content
+        h = hashlib.sha1(framed).hexdigest()
+        loose_bytes = zlib.compress(framed)
+
+        # Stale entry sits in deferred namespace, valid bytes in primary.
+        stub_s3.bytes_by_key[_stale_deferred_key(project_id, h)] = b"junk"
+        stub_s3.bytes_by_key[_primary_loose_key(backend, h)] = loose_bytes
+
+        # Primary read wins; the stale key is never fetched.
+        out = backend.get(h)
+        assert out == loose_bytes
+        assert _stale_deferred_key(project_id, h) not in stub_s3.download_calls
+
+    def test_valid_bytes_in_deferred_still_returned(
+        self, backend: S3StorageBackend, stub_s3: _StubS3, project_id: str,
+    ) -> None:
+        """The fallback path is still functional for the LEGITIMATE
+        case it was designed for — valid loose bytes in the deferred
+        namespace (a project pre-migration) should be returned, not
+        rejected as stale."""
+        import hashlib
+        import zlib
+
+        content = b"legacy but valid content"
+        framed = b"blob " + str(len(content)).encode() + b"\0" + content
+        h = hashlib.sha1(framed).hexdigest()
+        loose_bytes = zlib.compress(framed)
+
+        # Only in deferred — no primary copy.
+        stub_s3.bytes_by_key[_stale_deferred_key(project_id, h)] = loose_bytes
+
+        out = backend.get(h)
+        assert out == loose_bytes
+        # And no delete — these bytes are valid.
+        assert stub_s3.delete_calls == []
+
+
+class TestDeferredLooseSelfHealAsync:
+    """Async path mirror — same contract, same regressions."""
+
+    @pytest.mark.asyncio
+    async def test_async_stale_deferred_bytes_do_not_propagate_zlib_error(
+        self, backend: S3StorageBackend, stub_s3: _StubS3, project_id: str,
+    ) -> None:
+        h = "520885e2ece1037b" + "1" * 24
+        stub_s3.bytes_by_key[_stale_deferred_key(project_id, h)] = b'{"not": "loose"}'
+
+        with pytest.raises(ObjectNotFoundError):
+            await backend.async_get(h)
+
+    @pytest.mark.asyncio
+    async def test_async_stale_deferred_bytes_auto_delete(
+        self, backend: S3StorageBackend, stub_s3: _StubS3, project_id: str,
+    ) -> None:
+        h = "5" + "b" * 39
+        stale_key = _stale_deferred_key(project_id, h)
+        stub_s3.bytes_by_key[stale_key] = b"not zlib"
+
+        with pytest.raises(ObjectNotFoundError):
+            await backend.async_get(h)
+        assert stale_key in stub_s3.delete_calls


### PR DESCRIPTION
<!--
Thanks for the PR! Please fill in the sections below so reviewers can move fast.
See CONTRIBUTING.md for the full workflow:
https://github.com/puppyone-ai/puppyone/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- One or two sentences: what does this PR change and why? -->

## Target branch

<!--
Default target should be `qubits` (staging). Only two PR types should target
`main`:
- release PRs from `qubits`
- same-repo urgent hotfix PRs from `hotfix/*`

All other PRs targeting `main` are blocked by the "Main Release Gate" CI job.
-->

- [ ] Base branch is **`qubits`** (or this is a `qubits` → `main` release PR / same-repo `hotfix/*` → `main` hotfix PR)

## Type of change

- [ ] feat — new feature
- [ ] fix — bug fix
- [ ] perf — performance improvement
- [ ] refactor — code change that is neither a fix nor a feature
- [ ] docs — documentation only
- [ ] chore — tooling, build, CI, deps
- [ ] hotfix — urgent production fix targeted at `main`

## Test plan

<!--
How did you verify this change? Examples:
- Ran `uv run pytest -m "unit"` locally — all green
- Manually tested the new endpoint with `curl ...`
- Verified UI in `npm run dev` at http://localhost:3000/foo
-->

## Linked issues

<!-- Use `Fixes #123` to auto-close, or `Refs #123` to reference. -->

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] My code follows the existing style (frontend: ESLint via `npm run lint`; backend: ruff via `uv run ruff format`)
- [ ] I have not committed any secrets, `.env` files, or credentials
- [ ] I have updated docs / comments where behaviour changed
- [ ] I have added or updated tests when adding logic that should be covered
