### PR TITLE
feat(scope): root scope is the project-wide view — stop carving sub-s…

### DIFF
--- a/backend/src/version_engine/admission/repo_facade.py
+++ b/backend/src/version_engine/admission/repo_facade.py
@@ -59,9 +59,9 @@ def compute_carved_excludes(
 ) -> tuple[str, ...]:
     """Compute the set of child-scope paths that must be hidden from a parent scope.
 
-    The V2 Star architecture requires that when scope A has sub-scopes B and C
-    (at paths ``A/B`` and ``A/C``), the parent-scope view auto-excludes ``A/B``
-    and ``A/C`` so:
+    The V2 Star architecture requires that when a NON-ROOT scope A has
+    sub-scopes B and C (at paths ``A/B`` and ``A/C``), the parent-scope view
+    auto-excludes ``A/B`` and ``A/C`` so:
     - A parent Git push cannot accidentally write into a child scope's territory.
     - A parent filesystem view does not show content owned by a child scope.
 
@@ -69,23 +69,36 @@ def compute_carved_excludes(
     the admission layer only enforces user-configured ``exclude`` lists, leaving
     cross-scope boundary violations silently allowed.
 
+    ROOT EXCEPTION (project-wide view): the root scope (``scope_path == ""``)
+    is the project's full view — it intentionally does NOT carve out sub-scopes.
+    Root can read, write, and bidirectionally sync all sub-scope content; a
+    write under root into a sub-scope's path projects into that sub-scope's
+    head (and vice-versa) via the project-root visibility barrier. Sub-scope
+    keys remain narrow (each sees only its own subtree), so this only widens
+    the root key — which already represents project-level access — not any
+    delegated sub-scope key.
+
     Args:
         scope_path: The normalized path of the current scope ("" = root scope).
         all_scopes: All scopes for this project, each with at least {"path": str}.
 
     Returns:
         A tuple of normalized child-scope path strings to add as exclusions.
+        Empty for the root scope.
     """
     clean = scope_path.strip("/")
-    prefix = (clean + "/") if clean else ""
+    if not clean:
+        # Root scope = project-wide view: see/write/sync everything. Only
+        # user-configured excludes apply (merged by the caller).
+        return ()
+    prefix = clean + "/"
     carved: list[str] = []
     for s in all_scopes:
         child_path = normalize_path(s.get("path", ""))
         if not child_path:
             continue
-        # Root scope (prefix="") hides every non-root scope.
         # Non-root scope hides descendants whose path starts with "scope_path/".
-        if not prefix or child_path.startswith(prefix):
+        if child_path.startswith(prefix):
             carved.append(child_path)
     return tuple(sorted(set(carved)))
 

--- a/backend/tests/version_engine/test_carved_excludes.py
+++ b/backend/tests/version_engine/test_carved_excludes.py
@@ -26,14 +26,11 @@ ALL_SCOPES = [
 
 
 class TestComputeCarvedExcludes:
-    def test_root_scope_excludes_all_non_root(self):
+    def test_root_scope_carves_nothing(self):
+        # Root is the project-wide view: it sees/writes/syncs ALL sub-scopes,
+        # so it auto-carves NOTHING (only user-configured excludes apply).
         carved = compute_carved_excludes("", ALL_SCOPES)
-        assert "docs" in carved
-        assert "docs/api" in carved
-        assert "src" in carved
-        assert "src/lib" in carved
-        # root scope itself ("") must not appear
-        assert "" not in carved
+        assert carved == ()
 
     def test_docs_scope_excludes_only_its_children(self):
         carved = compute_carved_excludes("docs", ALL_SCOPES)
@@ -65,7 +62,7 @@ class TestComputeCarvedExcludes:
             assert path not in carved, f"self-exclusion found for scope={path!r}"
 
     def test_result_is_sorted_and_deduped(self):
-        carved = compute_carved_excludes("", ALL_SCOPES)
+        carved = compute_carved_excludes("docs", ALL_SCOPES)
         assert list(carved) == sorted(set(carved))
 
 
@@ -104,12 +101,21 @@ class TestRepoFacadeCarvedExcludes:
                                        scope_backend=self._make_backend())
         assert facade.excludes.count("docs/api") == 1
 
-    def test_root_scope_hides_all_child_scopes(self):
+    def test_root_scope_exposes_all_child_scopes(self):
+        # Root no longer carves sub-scopes — it is the full project view.
+        # Only user-configured excludes (none here) should appear.
         auth = self._make_auth(scope_path="")
         facade = repo_facade_from_auth("proj", auth, kind="access_point",
                                        scope_backend=self._make_backend())
         for name in ("docs", "docs/api", "src", "src/lib"):
-            assert name in facade.excludes, f"{name} missing from root carved_excludes"
+            assert name not in facade.excludes, f"root must not carve {name}"
+
+    def test_root_scope_still_honours_user_excludes(self):
+        auth = self._make_auth(scope_path="", user_exclude=["secrets"])
+        facade = repo_facade_from_auth("proj", auth, kind="access_point",
+                                       scope_backend=self._make_backend())
+        assert "secrets" in facade.excludes        # explicit user exclude kept
+        assert "docs" not in facade.excludes        # but sub-scopes not auto-carved
 
     def test_scope_backend_failure_falls_back_gracefully(self):
         """A DB error must not crash the auth flow — fall back to user excludes."""


### PR DESCRIPTION
…copes

Deployed deep test showed declared parent/child scopes were FULLY isolated: the root key got 403 ("Path is excluded from this access point") writing under a child scope's path and could not see child content. carved_excludes (GAP-4) was hiding ALL sub-scopes from the root scope, so root<->sub-scope content neither shared nor cross-synced — contrary to the intended "root is the whole project" model.

compute_carved_excludes now returns () for the root scope (path==""): root reads, writes, and bidirectionally syncs all sub-scope content (a root write into a sub-scope path projects into that sub-scope's head via the visibility barrier, and a sub-scope write is visible to root since root no longer carves). Non-root parent carving and sibling isolation are UNCHANGED — a sub-scope key still sees only its own subtree.

Security note: the root scope's access_key already represents project-level access; this widens only that key (and the project/root git remote, which now exposes the full tree). No delegated sub-scope key gains visibility.

Per product decision (option B). carved unit tests updated: root carves nothing / exposes all sub-scopes / still honours user-configured excludes; non-root cases unchanged (13 passed). The 3 real-git-cli scope_exclude failures are pre-existing environmental (local Supabase down, WinError 10061), unrelated to this change.

<!--
Thanks for the PR! Please fill in the sections below so reviewers can move fast.
See CONTRIBUTING.md for the full workflow:
https://github.com/puppyone-ai/puppyone/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- One or two sentences: what does this PR change and why? -->

## Target branch

<!--
Default target should be `qubits` (staging). Only two PR types should target
`main`:
- release PRs from `qubits`
- same-repo urgent hotfix PRs from `hotfix/*`

All other PRs targeting `main` are blocked by the "Main Release Gate" CI job.
-->

- [ ] Base branch is **`qubits`** (or this is a `qubits` → `main` release PR / same-repo `hotfix/*` → `main` hotfix PR)

## Type of change

- [ ] feat — new feature
- [ ] fix — bug fix
- [ ] perf — performance improvement
- [ ] refactor — code change that is neither a fix nor a feature
- [ ] docs — documentation only
- [ ] chore — tooling, build, CI, deps
- [ ] hotfix — urgent production fix targeted at `main`

## Test plan

<!--
How did you verify this change? Examples:
- Ran `uv run pytest -m "unit"` locally — all green
- Manually tested the new endpoint with `curl ...`
- Verified UI in `npm run dev` at http://localhost:3000/foo
-->

## Linked issues

<!-- Use `Fixes #123` to auto-close, or `Refs #123` to reference. -->

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] My code follows the existing style (frontend: ESLint via `npm run lint`; backend: ruff via `uv run ruff format`)
- [ ] I have not committed any secrets, `.env` files, or credentials
- [ ] I have updated docs / comments where behaviour changed
- [ ] I have added or updated tests when adding logic that should be covered
