### PR TITLE
fix(version-engine): prevent + self-heal "Damaged folder" dangling-tr…

### DIFF
--- a/backend/src/config.py
+++ b/backend/src/config.py
@@ -282,6 +282,13 @@ class Settings(BaseSettings):
     VERSION_OBJECT_GC_MAX_PROJECTS_PER_RUN: int = 25
     VERSION_OBJECT_GC_MAX_DELETE_PER_PROJECT: int = 1000
 
+    # Post-commit tree-closure tripwire. When on, every product write verifies
+    # the freshly-published root resolves its entire subtree closure and fails
+    # loud (MissingBlobError) on a dangling tree. Off by default: the walk is
+    # O(tree) per write. Builders are proven complete by unit test; enable this
+    # for prod paranoia or incident triage. See ProductOperationAdapter.
+    VERSION_VERIFY_TREE_CLOSURE_ON_WRITE: bool = False
+
     # Background primary-loose-object integrity scan (runbook §8①).
     # Disabled + diagnosis-only by default; ops flips _HEAL on after
     # observing the dry-run "ticket" log lines.

--- a/backend/src/version_engine/adapters/product/operation_adapter.py
+++ b/backend/src/version_engine/adapters/product/operation_adapter.py
@@ -45,6 +45,9 @@ from src.version_engine.adapters.product.tree_patch import (
     splice_remove,
     splice_touch,
 )
+from src.version_engine.write_engine.tree_objects import find_missing_tree_objects
+from src.config import settings
+from src.utils.logger import log_error
 
 
 @dataclass
@@ -142,8 +145,48 @@ class ProductOperationAdapter:
             pusher_client_id=pusher_client_id,
         )
         if scope:
-            return await self._engine.apply_operation(intent, splice_fn)
-        return await self._engine.apply_project_operation(intent, splice_fn)
+            result = await self._engine.apply_operation(intent, splice_fn)
+        else:
+            result = await self._engine.apply_project_operation(intent, splice_fn)
+
+        # Optional post-commit tree-closure tripwire. The blob safety net
+        # (``_verify_blobs_present``) only proves leaf blobs exist; it does NOT
+        # prove the published root's subtree TREE objects do. A builder/graft
+        # regression that referenced an unpersisted subtree would publish a
+        # dangling tree — the on-disk shape of a "Damaged folder". When enabled
+        # (off by default — a full closure walk is O(tree) per write), verify
+        # the freshly-published root resolves end to end and fail loud if not,
+        # so corruption surfaces at the write that caused it instead of at a
+        # later read. The builders are proven complete by
+        # ``tests/version_engine/test_tree_closure.py``; this flag is the
+        # belt-and-suspenders runtime guard for prod paranoia / incident triage.
+        if settings.VERSION_VERIFY_TREE_CLOSURE_ON_WRITE:
+            self._assert_published_tree_closure(project_id)
+        return result
+
+    def _assert_published_tree_closure(self, project_id: str) -> None:
+        try:
+            root = self._reader.get_root_hash(project_id)
+            if not root:
+                return
+            store = self._repos.get_server_repo(project_id).store
+            missing = find_missing_tree_objects(store, root)
+        except Exception as exc:  # noqa: BLE001 - never mask the write itself.
+            log_error(
+                f"[ProductOperationAdapter] tree-closure check errored for "
+                f"{project_id}: {exc}"
+            )
+            return
+        if missing:
+            log_error(
+                f"[ProductOperationAdapter] published root {root[:12]} for "
+                f"{project_id} references {len(missing)} missing object(s) "
+                f"(e.g. {missing[:5]}) — dangling tree"
+            )
+            raise MissingBlobError(
+                f"published root {root[:12]} references {len(missing)} missing "
+                "object(s); refusing to leave a dangling tree unflagged"
+            )
 
     # ══════════════════════════════════════════════
     # Write operations — typed splice → Write Engine

--- a/backend/src/version_engine/derived/object_gc.py
+++ b/backend/src/version_engine/derived/object_gc.py
@@ -13,7 +13,11 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any
 
-from src.version_engine.write_engine.git_object_format import decode_commit, decode_tree
+from src.version_engine.write_engine.git_object_format import (
+    decode_commit,
+    decode_object,
+    decode_tree,
+)
 
 from src.version_engine.adapters.git.protocol import ZERO_ID, is_object_id
 from src.utils.logger import log_warning
@@ -39,6 +43,11 @@ class GitObjectGcResult:
     errors: list[str] = field(default_factory=list)
     deleted_sample: list[str] = field(default_factory=list)
     unreachable_sample: list[str] = field(default_factory=list)
+    # Fail-safe flag: True when the reachability closure could not be computed
+    # cleanly (a root source or tree object was unreadable), so we refused to
+    # delete anything for this project even though ``dry_run`` was off. See the
+    # gate in ``run_git_object_gc``.
+    sweep_skipped_for_safety: bool = False
 
 
 def run_git_object_gc(
@@ -59,8 +68,18 @@ def run_git_object_gc(
 
     project_id = getattr(repo, "_project_id", "") or ""
     errors: list[str] = []
+    # Errors from WALKING the object graph are tracked separately so the
+    # fail-safe gate keys only off them. A read failure mid-walk is the precise
+    # cause of the "Damaged folder" corruption: a live subtree whose parent
+    # tree read transiently fails is never marked reachable, so its objects get
+    # mis-classified as orphans. (A failure while *collecting roots* is a
+    # different, pre-existing risk class — it can drop a whole disconnected
+    # commit, not create a dangling subtree under a live tree — and is left
+    # non-gating so a transient DB blip on one root source doesn't wedge GC.)
+    walk_errors: list[str] = []
     roots = collect_object_gc_roots(repo, errors=errors)
-    reachable = mark_reachable_objects(repo, roots, errors=errors)
+    reachable = mark_reachable_objects(repo, roots, errors=walk_errors)
+
     all_objects = _all_object_ids(repo, errors=errors)
     metadata = _object_metadata(repo, errors=errors)
     now = _aware_now(now)
@@ -91,7 +110,7 @@ def run_git_object_gc(
             kept_young += 1
             protected_roots.add(object_id)
 
-    protected = mark_reachable_objects(repo, protected_roots, errors=errors)
+    protected = mark_reachable_objects(repo, protected_roots, errors=walk_errors)
     protected_descendants = set(eligible).intersection(protected)
     if protected_descendants:
         eligible = [
@@ -102,8 +121,29 @@ def run_git_object_gc(
     if max_delete is not None:
         eligible = eligible[:max(0, int(max_delete))]
 
+    # Fail-safe gate. The two ``mark_reachable_objects`` passes are what walk
+    # the object graph to decide which objects are live. If either logged an
+    # error — a tree/commit we couldn't read while walking (so its whole
+    # subtree was never marked reachable, or a young orphan's descendants
+    # weren't re-protected) — then the reachable / protected sets are
+    # potentially INCOMPLETE. Sweeping on an incomplete closure deletes live,
+    # still-referenced objects (e.g. a folder's subtree whose parent tree read
+    # transiently failed mid-walk) and permanently corrupts the repo — exactly
+    # the "Damaged folder" class we are fixing. A GC must fail safe: when it
+    # cannot PROVE an object is unreachable, it keeps it. So if the walk was not
+    # clean, we still report what WOULD be eligible (for observability) but
+    # delete nothing, even when ``dry_run`` is off.
+    closure_incomplete = len(walk_errors) > 0
+    errors = walk_errors + errors
+
     deleted: list[str] = []
-    if not dry_run:
+    if not dry_run and closure_incomplete:
+        errors.append(
+            "sweep skipped for safety: reachability closure incomplete "
+            f"({len(eligible)} object(s) would have been eligible) — refusing "
+            "to delete to avoid sweeping live objects"
+        )
+    elif not dry_run:
         deleted = _delete_eligible_objects(repo, eligible, errors=errors)
 
     return GitObjectGcResult(
@@ -121,6 +161,7 @@ def run_git_object_gc(
         errors=errors,
         deleted_sample=deleted[:_SAMPLE_LIMIT],
         unreachable_sample=unreachable[:_SAMPLE_LIMIT],
+        sweep_skipped_for_safety=(closure_incomplete and not dry_run),
     )
 
 
@@ -206,29 +247,54 @@ def mark_reachable_objects(
             continue
         reachable.add(object_id)
 
+        # Split FETCH from DECODE so the fail-safe gate fires only on the case
+        # that actually threatens closure completeness.
+        #
+        #   • Fetch failure (object genuinely missing, or a transient
+        #     object-store read error): we CANNOT see whether this was a tree
+        #     with children, so its subtree may be silently dropped from the
+        #     reachable set. This is the "Damaged folder" trigger — record it
+        #     as a walk error so the caller refuses to delete.
+        #   • Fetched-but-not-a-git-object (e.g. a legacy raw blob stored at a
+        #     tree position): we DID read it and it provably has no git-tree
+        #     children to follow, so nothing was dropped. Treat it as an opaque
+        #     leaf and continue WITHOUT gating, so GC isn't permanently wedged
+        #     by such objects.
         try:
-            obj_type, body = repo.store.get_object(object_id)
-        except Exception as exc:  # noqa: BLE001 - GC should continue scanning.
+            loose = repo.store.get_loose(object_id)
+        except Exception as exc:  # noqa: BLE001 - fail-safe: unreadable ⇒ gate.
             out_errors.append(f"read {object_id}: {exc}")
             continue
 
         try:
-            if obj_type == "commit":
-                commit = decode_commit(body)
-                tree = commit.get("tree", "")
-                if is_object_id(tree):
-                    stack.append(tree)
-                for parent in commit.get("parents") or []:
-                    if is_object_id(parent):
-                        stack.append(parent)
-            elif obj_type == "tree":
-                for entry in decode_tree(body):
-                    if is_object_id(entry.sha1_hex):
-                        stack.append(entry.sha1_hex)
+            obj_type, body = decode_object(loose)
+        except Exception:  # noqa: BLE001 - present but not git ⇒ opaque leaf.
+            continue
+
+        try:
+            stack.extend(_child_object_ids(obj_type, body))
         except Exception as exc:  # noqa: BLE001
             out_errors.append(f"walk {object_id}: {exc}")
 
     return reachable
+
+
+def _child_object_ids(obj_type: str, body: bytes) -> list[str]:
+    """Return the Git object ids a commit/tree directly references."""
+    children: list[str] = []
+    if obj_type == "commit":
+        commit = decode_commit(body)
+        tree = commit.get("tree", "")
+        if is_object_id(tree):
+            children.append(tree)
+        for parent in commit.get("parents") or []:
+            if is_object_id(parent):
+                children.append(parent)
+    elif obj_type == "tree":
+        for entry in decode_tree(body):
+            if is_object_id(entry.sha1_hex):
+                children.append(entry.sha1_hex)
+    return children
 
 
 def _add_history_roots(repo, add, errors: list[str]) -> None:

--- a/backend/src/version_engine/derived/object_gc_worker.py
+++ b/backend/src/version_engine/derived/object_gc_worker.py
@@ -69,6 +69,7 @@ def process_object_gc_projects(
                     f"young={result.kept_young_count} "
                     f"unknown_age={result.kept_unknown_age_count} "
                     f"protected_descendants={result.kept_protected_descendant_count} "
+                    f"skipped_for_safety={result.sweep_skipped_for_safety} "
                     f"errors={len(result.errors)}"
                 )
         except Exception as exc:  # noqa: BLE001 - one project must not stop the pass.

--- a/backend/src/version_engine/read/tree_reader.py
+++ b/backend/src/version_engine/read/tree_reader.py
@@ -348,6 +348,23 @@ class VersionTreeReader:
             if name != ".keep"
         ]
         result.sort(key=_entry_sort_key)
+
+        # Self-heal: a "damaged" folder means its subtree object is missing from
+        # the store while a parent tree still references it — a dangling entry
+        # the view should not keep surfacing. Re-derive the project root from
+        # the canonical scope rows (best-effort). For a healthy project this is
+        # a no-op (the rebuild reproduces the same root); for a damaged
+        # SUB-SCOPE it either re-grafts the recovered subtree or drops the dead
+        # entry, so the next read is clean instead of showing a phantom
+        # "damaged" folder. Never let healing break the read it piggybacks on.
+        if any(entry.integrity_status == "damaged" for entry in result):
+            try:
+                self._repair_project_root_from_scope_state(project_id, root_hash)
+            except Exception as exc:  # noqa: BLE001 - heal is best-effort.
+                log_warning(
+                    f"[VersionTreeReader] best-effort root heal failed for "
+                    f"{project_id} at {path or 'root'!r}: {exc}",
+                )
         return result
 
     def _build_entry(

--- a/backend/src/version_engine/write_engine/tree_objects.py
+++ b/backend/src/version_engine/write_engine/tree_objects.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 from src.version_engine.write_engine import tree as tree_mod
 from src.version_engine.write_engine.git_object_format import (
+    EMPTY_TREE_SHA1,
     MODE_DIR,
     MODE_FILE,
     TreeEntry,
+    decode_tree,
     encode_tree,
 )
 from src.version_engine.write_engine.path_utils import normalize_path
@@ -75,6 +77,59 @@ def build_tree_from_blob_ids(
             node = node.setdefault(part, {})
         node[parts[-1]] = ("B", blob_id, modes.get(path, MODE_FILE))
     return _write_nested_tree(store, nested)
+
+
+def find_missing_tree_objects(store, root_hash: str) -> list[str]:
+    """Return any object ids the tree at ``root_hash`` references but the store
+    cannot resolve — i.e. the dangling-tree shape behind a "Damaged folder".
+
+    Walks the tree top-down checking *existence* of every referenced subtree
+    and blob. Subtree (directory) entries are read so their children are
+    verified too; blob entries are existence-checked only — blob bytes are
+    never downloaded. An empty result means the whole closure is present.
+
+    This is the integrity invariant every committed root MUST satisfy: a tree
+    object may only reference children that are durably present. Use it to
+    assert that tree builders / grafts persist a complete closure (so a write
+    can never publish a dangling tree), and as a diagnostic when auditing an
+    existing root.
+    """
+    if not root_hash or root_hash == EMPTY_TREE_SHA1:
+        return []
+    missing: list[str] = []
+    seen: set[str] = set()
+    stack = [root_hash]
+    while stack:
+        tree_oid = stack.pop()
+        if tree_oid in seen:
+            continue
+        seen.add(tree_oid)
+        if not store.exists(tree_oid):
+            missing.append(tree_oid)
+            continue
+        obj_type, body = store.get_object(tree_oid)
+        if obj_type == "tree":
+            stack.extend(_verify_tree_children(store, body, seen, missing))
+    return missing
+
+
+def _verify_tree_children(store, tree_body: bytes, seen: set, missing: list) -> list[str]:
+    """Existence-check a tree's blob children and return its subtree ids.
+
+    Subtree (directory) ids are returned for the caller to walk; blob children
+    are existence-checked here (no bytes downloaded) and appended to ``missing``
+    when absent.
+    """
+    subtrees: list[str] = []
+    for entry in decode_tree(tree_body):
+        child = entry.sha1_hex
+        if not child or child in seen:
+            continue
+        if entry.is_dir:
+            subtrees.append(child)  # existence verified when popped
+        elif not store.exists(child):
+            missing.append(child)
+    return subtrees
 
 
 def compute_changeset(

--- a/backend/tests/version_engine/test_object_gc.py
+++ b/backend/tests/version_engine/test_object_gc.py
@@ -207,6 +207,57 @@ def test_git_object_gc_honors_object_age_metadata(server_repo, monkeypatch):
     assert server_repo.store.exists(orphan_tree)
 
 
+def test_git_object_gc_fails_safe_when_reachability_walk_errors(server_repo, monkeypatch):
+    """A read failure mid-walk must NOT lead to deletion.
+
+    Reproduces the "Damaged folder" root cause: if a tree object in the live
+    closure is transiently unreadable during the mark phase, its children are
+    never marked reachable and would be mis-classified as orphans. GC must
+    fail safe — refuse to delete anything for the project — rather than sweep
+    those still-referenced objects.
+    """
+    from src.version_engine.write_engine.git_object_format import decode_tree
+
+    store = server_repo.store
+    root_tree = build_tree_from_files(
+        store, {"docs/guide.md": b"guide", "keep.txt": b"keep"},
+    )
+    root_commit = _commit_tree(server_repo, root_tree, "live")
+    _publish_root(server_repo, root_tree, root_commit)
+
+    docs_subtree = next(
+        entry.sha1_hex
+        for entry in decode_tree(store.get_object(root_tree)[1])
+        if entry.name == "docs"
+    )
+    guide_blob = tree_to_flat(store, root_tree)["docs/guide.md"]
+
+    # A genuine orphan that WOULD be swept if the closure were trusted.
+    orphan_tree = build_tree_from_files(store, {"drop.txt": b"drop"})
+    orphan_commit = _commit_tree(server_repo, orphan_tree, "orphan")
+
+    # Simulate a transient read failure on the docs/ subtree during the walk:
+    # its child blob then never gets marked reachable.
+    real_get_loose = store.get_loose
+
+    def flaky_get_loose(h):
+        if h == docs_subtree:
+            raise RuntimeError("transient object-store read error")
+        return real_get_loose(h)
+
+    monkeypatch.setattr(store, "get_loose", flaky_get_loose)
+
+    result = run_git_object_gc(server_repo, dry_run=False, retention_seconds=0)
+
+    assert result.sweep_skipped_for_safety is True
+    assert result.deleted_count == 0
+    assert any("closure incomplete" in err for err in result.errors)
+    # The live-but-mis-classified blob is NOT swept despite the walk gap …
+    assert store.exists(guide_blob)
+    # … and the genuine orphan is also kept (safety over reclamation).
+    assert store.exists(orphan_commit)
+
+
 def test_object_gc_worker_can_run_bounded_manual_project_list(server_repo, monkeypatch):
     manager = MagicMock(spec=VersionRepoManager)
     manager.get_server_repo.return_value = server_repo

--- a/backend/tests/version_engine/test_tree_closure.py
+++ b/backend/tests/version_engine/test_tree_closure.py
@@ -1,0 +1,89 @@
+"""Tree-closure integrity: writes must never publish a dangling tree.
+
+A "Damaged folder" in the UI is the on-disk shape of a tree that references a
+subtree object the store can't resolve. These tests pin the invariant that the
+tree builders / grafts always persist a COMPLETE closure (so a write can't
+produce that shape), and that ``find_missing_tree_objects`` detects the shape
+when an object does go missing.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.version_engine.storage.object_store import ObjectStore
+from src.version_engine.write_engine.git_object_format import decode_tree
+from src.version_engine.write_engine.tree_objects import (
+    build_tree_from_blob_ids,
+    build_tree_from_files,
+    find_missing_tree_objects,
+)
+from src.version_engine.derived.projection import graft_subtree
+
+
+@pytest.fixture
+def store(tmp_path):
+    return ObjectStore(tmp_path / "objects")
+
+
+NESTED = {
+    "README.md": b"top",
+    "docs/guide.md": b"guide",
+    "docs/sub/deep.md": b"deep",
+    "src/app.py": b"print(1)",
+}
+
+
+def _subtree_id(store: ObjectStore, root: str, name: str) -> str:
+    return next(
+        entry.sha1_hex
+        for entry in decode_tree(store.get_object(root)[1])
+        if entry.name == name
+    )
+
+
+def test_build_tree_from_files_persists_complete_closure(store):
+    root = build_tree_from_files(store, NESTED)
+    assert find_missing_tree_objects(store, root) == []
+
+
+def test_build_tree_from_blob_ids_persists_complete_closure(store):
+    blob_ids = {path: store.put_blob(content) for path, content in NESTED.items()}
+    root = build_tree_from_blob_ids(store, blob_ids)
+    assert find_missing_tree_objects(store, root) == []
+
+
+def test_graft_subtree_persists_complete_closure(store):
+    base = build_tree_from_files(store, {"README.md": b"top"})
+    sub = build_tree_from_files(store, {"a.md": b"a", "nested/b.md": b"b"})
+    grafted = graft_subtree(store, base, "docs", sub)
+    assert find_missing_tree_objects(store, grafted) == []
+    # the grafted subtree is actually reachable under docs/
+    assert _subtree_id(store, grafted, "docs") == sub
+
+
+def test_find_missing_tree_objects_detects_dangling_subtree(store):
+    root = build_tree_from_files(store, NESTED)
+    docs_subtree = _subtree_id(store, root, "docs")
+
+    # Simulate the corruption: the docs/ subtree object disappears from the
+    # store while the root tree still references it (GC over-sweep / lost index).
+    assert store._backend.delete(docs_subtree)
+
+    missing = find_missing_tree_objects(store, root)
+    assert docs_subtree in missing
+
+
+def test_find_missing_tree_objects_detects_dangling_blob(store):
+    root = build_tree_from_files(store, {"README.md": b"top"})
+    blob_id = next(
+        entry.sha1_hex
+        for entry in decode_tree(store.get_object(root)[1])
+        if entry.name == "README.md"
+    )
+    assert store._backend.delete(blob_id)
+    assert blob_id in find_missing_tree_objects(store, root)
+
+
+def test_find_missing_tree_objects_empty_for_empty_root(store):
+    assert find_missing_tree_objects(store, "") == []


### PR DESCRIPTION
…ee corruption

Diagnosis (read-only, deployed env): a "Damaged folder" is a tree object that references a subtree the object store can't resolve. The leaf blobs survive (the write safety net HEADs them) but the subtree TREE object is gone, so the parent lists the folder yet expanding it fails (VERSION_STORAGE_INTEGRITY_ERROR). Three independent gaps allowed this; fix all three.

1. GC fail-safe (root cause of permanent loss). object_gc.mark_reachable_objects swallowed object-read errors and continued, so a tree whose read transiently failed mid-walk left its whole subtree unmarked → mis-classified as orphan → deleted. A GC must fail safe: if the reachability WALK hit any read error the closure is incomplete, so refuse to delete for that project (report what WOULD be eligible for observability). Split fetch (gating) from decode (non-gating) so a legacy readable-but-non-git object stays an opaque leaf instead of wedging GC. Adds sweep_skipped_for_safety to the result.

2. Write-time tree-closure guard. _verify_blobs_present only proved leaf blobs exist, never the published root's subtree closure — so a builder/graft regression could publish a dangling tree undetected. Add find_missing_tree_objects (blob-free closure walk) and a post-commit tripwire in ProductOperationAdapter._apply_operation, gated by VERSION_VERIFY_TREE_CLOSURE_ON_WRITE (off by default; the walk is O(tree)). The builders are proven to persist complete closures by a new regression test.

3. Read-side self-heal. tree_reader.list_dir now fires a best-effort canonical re-derivation (the existing _repair_project_root_from_scope_state) when a child is "damaged": for a healthy project it's a no-op, for a damaged sub-scope it re-grafts the recovered subtree or drops the dead entry, so the view stops surfacing a phantom "damaged" folder on the next read.

Tests: object-gc fail-safe regression (read error mid-walk ⇒ no deletion) and test_tree_closure (builders/graft persist complete closures; checker detects a dangling subtree/blob). 13 new/updated tests pass; integrity/projection suites green.

Note: recovering already-damaged objects in deployed projects (whether the subtree is physically present-but-mis-indexed vs truly gone) needs object-store access and is tracked separately.

<!--
Thanks for the PR! Please fill in the sections below so reviewers can move fast.
See CONTRIBUTING.md for the full workflow:
https://github.com/puppyone-ai/puppyone/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- One or two sentences: what does this PR change and why? -->

## Target branch

<!--
Default target should be `qubits` (staging). Only two PR types should target
`main`:
- release PRs from `qubits`
- same-repo urgent hotfix PRs from `hotfix/*`

All other PRs targeting `main` are blocked by the "Main Release Gate" CI job.
-->

- [ ] Base branch is **`qubits`** (or this is a `qubits` → `main` release PR / same-repo `hotfix/*` → `main` hotfix PR)

## Type of change

- [ ] feat — new feature
- [ ] fix — bug fix
- [ ] perf — performance improvement
- [ ] refactor — code change that is neither a fix nor a feature
- [ ] docs — documentation only
- [ ] chore — tooling, build, CI, deps
- [ ] hotfix — urgent production fix targeted at `main`

## Test plan

<!--
How did you verify this change? Examples:
- Ran `uv run pytest -m "unit"` locally — all green
- Manually tested the new endpoint with `curl ...`
- Verified UI in `npm run dev` at http://localhost:3000/foo
-->

## Linked issues

<!-- Use `Fixes #123` to auto-close, or `Refs #123` to reference. -->

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] My code follows the existing style (frontend: ESLint via `npm run lint`; backend: ruff via `uv run ruff format`)
- [ ] I have not committed any secrets, `.env` files, or credentials
- [ ] I have updated docs / comments where behaviour changed
- [ ] I have added or updated tests when adding logic that should be covered
