### PR TITLE
fix(storage): keep object cache from publishing dangling refs

### DIFF
--- a/backend/src/version_engine/storage/backends/s3.py
+++ b/backend/src/version_engine/storage/backends/s3.py
@@ -223,7 +223,10 @@ class CachedStorageBackend(StorageBackend):
     Content-addressed objects are immutable by definition:
     same hash = same content, forever. No TTL needed.
 
-    The cache is process-wide and shared across all projects.
+    The cache object is process-wide, but entries are namespaced by
+    physical backend. S3 object paths are per-project, so a blob cached
+    after reading project A is not evidence that project B has the same
+    object in its own namespace.
     All cache access is protected by _cache_lock because
     cachetools.LRUCache is not thread-safe.
     """
@@ -231,6 +234,20 @@ class CachedStorageBackend(StorageBackend):
     def __init__(self, inner: StorageBackend):
         self._inner = inner
         self._cache = _get_global_cache()
+        self._cache_namespace = (
+            getattr(inner, "_cache_namespace", None)
+            or getattr(inner, "_prefix", None)
+            or getattr(inner, "_project_id", None)
+            or id(inner)
+        )
+
+    def _cache_key(self, h: str):
+        return (self._cache_namespace, h)
+
+    def _remember_cached(self, h: str, data: bytes) -> None:
+        if len(data) < _CACHEABLE_THRESHOLD:
+            with _cache_lock:
+                self._cache[self._cache_key(h)] = data
 
     def get(self, h: str) -> bytes:
         active_batch = _ACTIVE_WRITE_BATCH.get()
@@ -240,7 +257,7 @@ class CachedStorageBackend(StorageBackend):
                 trace_mark("object.cache.hit", object_id=h[:12], cache="write_batch")
                 return pending
         with _cache_lock:
-            cached = self._cache.get(h)
+            cached = self._cache.get(self._cache_key(h))
         if cached is not None:
             trace_mark(
                 "object.cache.hit",
@@ -251,15 +268,13 @@ class CachedStorageBackend(StorageBackend):
             return cached
         with trace_phase("object.cache.miss_remote_get", object_id=h[:12]):
             data = self._inner.get(h)
-        if len(data) < _CACHEABLE_THRESHOLD:
-            with _cache_lock:
-                self._cache[h] = data
+        self._remember_cached(h, data)
         return data
 
     def get_range(self, h: str, start: int = 0, limit: int | None = None) -> tuple[bytes, int]:
         """Return a byte range without forcing a full download when possible."""
         with _cache_lock:
-            cached = self._cache.get(h)
+            cached = self._cache.get(self._cache_key(h))
         if cached is not None:
             end = len(cached) if limit is None else min(len(cached), start + limit)
             return cached[start:end], len(cached)
@@ -276,28 +291,18 @@ class CachedStorageBackend(StorageBackend):
         return _run_async(self.async_get_many(hashes))
 
     def put(self, h: str, data: bytes) -> None:
-        # Content-addressed: if the hash is already in the cache,
-        # the inner backend has the same bytes (we put them there
-        # ourselves on a previous call). Skip the S3 HEAD round-trip.
-        # This is what makes repeated tree rebuilds that re-put already-known
-        # blobs effectively free.
-        with _cache_lock:
-            already_cached = h in self._cache
-        if already_cached:
-            trace_mark("object.cache.skip_put", object_id=h[:12], cache="memory")
-            return
+        # The memory cache is a read-through byte cache, not a durable
+        # existence proof. Writes must always reach the physical backend
+        # for this project namespace; otherwise cross-project cache hits
+        # or failed batch flushes can publish trees whose blobs were never
+        # materialized in S3.
         active_batch = _ACTIVE_WRITE_BATCH.get()
         if active_batch is not None and active_batch.backend is self:
             active_batch.put(h, data)
-            if len(data) < _CACHEABLE_THRESHOLD:
-                with _cache_lock:
-                    self._cache[h] = data
             return
         with trace_phase("object.remote_put", object_id=h[:12], size_bytes=len(data)):
             self._inner.put(h, data)
-        if len(data) < _CACHEABLE_THRESHOLD:
-            with _cache_lock:
-                self._cache[h] = data
+        self._remember_cached(h, data)
 
     def exists(self, h: str) -> bool:
         active_batch = _ACTIVE_WRITE_BATCH.get()
@@ -307,27 +312,21 @@ class CachedStorageBackend(StorageBackend):
             and active_batch.has(h)
         ):
             return True
-        with _cache_lock:
-            if h in self._cache:
-                return True
         return self._inner.exists(h)
 
     def exists_many(self, hashes: list[str]) -> set[str]:
         active_batch = _ACTIVE_WRITE_BATCH.get()
         existing: set[str] = set()
         remaining: list[str] = []
-        with _cache_lock:
-            for h in hashes:
-                if (
-                    active_batch is not None
-                    and active_batch.backend is self
-                    and active_batch.has(h)
-                ):
-                    existing.add(h)
-                elif h in self._cache:
-                    existing.add(h)
-                else:
-                    remaining.append(h)
+        for h in hashes:
+            if (
+                active_batch is not None
+                and active_batch.backend is self
+                and active_batch.has(h)
+            ):
+                existing.add(h)
+            else:
+                remaining.append(h)
         if remaining:
             existing.update(self._inner.exists_many(remaining))
         return existing
@@ -344,7 +343,7 @@ class CachedStorageBackend(StorageBackend):
                     if pending is not None:
                         results[h] = pending
                         continue
-                cached = self._cache.get(h)
+                cached = self._cache.get(self._cache_key(h))
                 if cached is not None:
                     results[h] = cached
                 else:
@@ -368,7 +367,7 @@ class CachedStorageBackend(StorageBackend):
         with _cache_lock:
             for h, data in fetched.items():
                 if len(data) < _CACHEABLE_THRESHOLD:
-                    self._cache[h] = data
+                    self._cache[self._cache_key(h)] = data
         results.update(fetched)
         return results
 
@@ -386,7 +385,7 @@ class CachedStorageBackend(StorageBackend):
 
     def delete(self, h: str) -> bool:
         with _cache_lock:
-            self._cache.pop(h, None)
+            self._cache.pop(self._cache_key(h), None)
         return self._inner.delete(h)
 
     def sweep_dead_bundles(self, dead_object_ids) -> tuple[int, list[str]]:
@@ -397,7 +396,7 @@ class CachedStorageBackend(StorageBackend):
         if swept:
             with _cache_lock:
                 for object_id in swept:
-                    self._cache.pop(object_id, None)
+                    self._cache.pop(self._cache_key(object_id), None)
         return count, swept
 
     @contextmanager
@@ -446,6 +445,8 @@ class ObjectWriteBatch:
             else:
                 for h, data in objects.items():
                     inner.put(h, data)
+        for h, data in objects.items():
+            self.backend._remember_cached(h, data)
         self._objects.clear()
 
 

--- a/backend/tests/version_engine/test_cached_storage_backend.py
+++ b/backend/tests/version_engine/test_cached_storage_backend.py
@@ -1,0 +1,93 @@
+"""Cached storage backend durability regressions."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.version_engine.storage.backends import s3 as s3_backend
+from src.version_engine.storage.backends.s3 import CachedStorageBackend
+from src.version_engine.storage.object_store import StorageBackend
+from src.version_engine.write_engine.git_object_format import encode_object
+
+
+class _MemoryBackend(StorageBackend):
+    def __init__(self, project_id: str):
+        self._project_id = project_id
+        self.objects: dict[str, bytes] = {}
+        self.put_calls: list[str] = []
+
+    def get(self, h: str) -> bytes:
+        return self.objects[h]
+
+    def put(self, h: str, loose_bytes: bytes) -> None:
+        self.put_calls.append(h)
+        self.objects[h] = loose_bytes
+
+    def exists(self, h: str) -> bool:
+        return h in self.objects
+
+    def all_hashes(self) -> list[str]:
+        return list(self.objects)
+
+    def count(self) -> tuple[int, int]:
+        return len(self.objects), sum(len(v) for v in self.objects.values())
+
+    def delete(self, h: str) -> bool:
+        return self.objects.pop(h, None) is not None
+
+
+class _FailingBatchBackend(_MemoryBackend):
+    def __init__(self, project_id: str):
+        super().__init__(project_id)
+        self.fail_batch = True
+
+    async def async_put_many(
+        self,
+        objects: dict[str, bytes],
+        concurrency: int = 20,
+        skip_exists: bool = False,
+    ) -> None:
+        if self.fail_batch:
+            raise RuntimeError("batch flush failed")
+        for h, data in objects.items():
+            self.put(h, data)
+
+
+def _reset_cache(monkeypatch) -> None:
+    monkeypatch.setattr(s3_backend, "_global_cache", None)
+
+
+def test_cache_hit_in_one_project_does_not_skip_put_in_another(monkeypatch) -> None:
+    _reset_cache(monkeypatch)
+    object_id, loose = encode_object("blob", b"shared bytes")
+    project_a = CachedStorageBackend(_MemoryBackend("project-a"))
+    project_b = CachedStorageBackend(_MemoryBackend("project-b"))
+
+    project_a.put(object_id, loose)
+    assert project_a.get(object_id) == loose
+
+    project_b.put(object_id, loose)
+
+    assert project_b._inner.objects[object_id] == loose
+    assert project_b._inner.put_calls == [object_id]
+
+
+def test_failed_write_batch_does_not_poison_existence_cache(monkeypatch) -> None:
+    _reset_cache(monkeypatch)
+    object_id, loose = encode_object("blob", b"retry me")
+    inner = _FailingBatchBackend("project-a")
+    backend = CachedStorageBackend(inner)
+
+    with pytest.raises(RuntimeError, match="batch flush failed"):
+        with backend.stage_object_writes() as batch:
+            backend.put(object_id, loose)
+            assert backend.exists(object_id) is True
+            batch.flush()
+
+    assert backend.exists(object_id) is False
+
+    inner.fail_batch = False
+    backend.put(object_id, loose)
+
+    assert inner.objects[object_id] == loose
+    assert inner.put_calls == [object_id]


### PR DESCRIPTION
## Summary
- namespace the process-wide object cache by physical backend/project scope
- stop treating memory cache hits as durable object-store existence
- cache staged batch objects only after the physical flush succeeds
- add regressions for cross-project cache hits and failed batch flush retry

## Tests
- uv run pytest tests/version_engine/test_cached_storage_backend.py tests/version_engine/test_l6_io_storage_strategy.py tests/version_engine/test_bundle_exists_race.py tests/version_engine/test_s3_exists_many.py tests/version_engine/test_deferred_loose_self_heal.py tests/version_engine/test_git_kernel_migration_contracts.py
- uv run pytest tests/ingest/test_upload_schemas.py tests/ingest/test_upload_policy.py tests/platform/test_import_jobs.py tests/version_engine/test_object_gc.py tests/version_engine/test_object_gc_packed.py tests/version_engine/test_receive_pack_named_refs.py tests/version_engine/test_upload_pack_named_refs.py tests/version_engine/test_write_engine.py tests/version_engine/test_cached_storage_backend.py -k 'not test_real_git_cli_tag_push_is_stored_without_advancing_scope'