### PR TITLE
fix(/ap-fs/search): silence Turbopuffer NotFound for fresh projects

### DIFF
--- a/backend/src/version_engine/entrypoints/http/access_point_fs.py
+++ b/backend/src/version_engine/entrypoints/http/access_point_fs.py
@@ -1230,6 +1230,77 @@ class _SearchRequest(_BaseModel):
     limit: int = 20
 
 
+async def _run_semantic_channel(
+    *,
+    project_id: str,
+    combined_scope: str,
+    query: str,
+    limit: int,
+) -> tuple[list[dict], str]:
+    """Run the Turbopuffer-backed semantic channel for ``/ap-fs/search``.
+
+    Returned tuple is ``(hits, semantic_error)``. Pulled out of the
+    endpoint body so the request handler stays readable and the
+    exception ladder for "expected fresh-project" vs "ops misconfig"
+    vs "unexpected" lives in one place.
+
+    Failure-mode mapping:
+
+      - ``TurbopufferNotFound`` / ``FileNotFoundError``
+            Namespace doesn't exist (no semantic indexing has run on
+            this scope yet) or the JSON-tree indexer's source file
+            isn't there. Both are normal "nothing to find" states;
+            ``semantic_error`` stays empty so the CLI doesn't show a
+            spooky red banner.
+      - ``TurbopufferConfigError``
+            Server-side API key / region missing. Ops needs to see
+            this; ``semantic_error`` carries a one-line hint.
+      - anything else
+            Likely transient (network, auth, SDK). Surfaced as
+            ``semantic_error`` so the CLI can render "unavailable"
+            without crashing the response.
+
+    The literal channel always runs alongside this so the user still
+    gets results even when semantic returns nothing.
+    """
+    from src.infra.turbopuffer.exceptions import (
+        TurbopufferNotFound,
+        TurbopufferConfigError,
+    )
+    from src.infra.search.dependencies import get_search_service
+
+    hits: list[dict] = []
+    try:
+        search_svc = get_search_service()
+        results = await search_svc.search_scope(
+            project_id=project_id,
+            path=combined_scope,
+            # tool_json_path empty = the scope's root JSON pointer;
+            # vector indexes for the SearchService are keyed by
+            # (project, path, json_path). Empty matches anything
+            # indexed under this AP scope without a sub-tool slice.
+            tool_json_path="",
+            query=query,
+            top_k=max(1, min(int(limit), 100)),
+        )
+        for item in results or []:
+            hits.append({
+                "path": item.get("path") or item.get("file_path") or "",
+                "line": int(item.get("line") or item.get("line_start") or 1),
+                "col": 0,
+                "match": (item.get("text") or item.get("chunk") or "")[:240],
+                "content_hash": item.get("content_hash") or "",
+                "score_semantic": float(item.get("score") or 0.0),
+            })
+        return hits, ""
+    except (TurbopufferNotFound, FileNotFoundError):
+        return [], ""
+    except TurbopufferConfigError as cfg_err:
+        return [], f"semantic disabled: {cfg_err}"
+    except Exception as exc:  # noqa: BLE001 - degrade gracefully
+        return [], str(exc)
+
+
 @router.post("/search", response_model=ApiResponse)
 async def search(
     body: _SearchRequest,
@@ -1292,43 +1363,12 @@ async def search(
             })
 
     if body.mode in ("semantic", "hybrid"):
-        try:
-            # Use the same cached singleton the tools router uses, with
-            # the full DI graph (ops + chunk_repo + project_service +
-            # chunking + embeddings + turbopuffer). Constructing
-            # ``SearchService()`` directly fails because three
-            # arguments are keyword-only — go through the factory.
-            from src.infra.search.dependencies import get_search_service
-            search_svc = get_search_service()
-            results = await search_svc.search_scope(
-                project_id=project_id,
-                path=combined_scope,
-                # tool_json_path empty = the scope's root JSON pointer;
-                # vector indexes for the SearchService are keyed by
-                # (project, path, json_path). Empty matches anything
-                # indexed under this AP scope without a sub-tool slice.
-                tool_json_path="",
-                query=body.query,
-                top_k=max(1, min(int(body.limit), 100)),
-            )
-            for item in results or []:
-                semantic_hits.append({
-                    "path": item.get("path") or item.get("file_path") or "",
-                    "line": int(item.get("line") or item.get("line_start") or 1),
-                    "col": 0,
-                    "match": (item.get("text") or item.get("chunk") or "")[:240],
-                    "content_hash": item.get("content_hash") or "",
-                    "score_semantic": float(item.get("score") or 0.0),
-                })
-        except Exception as exc:  # noqa: BLE001 - degrade gracefully
-            # The semantic path depends on embeddings + an external
-            # API. Don't crash the whole search if that's misconfigured;
-            # surface the failure mode in the response so the CLI can
-            # tell the user "semantic unavailable, showing literal".
-            semantic_hits = []
-            semantic_error = str(exc)
-        else:
-            semantic_error = ""
+        semantic_hits, semantic_error = await _run_semantic_channel(
+            project_id=project_id,
+            combined_scope=combined_scope,
+            query=body.query,
+            limit=body.limit,
+        )
     else:
         semantic_error = ""
 


### PR DESCRIPTION
TurbopufferNotFound was bubbling up as semantic_error in the response for projects that haven't created a search tool yet — these projects have no Turbopuffer namespace, which is a normal 'no semantic data' state, not an error. Catch NotFound (and the per-file FileNotFoundError from the JSON-tree indexer) and return empty silently. Keep TurbopufferConfigError surfaced so ops sees real misconfigs, and keep the catch-all for transient SDK failures.

Refactor the semantic block into _run_semantic_channel so the endpoint body stays under the cognitive-complexity ceiling.

<!--
Thanks for the PR! Please fill in the sections below so reviewers can move fast.
See CONTRIBUTING.md for the full workflow:
https://github.com/puppyone-ai/puppyone/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- One or two sentences: what does this PR change and why? -->

## Target branch

<!--
Default target should be `qubits` (staging). Only two PR types should target
`main`:
- release PRs from `qubits`
- same-repo urgent hotfix PRs from `hotfix/*`

All other PRs targeting `main` are blocked by the "Main Release Gate" CI job.
-->

- [ ] Base branch is **`qubits`** (or this is a `qubits` → `main` release PR / same-repo `hotfix/*` → `main` hotfix PR)

## Type of change

- [ ] feat — new feature
- [ ] fix — bug fix
- [ ] perf — performance improvement
- [ ] refactor — code change that is neither a fix nor a feature
- [ ] docs — documentation only
- [ ] chore — tooling, build, CI, deps
- [ ] hotfix — urgent production fix targeted at `main`

## Test plan

<!--
How did you verify this change? Examples:
- Ran `uv run pytest -m "unit"` locally — all green
- Manually tested the new endpoint with `curl ...`
- Verified UI in `npm run dev` at http://localhost:3000/foo
-->

## Linked issues

<!-- Use `Fixes #123` to auto-close, or `Refs #123` to reference. -->

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] My code follows the existing style (frontend: ESLint via `npm run lint`; backend: ruff via `uv run ruff format`)
- [ ] I have not committed any secrets, `.env` files, or credentials
- [ ] I have updated docs / comments where behaviour changed
- [ ] I have added or updated tests when adding logic that should be covered
