### PR TITLE
fix(scope-sync): emit upstream events on the root-first publish path too

### DIFF
--- a/backend/src/version_engine/derived/hooks.py
+++ b/backend/src/version_engine/derived/hooks.py
@@ -416,6 +416,11 @@ def run_post_project_update_hook(
             {"", *_project_root_affected_scope_paths(repo, changed_paths)},
         )
         _broadcast_commit_update(project_id, entry, changes)
+        # Scope-sync: fan out path-scoped "upstream advanced" events (M3/M4).
+        # This is the root-first publish path (git push + typed writes), so the
+        # changes are project-root-absolute → scope_path="" lets record_publish
+        # translate them into each affected scope's coordinates.
+        _emit_scope_sync_event(project_id, "", changes, commit_id, entry.get("who"))
 
     except Exception as e:
         log_error(


### PR DESCRIPTION
Live test on the deployed qubits build: a real git push landed on SoT but /activity stayed empty — the emit was only in run_post_push_hook (legacy/outbox path), while git pushes + typed writes finalize through run_post_project_update_hook (root-first). Add _emit_scope_sync_event there with scope_path="" (changes are project-root-absolute on this path, so record_publish fans them out into each affected scope's coordinates). Kept the legacy-path emit too (harmless if both ever fire — duplicate integrate is idempotent).

Needs redeploy to take effect; then a publish should populate /scope-sync/activity + /events.

<!--
Thanks for the PR! Please fill in the sections below so reviewers can move fast.
See CONTRIBUTING.md for the full workflow:
https://github.com/puppyone-ai/puppyone/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- One or two sentences: what does this PR change and why? -->

## Target branch

<!--
Default target should be `qubits` (staging). Only two PR types should target
`main`:
- release PRs from `qubits`
- same-repo urgent hotfix PRs from `hotfix/*`

All other PRs targeting `main` are blocked by the "Main Release Gate" CI job.
-->

- [ ] Base branch is **`qubits`** (or this is a `qubits` → `main` release PR / same-repo `hotfix/*` → `main` hotfix PR)

## Type of change

- [ ] feat — new feature
- [ ] fix — bug fix
- [ ] perf — performance improvement
- [ ] refactor — code change that is neither a fix nor a feature
- [ ] docs — documentation only
- [ ] chore — tooling, build, CI, deps
- [ ] hotfix — urgent production fix targeted at `main`

## Test plan

<!--
How did you verify this change? Examples:
- Ran `uv run pytest -m "unit"` locally — all green
- Manually tested the new endpoint with `curl ...`
- Verified UI in `npm run dev` at http://localhost:3000/foo
-->

## Linked issues

<!-- Use `Fixes #123` to auto-close, or `Refs #123` to reference. -->

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] My code follows the existing style (frontend: ESLint via `npm run lint`; backend: ruff via `uv run ruff format`)
- [ ] I have not committed any secrets, `.env` files, or credentials
- [ ] I have updated docs / comments where behaviour changed
- [ ] I have added or updated tests when adding logic that should be covered
